### PR TITLE
EXLM 357 Removed Nested Setions from Component Definitions 

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -60,7 +60,6 @@
               "page": {
                 "resourceType": "core/franklin/components/section/v1/section",
                 "template": {
-                  "allowedComponents": ["group:default", "group:blocks"]
                 }
               }
             }
@@ -80,7 +79,6 @@
               "page": {
                 "resourceType": "core/franklin/components/section/v1/section",
                 "template": {
-                  "allowedComponents": ["group:default", "group:blocks"]
                 }
               }
             }

--- a/component-definition.json
+++ b/component-definition.json
@@ -51,19 +51,6 @@
               }
             }
           }
-        },
-        {
-          "title": "Section",
-          "id": "section",
-          "plugins": {
-            "aem": {
-              "page": {
-                "resourceType": "core/franklin/components/section/v1/section",
-                "template": {
-                }
-              }
-            }
-          }
         }
       ]
     },


### PR DESCRIPTION
Removed the allowed component data from the template to avoid nested sections 

Jira ID: https://jira.corp.adobe.com/browse/EXLM-357

Dummy Test URLs:

Before: https://main--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/markdown/cheatsheet
After: https://feature-exlm-357-compdef--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/markdown/cheatsheet
