### PR TITLE
build table synthetic blocks

### DIFF
--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -5,11 +5,17 @@
  */
 
 function buildCell(rowIndex) {
-  const cell = rowIndex ? document.createElement('td') : document.createElement('th');
+  const cell = rowIndex
+    ? document.createElement('td')
+    : document.createElement('th');
   if (!rowIndex) cell.setAttribute('scope', 'col');
   return cell;
 }
 
+/**
+ *
+ * @param {HTMLDivElement} block
+ */
 export default async function decorate(block) {
   const table = document.createElement('table');
   const thead = document.createElement('thead');
@@ -21,10 +27,9 @@ export default async function decorate(block) {
     else thead.append(row);
     [...child.children].forEach((col) => {
       const cell = buildCell(i);
-      cell.innerHTML = col.innerHTML;
+      cell.append(...col.childNodes);
       row.append(cell);
     });
   });
-  block.innerHTML = '';
   block.append(table);
 }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -532,11 +532,7 @@ export function tableToBlock(table) {
 
   // add classes to result block
   const resultBlock = document.createElement('div');
-  blockClassNames
-    .split(' ')
-    .map((c) => c.trim())
-    .filter((c) => c.length > 0)
-    .forEach((c) => resultBlock.classList.add(c));
+  resultBlock.className = blockClassNames;
 
   // convert all table rows/cells to div rows/cells
   rows.forEach((row) => {

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -510,6 +510,66 @@ function getBlockConfig(block) {
 }
 
 /**
+ * Convert Table to block HTMl
+ * @param {HTMLTableElement} table
+ */
+export function tableToBlock(table) {
+  let blockClassNames = '';
+  const rows = [];
+  [...table.children].forEach((child) => {
+    if (child.tagName.toLowerCase() === 'thead') {
+      [...child.children].forEach((hRow, hRowIndex) => {
+        if (hRowIndex === 0) {
+          blockClassNames = hRow.textContent.toLowerCase(); // first header cell in first header row is block class names
+        } else {
+          rows.push(hRow.children); // all other header rows are rows
+        }
+      });
+    } else if (child.tagName.toLowerCase() === 'tbody') {
+      rows.push(...child.children); // all body rows are rows
+    }
+  });
+
+  // add classes to result block
+  const resultBlock = document.createElement('div');
+  blockClassNames
+    .split(' ')
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0)
+    .forEach((c) => resultBlock.classList.add(c));
+
+  // convert all table rows/cells to div rows/cells
+  rows.forEach((row) => {
+    const blockRow = document.createElement('div');
+    [...row.children].forEach((cell) => {
+      const blockCell = document.createElement('div');
+      blockCell.innerHTML = cell.innerHTML;
+      blockRow.appendChild(blockCell);
+    });
+    resultBlock.appendChild(blockRow);
+  });
+
+  return resultBlock;
+}
+
+/**
+ * Build synthetic blocks nested in the given block.
+ * A synthetic block is a table whose first header is the block class names (sort of like the tables in doc authoring)
+ * @param {HTMLDivElement} block
+ */
+export function buildSyntheticBlocks(block) {
+  const tables = [...block.querySelectorAll('table')];
+  return tables.map((table) => {
+    const syntheticBlock = tableToBlock(table);
+    const syntheticBlockWrapper = document.createElement('div');
+    syntheticBlockWrapper.appendChild(syntheticBlock);
+    table.replaceWith(syntheticBlockWrapper);
+    decorateBlock(syntheticBlock);
+    return syntheticBlock;
+  });
+}
+
+/**
  * Loads JS and CSS for a block.
  * @param {Element} block The block element
  */
@@ -552,7 +612,20 @@ export async function loadBlocks(main) {
   const blocks = [...main.querySelectorAll('div.block')];
   for (let i = 0; i < blocks.length; i += 1) {
     // eslint-disable-next-line no-await-in-loop
-    await loadBlock(blocks[i]);
+    const block = blocks[i];
+
+    // load syntheticBlocks first and in parallell
+    // this is crucial to ensure all nested blocks are loaded, before the parent block is loaded
+    // given that blocks tend to make a lot of dom changes.
+    const syntheticBlocks = buildSyntheticBlocks(block);
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.all(
+      syntheticBlocks.map((syntheticBlock) => loadBlock(syntheticBlock)),
+    );
+
+    // load the parent block.
+    // eslint-disable-next-line no-await-in-loop
+    await loadBlock(block);
     updateSectionsStatus(main);
   }
 }


### PR DESCRIPTION
This PR adds support for nested (or synthetic blocks). these blocks are initially rendered as a table, and this PR converts that table structure into a block that's automatically loaded.

See: https://github.com/adobe-experience-league/exlm-converter/pull/27 for converter context.

Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: EXLM-172

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/markdown/syntax-style-guide
- After: https://feat-exlm-172--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/markdown/syntax-style-guide
