### PR TITLE
Update paths.yaml

### DIFF
--- a/paths.yaml
+++ b/paths.yaml
@@ -4,6 +4,8 @@ mappings:
   - /content/exlm/metadata:/metadata.json
   # load fragments as resource from codebus in the editor (sw.js)
   - /content/exlm.resource/fragments/:/fragments/
+  
+  - /content/exlm/redirects:/redirects.json
 
 includes:
   - /content/exlm/


### PR DESCRIPTION
Setup redirects to map from / to /en for today's demo to ExL team.
Slack conversation: https://adobe-acs.slack.com/archives/C05R2GKATDJ/p1699456298863879

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://<BRANCH NAME>--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
