### PR TITLE
Carousel/Teaser: removed carousel alignment options, added missing teaser color

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -17,47 +17,18 @@
   overflow: hidden;
   scroll-behavior: smooth;
   margin: auto;
-}
-
-/* if teasers are centered vertically */
-.carousel.block.center > .panel-container {
-  align-items: center;
-}
-
-/* if teasers are aligned at the top border */
-.carousel.block.top > .panel-container {
-  align-items: flex-start;
-}
-
-/* if teasers are aligned at the bottom border */
-.carousel.block.bottom > .panel-container {
-  align-items: flex-end;
-}
-
-/* if teaser have the same height as the tallest one */
-.carousel.block.sametop > .panel-container {
   align-items: stretch;
 }
 
-/* teaser should not shrink and snap to start when scrolling */
+/* teaser inside carousel have same height and texts are centered */
 .carousel.block > .panel-container > .teaser.block {
   flex-shrink: 0;
   scroll-snap-align: start;
-}
-
-/* for full height versions we set height to auto */
-.carousel.block.samecenter > .panel-container > .teaser.block,
-.carousel.block.sametop > .panel-container > .teaser.block {
   height:auto;
 }
-/* .. and forground to 100% */
-.carousel.block.sametop > .panel-container > .teaser.block > .foreground,
-.carousel.block.samecenter > .panel-container > .teaser.block > .foreground {
-  height: 100%;
-}
 
-/* for same height , text centered we use flex */
-.carousel.block.samecenter > .panel-container > .teaser.block > .foreground {
+.carousel.block > .panel-container > .teaser.block > .foreground {
+  height: 100%;
   display: flex;
   align-items: center;
 }

--- a/component-models.json
+++ b/component-models.json
@@ -92,6 +92,10 @@
             "value": "--spectrum-blue-700"
           },
           {
+            "name": "Green",
+            "value": "--spectrum-green-700"
+          },
+          {
             "name": "Orange",
             "value": "--spectrum-orange-700"
           },
@@ -441,37 +445,7 @@
   },
   {
     "id": "carousel",
-    "fields": [
-      {
-        "component": "select",
-        "name": "classes",
-        "value": "center",
-        "label": "Vertical Alignment",
-        "valueType": "string",
-        "options": [
-          {
-            "name": "Top",
-            "value": "top"
-          },
-          {
-            "name": "Center",
-            "value": "center"
-          },
-          {
-            "name": "Bottom",
-            "value": "bottom"
-          },
-          {
-            "name": "Same Height, text top",
-            "value": "sametop"
-          },
-          {
-            "name": "Same Height, text center",
-            "value": "samecenter"
-          }
-        ]
-      }
-    ]
+    "fields": []
   },
   {
     "id": "marquee",


### PR DESCRIPTION
Small fixes for Carousel /teaser:
- Removed fixed teaser alignment inside carousel see comment in [comment in EXLM-254](https://jira.corp.adobe.com/browse/EXLM-254?focusedCommentId=39137074&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-39137074)
- Added missing color green for background drop down for teaser, see comment in[ EXLM-9](https://jira.corp.adobe.com/browse/EXLM-9)
Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/carousel
- After: https://carousel-alignment--exlm--adobe-experience-league.hlx.page/en/carousel
