### PR TITLE
fix: load requestIdleCallback polyfill conditionally when there is no support EXLM-293

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -311,6 +311,22 @@ function loadDelayed() {
   // load anything that can be postponed to the latest here
 }
 
+async function importScript(url) {
+  return new Promise((resolve, reject) => {
+    const scriptElement = document.createElement('script');
+    scriptElement.src = url;
+    document.head.appendChild(scriptElement);
+    scriptElement.onload = () => {
+      resolve();
+    };
+
+    scriptElement.onabort = () => {
+      console.error(`script failed to load :: ${url}`);
+      reject();
+    };
+  });
+}
+
 /**
  * Custom - Loads the right and left rails for doc pages only.
  */
@@ -327,6 +343,11 @@ function loadRails() {
 }
 
 async function loadPage() {
+  if (!window.requestIdleCallback) {
+    await importScript(
+      'https://polyfill.io/v3/polyfill.min.js?features=requestIdleCallback',
+    );
+  }
   await loadEager(document);
   await loadLazy(document);
   loadRails();


### PR DESCRIPTION

Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: https://jira.corp.adobe.com/browse/EXLM-293

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/experience-manager-guides-learn/tutorials/user-guide/manage-content/authoring-file-management
- After: https://ipad-test--exlm--adobe-experience-league.hlx.page/docs/experience-manager-guides-learn/tutorials/user-guide/manage-content/authoring-file-management
