### PR TITLE
fix: make icons reference base relative

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -112,7 +112,7 @@ body.is-shown .exl-curtain {
   }
 }
 .header .language-selector > a {
-  background: url("/icons/globegrid.svg") 0 24px no-repeat;
+  background: url("../../icons/globegrid.svg") 0 24px no-repeat;
   background-size: contain;
   display: inline-block;
   height: var(--nav-height);

--- a/blocks/header/header.scss
+++ b/blocks/header/header.scss
@@ -115,7 +115,7 @@ body.is-shown {
   }
 
   & .language-selector > a {
-    background: url('/icons/globegrid.svg') 0 24px no-repeat;
+    background: url('../../icons/globegrid.svg') 0 24px no-repeat;
     background-size: contain;
     display: inline-block;
     height: var(--nav-height);


### PR DESCRIPTION
We should the references relative to the file. This makes importing them in the context of AEM easier.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://buuhuu-patch-5--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
