### PR TITLE
EXLM 343 Secondary Search Block UE

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -242,6 +242,21 @@
               }
             }
           }
+        },
+        {
+          "title": "Secondary Search",
+          "id": "secondary-search",
+          "plugins": {
+            "aem": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Secondary Search",
+                  "model": "secondary-search"
+                }
+              }
+            }
+          }
         }
       ]
     }

--- a/component-models.json
+++ b/component-models.json
@@ -638,5 +638,26 @@
         "description": "Please provide a URL to an MPC video."
       }
     ]
+  },
+  {
+    "id": "secondary-search",
+    "fields": [
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "name": "heading",
+        "value": "",
+        "label": "Heading",
+        "description": "Sets the title for Secondary Search"
+      },
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "name": "searchBar",
+        "value": "",
+        "label": "Search Bar Text",
+        "description": "Search Input Text from User"
+      }
+    ]
   }
 ]

--- a/component-models.json
+++ b/component-models.json
@@ -656,7 +656,7 @@
         "name": "searchBar",
         "value": "",
         "label": "Search Bar Text",
-        "description": "Search Input Text from User"
+        "description": "Search the search bar Placeholder Text"
       }
     ]
   }


### PR DESCRIPTION
Updated the component-definition.json component-models.json FOR Secondary Search with required fields according to AC

Jira ID:https://jira.corp.adobe.com/browse/EXLM-343

<img width="419" alt="image" src="https://github.com/adobe-experience-league/exlm/assets/30936827/f4371a06-b666-4fb5-a0be-4c0b49bae38f">


Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://feature-exlm-343-sec-search--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management

AEM Author URL : 
https://experience.adobe.com/#/@amc/aem/editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/secondary-search-test-page.html?ref=feature-EXLM-343-sec-search

<img width="905" alt="image" src="https://github.com/adobe-experience-league/exlm/assets/30936827/818ac09b-8528-4688-bdda-46f646c39db4">

