### PR TITLE
Added sling:resourceType for Icon card and accordion

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -93,7 +93,7 @@
                   "allowedComponents": "icon-block",
                   "name": "Icon Block",
                   "item1": {
-                    "resourceType": "core/franklin/components/block/v1/block/item",
+                    "sling:resourceType": "core/franklin/components/block/v1/block/item",
                     "name": "Icon Card",
                     "model": "icon-card",
                     "cardIcon": "/content/dam/exlm/icons/S_ExperienceManager_24_N.svg",
@@ -103,7 +103,7 @@
                     "cardLink": "/content/exlm/global/en"
                   },
                   "item2": {
-                    "resourceType": "core/franklin/components/block/v1/block/item",
+                    "sling:resourceType": "core/franklin/components/block/v1/block/item",
                     "name": "Icon Card",
                     "model": "icon-card",
                     "cardIcon": "/content/dam/exlm/icons/S_ExperienceManager_24_N.svg",
@@ -113,7 +113,7 @@
                     "cardLink": "/content/exlm/global/en"
                   },
                   "item3": {
-                    "resourceType": "core/franklin/components/block/v1/block/item",
+                    "sling:resourceType": "core/franklin/components/block/v1/block/item",
                     "name": "Icon Card",
                     "model": "icon-card",
                     "cardIcon": "/content/dam/exlm/icons/S_ExperienceManager_24_N.svg",
@@ -276,7 +276,7 @@
                   "model": "accordion-group",
                   "allowedComponents": "accordion",
                   "item": {
-                    "resourceType": "core/franklin/components/block/v1/block/item",
+                    "sling:resourceType": "core/franklin/components/block/v1/block/item",
                     "name": "Accordion",
                     "model": "accordion",
                     "heading": "Lorem ipsum",


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: EXLM-74 EXLM-75

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/icon-card
- After: https://feature-exlm-74-icon-card-block--exlm--adobe-experience-league.hlx.page/en/icon-card
