### PR TITLE
Temporary TOC fragment

### DIFF
--- a/blocks/toc/toc.css
+++ b/blocks/toc/toc.css
@@ -1,0 +1,31 @@
+.toc ul {
+    list-style: none;
+    margin-left: 0;
+}
+
+.toc ul li {
+    justify-content: start;
+    box-sizing: border-box;
+    width: 100%;
+    min-height: var(--spectrum-sidenav-item-height, var(--spectrum-alias-single-line-height));
+    padding: var(--spectrum-sidenav-item-padding-y) var(--spectrum-sidenav-item-padding-x, var(--spectrum-global-dimension-size-150)) var(--spectrum-sidenav-item-padding-y) var(--spectrum-sidenav-item-padding-x, var(--spectrum-global-dimension-size-150));
+    margin: 4px 0;
+}
+
+.toc ul li ul {
+    margin-left: 12px;
+}
+
+.toc ul li a, .toc ul li ul li:last-child{
+    font-size: var(--spectrum-font-size-100);
+    line-height: 21px;
+    display: inline-flex;
+    min-height: 32px;
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0;
+    border-radius: 4px;
+    padding: 5px 12px;
+    color: var(--non-spectrum-grey-updated, var(--spectrum-alias-text-color-hover));
+    padding-left: 24px;
+}

--- a/blocks/toc/toc.js
+++ b/blocks/toc/toc.js
@@ -1,3 +1,32 @@
-export default async function decorate() {
-  // TODO: handle toc - load as fragment and decorate, akin header/footer ..etc.
+// FIXME: Revisit this implementation. This is only a temp example untill we get a TOC API from the EXL team.
+const CONFIG = {
+  basePath: '/fragments/en',
+  tocPath: '/toc/toc.plain.html',
+};
+
+// Utility function for http call
+const getHTMLData = async (url) => {
+  const response = await fetch(url);
+  if (response.ok) {
+    const responseData = response.text();
+    return responseData;
+  }
+  throw new Error(`${url} not found`);
+};
+
+/**
+ * loads and decorates the toc
+ * @param {Element} block The toc block element
+ */
+export default async function decorate(block) {
+  // fetch toc content
+  const tocPath = `${CONFIG.basePath}${CONFIG.tocPath}`;
+  const resp = await getHTMLData(tocPath);
+
+  if (resp) {
+    const html = resp;
+
+    // decorate TOC DOM
+    block.innerHTML = html;
+  }
 }


### PR DESCRIPTION
Temporary TOC fragment to be loaded on doc pages.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/markdown/cheatsheet
- After: https://feature-toc--exlm--adobe-experience-league.hlx.page/docs/authoring-guide-exl/using/markdown/cheatsheet
