### PR TITLE
Fix firefox specific issue with image loading

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -711,7 +711,8 @@ export async function waitForLCP(lcpBlocks) {
   document.body.style.display = null;
   const lcpCandidate = document.querySelector('main img');
   await new Promise((resolve) => {
-    if (lcpCandidate.src === 'about:error') resolve(); // error loading image
+    if (lcpCandidate && lcpCandidate.src === 'about:error')
+      resolve(); // error loading image
     else if (lcpCandidate && !lcpCandidate.complete) {
       lcpCandidate.setAttribute('loading', 'eager');
       lcpCandidate.addEventListener('load', resolve);

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -711,7 +711,8 @@ export async function waitForLCP(lcpBlocks) {
   document.body.style.display = null;
   const lcpCandidate = document.querySelector('main img');
   await new Promise((resolve) => {
-    if (lcpCandidate && !lcpCandidate.complete) {
+    if (lcpCandidate.src === 'about:error') resolve(); // error loading image
+    else if (lcpCandidate && !lcpCandidate.complete) {
       lcpCandidate.setAttribute('loading', 'eager');
       lcpCandidate.addEventListener('load', resolve);
       lcpCandidate.addEventListener('error', resolve);


### PR DESCRIPTION
Some pages, like: https://main--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/markdown/cheatsheet happen to have the first image (LCP image) where the image `src` is set to `about:error`

_it seems_ Helix services try to load the original image from the converter HTML, but that image returns a 404, so helix replaces it with `<img src="about:error" ...>`

For that img, in FireFox specifically, `img.complete` evaluates to false, and firefox (unlike chrome) does not trigger neither a `load` not a `error` event; which the franklin scripts expect, see `waitForLCP` here: 
https://github.com/adobe-experience-league/exlm/blob/36df32e23f75ff85538ce33ffb833ae1ec9f3c03/scripts/lib-franklin.js#L706


As such, this PR change force resolves `waitForLCP` when the image source is specifically `about:error`

I will be talking to the Franklin team to understand why `about:error` is set instead of setting a different error path or keeping the original image `src`


Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://bugfix-firefox-error-images--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
