### PR TITLE
EXLM-74 Added resourceType for Icon card

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -93,6 +93,7 @@
                   "allowedComponents": "icon-block",
                   "name": "Icon Block",
                   "item1": {
+                    "resourceType": "core/franklin/components/block/v1/block/item",
                     "name": "Icon Card",
                     "model": "icon-card",
                     "cardIcon": "/content/dam/exlm/icons/S_ExperienceManager_24_N.svg",
@@ -102,6 +103,7 @@
                     "cardLink": "/content/exlm/global/en"
                   },
                   "item2": {
+                    "resourceType": "core/franklin/components/block/v1/block/item",
                     "name": "Icon Card",
                     "model": "icon-card",
                     "cardIcon": "/content/dam/exlm/icons/S_ExperienceManager_24_N.svg",
@@ -111,6 +113,7 @@
                     "cardLink": "/content/exlm/global/en"
                   },
                   "item3": {
+                    "resourceType": "core/franklin/components/block/v1/block/item",
                     "name": "Icon Card",
                     "model": "icon-card",
                     "cardIcon": "/content/dam/exlm/icons/S_ExperienceManager_24_N.svg",


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: EXLM-74

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/icon-card
- After: https://feature-exlm-74-icon-card-block--exlm--adobe-experience-league.hlx.page/en/icon-card
