### PR TITLE
Exlm 75: Adding Accordion / Accordion Group to Marketing Pages

### DIFF
--- a/blocks/accordion-group/accordion-group.css
+++ b/blocks/accordion-group/accordion-group.css
@@ -10,7 +10,7 @@
   margin-top: 14px;
 }
 
-.accordion-group > .accordion details div *{
+.accordion-group > .accordion details div p {
   font-size: var(--spectrum-font-size-200);
   line-height: var(--spectrum-line-height-m);
 }
@@ -23,7 +23,7 @@
   margin-top: 14px;
 }
 
-.section.marketing .accordion-group > .accordion details div * {
+.section.marketing .accordion-group > .accordion details div p {
   font-size: var(--exlm-font-size-content);
   line-height: var(--exlm-line-height-h4);
 }

--- a/blocks/accordion-group/accordion-group.css
+++ b/blocks/accordion-group/accordion-group.css
@@ -1,1 +1,28 @@
 @import "../shade-box/shade-box.css";
+@import "../accordion/accordion.css";
+
+/* when used inside accordion group we have one less div 
+  TODO : change font size to default of 18px; */
+.accordion-group > .accordion details div *,
+.accordion-group > .accordion details div {
+  color: var(--non-spectrum-raisin-black);
+  font-size: var(--spectrum-font-size-200);
+  line-height: var(--spectrum-line-height-m);
+  margin-left: 14px;
+  margin-top: 14px;
+}
+
+/* Temporary: to demonstrate marking font sizes */
+.section.marketing .accordion-group > .accordion details div *,
+.section.marketing .accordion-group > .accordion details div {
+  color: var(--non-spectrum-raisin-black);
+  font-size: var(--exlm-font-size-content);
+  line-height: var(--spectrum-line-height-m);
+  margin-left: 14px;
+  margin-top: 14px;
+}
+
+/* Temporary to demonstrate marking font sizes */
+.section.marketing .accordion-group > .accordion details summary {
+  font-size: var(--spectrum-font-size-200);
+}

--- a/blocks/accordion-group/accordion-group.css
+++ b/blocks/accordion-group/accordion-group.css
@@ -1,39 +1,16 @@
 @import "../shade-box/shade-box.css";
 @import "../accordion/accordion.css";
 
-/* when used inside accordion group we have one less div 
-  TODO : change font size to default of 18px; */
+/* inside accordion group we can have text below first div */
 .accordion-group > .accordion details div {
-  font-size: var(--spectrum-font-size-200);
-  line-height: var(--spectrum-line-height-m);
-  margin-left: 14px;
-  margin-top: 14px;
-}
-
-.accordion-group > .accordion details div p,
-.accordion-group > .accordion details div ul li,
-.accordion-group > .accordion details div ol li {
-  font-size: var(--spectrum-font-size-200);
-  line-height: var(--spectrum-line-height-m);
-}
-
-/* Temporary: to demonstrate marking font sizes */
-.section.marketing .accordion-group > .accordion details div {
   font-size: var(--exlm-font-size-content);
   line-height: var(--exlm-line-height-h4);
   margin-left: 14px;
   margin-top: 14px;
 }
 
-.section.marketing .accordion-group > .accordion details div p,
-.section.marketing .accordion-group > .accordion details div ul li,
-.section.marketing .accordion-group > .accordion details div ol li{
-  font-size: var(--exlm-font-size-content);
-  line-height: var(--exlm-line-height-h4);
-}
-
-/* Temporary to demonstrate marking font sizes */
-.section.marketing .accordion-group > .accordion details summary {
+/* override /docs font size */
+.accordion-group > .accordion details summary {
   font-size: var(--spectrum-font-size-200);
   line-height: var(--exlm-line-height-h4);
 }

--- a/blocks/accordion-group/accordion-group.css
+++ b/blocks/accordion-group/accordion-group.css
@@ -10,7 +10,9 @@
   margin-top: 14px;
 }
 
-.accordion-group > .accordion details div p {
+.accordion-group > .accordion details div p,
+.accordion-group > .accordion details div ul li,
+.accordion-group > .accordion details div ol li {
   font-size: var(--spectrum-font-size-200);
   line-height: var(--spectrum-line-height-m);
 }
@@ -23,7 +25,9 @@
   margin-top: 14px;
 }
 
-.section.marketing .accordion-group > .accordion details div p {
+.section.marketing .accordion-group > .accordion details div p,
+.section.marketing .accordion-group > .accordion details div ul li,
+.section.marketing .accordion-group > .accordion details div ol li{
   font-size: var(--exlm-font-size-content);
   line-height: var(--exlm-line-height-h4);
 }

--- a/blocks/accordion-group/accordion-group.css
+++ b/blocks/accordion-group/accordion-group.css
@@ -1,0 +1,1 @@
+@import "../shade-box/shade-box.css";

--- a/blocks/accordion-group/accordion-group.css
+++ b/blocks/accordion-group/accordion-group.css
@@ -3,26 +3,33 @@
 
 /* when used inside accordion group we have one less div 
   TODO : change font size to default of 18px; */
-.accordion-group > .accordion details div *,
 .accordion-group > .accordion details div {
-  color: var(--non-spectrum-raisin-black);
   font-size: var(--spectrum-font-size-200);
   line-height: var(--spectrum-line-height-m);
   margin-left: 14px;
   margin-top: 14px;
 }
 
-/* Temporary: to demonstrate marking font sizes */
-.section.marketing .accordion-group > .accordion details div *,
-.section.marketing .accordion-group > .accordion details div {
-  color: var(--non-spectrum-raisin-black);
-  font-size: var(--exlm-font-size-content);
+.accordion-group > .accordion details div *{
+  font-size: var(--spectrum-font-size-200);
   line-height: var(--spectrum-line-height-m);
+}
+
+/* Temporary: to demonstrate marking font sizes */
+.section.marketing .accordion-group > .accordion details div {
+  font-size: var(--exlm-font-size-content);
+  line-height: var(--exlm-line-height-h4);
   margin-left: 14px;
   margin-top: 14px;
+}
+
+.section.marketing .accordion-group > .accordion details div * {
+  font-size: var(--exlm-font-size-content);
+  line-height: var(--exlm-line-height-h4);
 }
 
 /* Temporary to demonstrate marking font sizes */
 .section.marketing .accordion-group > .accordion details summary {
   font-size: var(--spectrum-font-size-200);
+  line-height: var(--exlm-line-height-h4);
 }

--- a/blocks/accordion-group/accordion-group.js
+++ b/blocks/accordion-group/accordion-group.js
@@ -7,7 +7,7 @@ export default function decorate(block) {
   // loop through all accordion blocks
   [...accordions].forEach((accordion) => {
     // generate the accordion
-    const accordionDOM = generateAccordionDOM(accordion.children);
+    const accordionDOM = generateAccordionDOM(accordion);
     // empty the content ,keep root element with UE instrumentation
     accordion.textContent = '';
     // add block classes

--- a/blocks/accordion-group/accordion-group.js
+++ b/blocks/accordion-group/accordion-group.js
@@ -1,7 +1,7 @@
 import { generateAccordionDOM } from '../accordion/accordion.js';
 
 export default function decorate(block) {
-  // get all children elements
+  // each row is an accordion entry
   const accordions = [...block.children];
 
   // loop through all accordion blocks
@@ -13,6 +13,7 @@ export default function decorate(block) {
     // add block classes
     accordion.classList.add('accordion', 'block');
     accordion.append(accordionDOM);
+    // use same styling as shade-box from /docs
     block.classList.add('shade-box');
     block.append(accordion);
   });

--- a/blocks/accordion-group/accordion-group.js
+++ b/blocks/accordion-group/accordion-group.js
@@ -1,0 +1,19 @@
+import { generateAccordionDOM } from '../accordion/accordion.js';
+
+export default function decorate(block) {
+  // get all children elements
+  const accordions = [...block.children];
+
+  // loop through all accordion blocks
+  [...accordions].forEach((accordion) => {
+    // generate the accordion
+    const accordionDOM = generateAccordionDOM(accordion.children);
+    // empty the content ,keep root element with UE instrumentation
+    accordion.textContent = '';
+    // add block classes
+    accordion.classList.add('accordion', 'block');
+    accordion.append(accordionDOM);
+    block.classList.add('shade-box');
+    block.append(accordion);
+  });
+}

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -26,6 +26,8 @@
 .accordion details summary::marker {
   content: none;
 }
+
+.accordion details div,
 .accordion details div > div {
   color: var(--non-spectrum-raisin-black);
   font-size: var(--spectrum-font-size-200);

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -26,8 +26,6 @@
 .accordion details summary::marker {
   content: none;
 }
-
-.accordion details div,
 .accordion details div > div {
   color: var(--non-spectrum-raisin-black);
   font-size: var(--spectrum-font-size-200);

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -4,6 +4,7 @@
   color: var(--non-spectrum-grey);
   padding: 0 16px;
 }
+
 .accordion details summary {
   box-sizing: content-box;
   cursor: pointer;
@@ -13,6 +14,7 @@
   font-size: var(--spectrum-font-size-100);
   line-height: 21px;
 }
+
 .accordion details summary::before {
   content: url("../../icons/chevron_right.svg");
   position: relative; 
@@ -20,14 +22,15 @@
   left: -4.2px;
   margin-right: -2px;
 }
+
 .accordion details summary::-webkit-details-marker {
   display: none;
 }
+
 .accordion details summary::marker {
   content: none;
 }
 
-.accordion details div,
 .accordion details div > div {
   color: var(--non-spectrum-raisin-black);
   font-size: var(--spectrum-font-size-200);
@@ -35,6 +38,7 @@
   margin-left: 14px;
   margin-top: 14px;
 }
+
 .accordion details h1,
 .accordion details h2,
 .accordion details h3 {
@@ -82,16 +86,20 @@ ol .accordion ul {
 .accordion details .accordion {
   margin: 0;
 }
+
 .accordion details details summary {
   font-size: var(--spectrum-font-size-200);
   line-height: 24px;
 }
+
 .accordion details[open] {
   padding-bottom: 16px;
 }
+
 .accordion details[open] summary::before {
   content: url("../../icons/chevron_down.svg");
 }
+
 .accordion .code-wrapper, 
 .accordion .code-wrapper div, 
 .accordion .note-wrapper,

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -112,9 +112,3 @@ ol .accordion ul {
 .shade-box .accordion-wrapper:first-child details {
   padding-top: 16px;
 }
-
-.section.accordion-group > .accordion-wrapper {
-  background-color: var(--spectrum-gray-100);
-  padding: 0 21px;
-  margin:auto;
-}

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -14,7 +14,7 @@
   line-height: 21px;
 }
 .accordion details summary::before {
-  content: url("/icons/chevron_right.svg");
+  content: url("../../icons/chevron_right.svg");
   position: relative; 
   top: 3.5px;
   left: -4.2px;
@@ -26,6 +26,8 @@
 .accordion details summary::marker {
   content: none;
 }
+
+.accordion details div,
 .accordion details div > div {
   color: var(--non-spectrum-raisin-black);
   font-size: var(--spectrum-font-size-200);
@@ -88,7 +90,7 @@ ol .accordion ul {
   padding-bottom: 16px;
 }
 .accordion details[open] summary::before {
-  content: url("/icons/chevron_down.svg");
+  content: url("../../icons/chevron_down.svg");
 }
 .accordion .code-wrapper, 
 .accordion .code-wrapper div, 
@@ -109,4 +111,10 @@ ol .accordion ul {
 
 .shade-box .accordion-wrapper:first-child details {
   padding-top: 16px;
+}
+
+.section.accordion-group > .accordion-wrapper {
+  background-color: var(--spectrum-gray-100);
+  padding: 0 21px;
+  margin:auto;
 }

--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -1,3 +1,4 @@
+/* this function also gets called by accordion-group */
 export function generateAccordionDOM(block) {
   const details = document.createElement('details');
   const summary = document.createElement('summary');

--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -1,9 +1,9 @@
-export function generateAccordionDOM(props) {
+export function generateAccordionDOM(block) {
   const details = document.createElement('details');
   const summary = document.createElement('summary');
   details.append(summary);
-  Array.from(props).forEach((element, i) => {
-    if (i === 0) summary.append(props[0].textContent.trim());
+  Array.from(block.children).forEach((element, i) => {
+    if (i === 0) summary.append(block.children[0].textContent.trim());
     else {
       details.append(element);
     }
@@ -12,7 +12,7 @@ export function generateAccordionDOM(props) {
 }
 
 export default function decorate(block) {
-  const props = [...block.children].map((row) => row.firstElementChild);
+  const dom = generateAccordionDOM(block);
   block.textContent = '';
-  block.append(generateAccordionDOM(props));
+  block.append(dom);
 }

--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -1,13 +1,18 @@
-export default function decorate(block) {
+export function generateAccordionDOM(props) {
   const details = document.createElement('details');
   const summary = document.createElement('summary');
   details.append(summary);
-  Array.from(block.children).forEach((element, i) => {
-    if (i === 0) summary.append(block.children[0].textContent.trim());
+  Array.from(props).forEach((element, i) => {
+    if (i === 0) summary.append(props[0].textContent.trim());
     else {
       details.append(element);
     }
   });
-  block.innerHTML = '';
-  block.append(details);
+  return details;
+}
+
+export default function decorate(block) {
+  const props = [...block.children].map((row) => row.firstElementChild);
+  block.textContent = '';
+  block.append(generateAccordionDOM(props));
 }

--- a/component-definition.json
+++ b/component-definition.json
@@ -205,7 +205,6 @@
         {
           "title": "Carousel",
           "id": "carousel",
-          "classes": "center",
           "plugins": {
             "aem": {
               "page": {
@@ -253,6 +252,45 @@
                 "template": {
                   "name": "Secondary Search",
                   "model": "secondary-search"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Accordion Group",
+          "id": "accordion-group",
+          "plugins": {
+            "aem": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Accordion Group",
+                  "model": "accordion-group",
+                  "allowedComponents": "accordion",
+                  "item": {
+                    "name": "Accordion",
+                    "model": "accordion",
+                    "heading": "Lorem ipsum",
+                    "body": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Accordion",
+          "id": "accordion",
+          "plugins": {
+            "aem": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Accordion",
+                  "model": "accordion",
+                  "heading": "Lorem ipsum",
+                  "body": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -326,11 +326,25 @@
     "id": "section",
     "fields": [
       {
-        "component": "text-input",
+        "component": "select",
         "name": "style",
         "value": "",
-        "label": "Style",
-        "valueType": "string"
+        "label": "Type",
+        "valueType": "string",
+        "options": [
+          {
+            "name": "default",
+            "value": ""
+          },
+          {
+            "name": "Hightlight",
+            "value": "highlight"
+          },
+          {
+            "name": "FAQ",
+            "value": "accordion-group"
+          }
+        ]
       }
     ]
   },
@@ -657,6 +671,29 @@
         "value": "",
         "label": "Search Bar Text",
         "description": "Search the search bar Placeholder Text"
+      }
+    ]
+  },
+  {
+    "id": "collapsible",
+    "fields": []
+  },
+  {
+    "id": "accordion",
+    "fields": [
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "name": "heading",
+        "value": "",
+        "label": "Heading"
+      },
+      {
+        "component": "text-area",
+        "valueType": "string",
+        "name": "body",
+        "value": "",
+        "label": "Body"
       }
     ]
   }

--- a/component-models.json
+++ b/component-models.json
@@ -326,25 +326,11 @@
     "id": "section",
     "fields": [
       {
-        "component": "select",
+        "component": "text-input",
         "name": "style",
         "value": "",
-        "label": "Type",
-        "valueType": "string",
-        "options": [
-          {
-            "name": "default",
-            "value": ""
-          },
-          {
-            "name": "Hightlight",
-            "value": "highlight"
-          },
-          {
-            "name": "FAQ",
-            "value": "accordion-group"
-          }
-        ]
+        "label": "Style",
+        "valueType": "string"
       }
     ]
   },
@@ -675,7 +661,7 @@
     ]
   },
   {
-    "id": "collapsible",
+    "id": "accordion-group",
     "fields": []
   },
   {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -744,6 +744,7 @@ img {
 .section.highlight {
   background-color: var(--highlight-background-color);
 }
+
 .section > div {
   /* limit block wrappers max width */
   max-width: var(--non-spectrum-max-width);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -744,7 +744,6 @@ img {
 .section.highlight {
   background-color: var(--highlight-background-color);
 }
-
 .section > div {
   /* limit block wrappers max width */
   max-width: var(--non-spectrum-max-width);


### PR DESCRIPTION
- New Component Accordion Group (same styling as shade-box for /docs)
- Reuse Component Accordion as only allowed child of Accordion Group.

Jira ID:  [EXLM-75](https://jira.corp.adobe.com/browse/EXLM-75)

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/collapsible
- After: https://exlm-75--exlm--adobe-experience-league.hlx.page/en/collapsible
