### PR TITLE
fix: preserve metadata.json extension

### DIFF
--- a/paths.yaml
+++ b/paths.yaml
@@ -1,7 +1,7 @@
 mappings:
  - /content/exlm/global/:/
  - /content/exlm/global/en:/
- - /content/exlm/metadata:/metadata.json
+ - /content/exlm/metadata.json:/metadata.json
 
 includes:
  - /content/exlm/global/en


### PR DESCRIPTION
Currently there is still an issue handling extension in the inbound mapping in the delivery servlet. This can be mitigated by directly mapping metadata.json to /content/exlm/metadata.json.