### PR TITLE
EXLM 64 UE Paths Update

### DIFF
--- a/paths.yaml
+++ b/paths.yaml
@@ -1,5 +1,6 @@
 mappings:
  - /content/exlm/us/en:/
+ - /content/exlm/us/en/:/us/en/
 
 includes:
  - /content/exlm/us/en

--- a/paths.yaml
+++ b/paths.yaml
@@ -1,5 +1,5 @@
 mappings:
- - /content/exlm/:/
+ - /content/exlm/us/en/:/
 
 includes:
- - /content/exlm/
+ - /content/exlm/us/en/

--- a/paths.yaml
+++ b/paths.yaml
@@ -1,5 +1,5 @@
 mappings:
- - /content/exlm/us/en/:/
+ - /content/exlm/us/en:/
 
 includes:
- - /content/exlm/us/en/
+ - /content/exlm/us/en

--- a/paths.yaml
+++ b/paths.yaml
@@ -1,0 +1,5 @@
+mappings:
+ - /content/exlm/:/
+
+includes:
+ - /content/exlm/


### PR DESCRIPTION
Added new file paths.yaml with reference to mappings to the path /content/exlm for Universal Editor and Franklin Repo Mapping

Jira ID:https://jira.corp.adobe.com/browse/EXLM-64

Dummy Test URLs:

Before: https://main--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/markdown/cheatsheet
After: https://feature-EXLM-64-ue-paths--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/markdown/cheatsheet
