### PR TITLE
Carousel fix: Mobile  view should have same alignment as desktop

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -10,6 +10,7 @@
   margin-right: calc(-1 * var(--space-token-xs));
 }
 
+/* contains all teaser divs */
 .carousel.block > .panel-container {
   display: flex;
   scroll-snap-type: x mandatory;
@@ -18,41 +19,50 @@
   margin: auto;
 }
 
+/* if teasers are centered vertically */
 .carousel.block.center > .panel-container {
   align-items: center;
 }
 
+/* if teasers are aligned at the top border */
 .carousel.block.top > .panel-container {
   align-items: flex-start;
 }
 
+/* if teasers are aligned at the bottom border */
 .carousel.block.bottom > .panel-container {
   align-items: flex-end;
 }
 
+/* if teaser have the same height as the tallest one */
 .carousel.block.sametop > .panel-container {
   align-items: stretch;
 }
 
+/* teaser should not shrink and snap to start when scrolling */
 .carousel.block > .panel-container > .teaser.block {
   flex-shrink: 0;
   scroll-snap-align: start;
 }
 
+/* for full height versions we set height to auto */
 .carousel.block.samecenter > .panel-container > .teaser.block,
 .carousel.block.sametop > .panel-container > .teaser.block {
   height:auto;
 }
-
+/* .. and forground to 100% */
+.carousel.block.sametop > .panel-container > .teaser.block > .foreground,
 .carousel.block.samecenter > .panel-container > .teaser.block > .foreground {
   height: 100%;
 }
 
-.carousel.block.samecenter > .panel-container > .teaser.block > .foreground > .text {
-  margin-top: auto;
-  margin-bottom: auto;
+/* for same height , text centered we use flex */
+.carousel.block.samecenter > .panel-container > .teaser.block > .foreground {
+  display: flex;
+  align-items: center;
 }
 
+/* contains the carousel buttons */
 .carousel.block > .button-container {
   display:flex;
   justify-content: center;
@@ -60,6 +70,7 @@
   padding-top:22px;
 }
 
+/* defines look of a button */
 .carousel.block > .button-container button {
   display: block;
   height: 10px;


### PR DESCRIPTION
Small fix so that teasers in a carousel in mobile view also show same vertical alignment behavior as for desktop and tablet.

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/carousel
- After: https://carousel-mobile-css-fix--exlm--adobe-experience-league.hlx.page/en/carousel
