### PR TITLE
fix: mini-toc sticky nature on ipad exlm-293

### DIFF
--- a/scripts/rails/rails.css
+++ b/scripts/rails/rails.css
@@ -12,7 +12,7 @@
     padding: 46px 0.75rem 0.75rem;
   }
   .docs .rail .rail-content {
-    margin-top: 0;
+    margin: 0;
     padding-top: 8px;
   }
   .docs .rail .rail-toggle {

--- a/scripts/rails/rails.scss
+++ b/scripts/rails/rails.scss
@@ -16,7 +16,7 @@
       padding: 46px 0.75rem 0.75rem;
 
       .rail-content {
-        margin-top: 0;
+        margin: 0;
         padding-top: 8px;
       }
 


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: https://jira.corp.adobe.com/browse/EXLM-293

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/authoring/tables
- After: https://bugfix-exlm-293-ipad-mini-toc--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/authoring/tables
