### PR TITLE
fix: allow new tab link nav for all non abobe exp sites EXLM-373

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -132,9 +132,9 @@ export function decorateExternalLinks(main) {
     if (href.includes('#_blank')) {
       a.setAttribute('target', '_blank');
     } else if (
-      a.classList.contains('button') &&
       href &&
-      !href.includes('experienceleague-dev.corp.adobe.com')
+      !href.includes('experienceleague-dev.corp.adobe.com') &&
+      href !== '#'
     ) {
       a.target = '_blank';
       if (!href.startsWith('/') && !href.startsWith('http')) {


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: https://jira.corp.adobe.com/browse/EXLM-373

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/button-samples
- After: N/A
