### PR TITLE
add accordion and accordion-group to model for testing

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -670,5 +670,28 @@
         "description": "Search the search bar Placeholder Text"
       }
     ]
+  },
+  {
+    "id": "accordion-group",
+    "fields": []
+  },
+  {
+    "id": "accordion",
+    "fields": [
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "name": "heading",
+        "value": "",
+        "label": "Heading"
+      },
+      {
+        "component": "text-area",
+        "valueType": "string",
+        "name": "body",
+        "value": "",
+        "label": "Body"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
To be able to work with before/after urls when creating new components we need to push the `components-model.json` to main branch first since the converter always loads the model definition from this branch. If not then any content for new components will not be visible/rendered on the Before/After pages.

Jira ID: none

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/collapsible
- After: https://accordion-model--exlm--adobe-experience-league.hlx.page/en/collapsible
