### PR TITLE
remove requestIdleCallback due to lack of browser support

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -30,4 +30,4 @@ function loadPrism(document) {
     .catch((err) => console.error(err));
 }
 
-requestIdleCallback(() => loadPrism(document));
+loadPrism(document);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -314,16 +314,14 @@ function loadDelayed() {
 /**
  * Custom - Loads the right and left rails for doc pages only.
  */
-function loadRails() {
-  requestIdleCallback(async () => {
-    if (isDocPage()) {
-      loadCSS(`${window.hlx.codeBasePath}/scripts/rails/rails.css`);
-      const mod = await import('./rails/rails.js');
-      if (mod.default) {
-        await mod.default();
-      }
+async function loadRails() {
+  if (isDocPage()) {
+    loadCSS(`${window.hlx.codeBasePath}/scripts/rails/rails.css`);
+    const mod = await import('./rails/rails.js');
+    if (mod.default) {
+      await mod.default();
     }
-  });
+  }
 }
 
 async function loadPage() {


### PR DESCRIPTION

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://bugfix-exlm-378--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
