### PR TITLE
EXLM 280 Breadcrumb Block

### DIFF
--- a/blocks/breadcrumbs/breadcrumbs.css
+++ b/blocks/breadcrumbs/breadcrumbs.css
@@ -7,7 +7,7 @@
   .breadcrumbs > div > div > a {
    font-size: 16px;
    margin: 0px;
-   color: var(--spectrum-global-color-gray-900);
+   color: var(--non-spectrum-grey-updated);
   }
 
   .breadcrumbs > div > div > a::before {

--- a/blocks/breadcrumbs/breadcrumbs.css
+++ b/blocks/breadcrumbs/breadcrumbs.css
@@ -1,0 +1,36 @@
+ .breadcrumbs > div > div {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .breadcrumbs > div > div > a {
+   font-size: 16px;
+   margin: 0px;
+   color: var(--spectrum-global-color-gray-900);
+  }
+
+  .breadcrumbs > div > div > a::before {
+    display: inline-block;
+    background-image: url("/icons/chevron_right.svg");
+    content:"";
+    margin-right: 5px;
+    margin-left: 5px;
+    height: 16px;
+    width: 16px;
+    position: relative;
+    bottom: -2px;
+  } 
+
+  .breadcrumbs > div > div > a:first-child::before {
+    content: none;
+  }
+
+  .breadcrumbs > div > div > a:last-child {
+    color: var(--spectrum-global-color-gray-900);
+    font-weight: bold;
+  }
+
+
+
+


### PR DESCRIPTION
Added the required CSS for static context from the Converter end 

Jira ID: https://jira.corp.adobe.com/browse/EXLM-280

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://feature-exlm-280-breadcrumb--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management

Franklin Published Site with Static Content :

<img width="393" alt="image" src="https://github.com/adobe-experience-league/exlm/assets/30936827/ce6635bf-c268-42b6-b7b8-c47dda718ae3">
