### PR TITLE
fixed css style for dark theme in teaser

### DIFF
--- a/blocks/teaser/teaser.css
+++ b/blocks/teaser/teaser.css
@@ -53,6 +53,7 @@
 }
 
 /* the short description */
+.teaser.block > .foreground > .text > .short-description,
 .teaser.block > .foreground > .text > .short-description * {
   font-family: var(--body-font-family);
   font-size: var(--spectrum-font-size-300);
@@ -67,6 +68,7 @@
   display: none;
 }
 
+.teaser.block > .foreground > .text > .long-description,
 .teaser.block > .foreground > .text > .long-description * {
   font-family: var(--body-font-family);
   font-size: var(--spectrum-font-size-300);
@@ -74,6 +76,7 @@
   margin: 0;
 }
 
+.teaser.block.dark > .foreground > .text > .long-description,
 .teaser.block.dark > .foreground > .text > .long-description * {
   color: var(--background-color);
 }


### PR DESCRIPTION
- If a rich text input only has one paragraph ,then the` <p>` element gets stripped when published (see 3rd teaser example in test page) .
-  If the input field has multiple paragraphs the `<p>` elements are preserved (see 4th teaser example in testpage.)

The CSS was adapted to take this into account and prevent wrong font styles.

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/teaser-test-page
- After: https://fix-teaser-dark-style--exlm--adobe-experience-league.hlx.page/en/teaser-test-page
