### PR TITLE
EXLM-470 Hyperlink color updated

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -399,7 +399,7 @@ strong {
   --non-spectrum-viridian: #007e50;
   --non-spectrum-grey: #4a4a4a;
   --non-spectrum-grey-updated: #6e6e6e;
-  --non-spectrum-link: #378ef0;
+  --non-spectrum-link: #0265dc;
   --non-spectrum-navy-blue: #1473e6;
   --non-spectrum-article-light-gray: #d3d3d3;
   --non-spectrum-article-dark-gray: #505050;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -399,7 +399,7 @@ strong {
   --non-spectrum-viridian: #007e50;
   --non-spectrum-grey: #4a4a4a;
   --non-spectrum-grey-updated: #6e6e6e;
-  --non-spectrum-link: #378ef0; /* this provides better contrast for a11y */
+  --non-spectrum-link: #378ef0;
   --non-spectrum-navy-blue: #1473e6;
   --non-spectrum-article-light-gray: #d3d3d3;
   --non-spectrum-article-dark-gray: #505050;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -399,7 +399,7 @@ strong {
   --non-spectrum-viridian: #007e50;
   --non-spectrum-grey: #4a4a4a;
   --non-spectrum-grey-updated: #6e6e6e;
-  --non-spectrum-link: #485fc7; /* this provides better contrast for a11y */
+  --non-spectrum-link: #378ef0; /* this provides better contrast for a11y */
   --non-spectrum-navy-blue: #1473e6;
   --non-spectrum-article-light-gray: #d3d3d3;
   --non-spectrum-article-dark-gray: #505050;

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -282,7 +282,7 @@
   --non-spectrum-viridian: #007e50;
   --non-spectrum-grey: #4a4a4a;
   --non-spectrum-grey-updated: #6e6e6e;
-  --non-spectrum-link: #378ef0;
+  --non-spectrum-link: #0265dc;
   --non-spectrum-navy-blue: #1473e6;
   --non-spectrum-article-light-gray: #d3d3d3;
   --non-spectrum-article-dark-gray: #505050;

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -282,7 +282,7 @@
   --non-spectrum-viridian: #007e50;
   --non-spectrum-grey: #4a4a4a;
   --non-spectrum-grey-updated: #6e6e6e;
-  --non-spectrum-link: #485fc7; /* this provides better contrast for a11y */
+  --non-spectrum-link: #378ef0; /* this provides better contrast for a11y */
   --non-spectrum-navy-blue: #1473e6;
   --non-spectrum-article-light-gray: #d3d3d3;
   --non-spectrum-article-dark-gray: #505050;

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -282,7 +282,7 @@
   --non-spectrum-viridian: #007e50;
   --non-spectrum-grey: #4a4a4a;
   --non-spectrum-grey-updated: #6e6e6e;
-  --non-spectrum-link: #378ef0; /* this provides better contrast for a11y */
+  --non-spectrum-link: #378ef0;
   --non-spectrum-navy-blue: #1473e6;
   --non-spectrum-article-light-gray: #d3d3d3;
   --non-spectrum-article-dark-gray: #505050;


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: EXLM-470 

Updated hyperlink color to match with links on https://spectrum.corp.adobe.com/page/body/ as per Nick's comment in the ticket.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/target-dev/developer/client-side/at-js-implementation/at-js/how-atjs-works
- After: https://feature-exlm-470--exlm--adobe-experience-league.hlx.page/docs/target-dev/developer/client-side/at-js-implementation/at-js/how-atjs-works
