### PR TITLE
Use new multiselect for teaser styles

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -19,27 +19,38 @@
         "description": "A descriptive text of the image will be shown as tooltip."
       },
       {
-        "component": "select",
+        "component": "multiselect",
         "name": "classes",
-        "label": "Theme / Order",
+        "label": "Style",
         "valueType": "string",
-        "multi": true,
+        "required": true,
+        "maxSize": 2,
         "options": [
           {
-            "name": "Light Theme",
-            "value": "light"
+            "name": "Theme",
+            "children": [
+              {
+                "name": "Light",
+                "value": "light"
+              },
+              {
+                "name": "Dark",
+                "value": "dark"
+              }
+            ]
           },
           {
-            "name": "Dark Theme",
-            "value": "dark"
-          },
-          {
-            "name": "Text left",
-            "value": "left"
-          },
-          {
-            "name": "Text right",
-            "value": "right"
+            "name": "Alignment",
+            "children": [
+              {
+                "name": "Left",
+                "value": "left"
+              },
+              {
+                "name": "Right",
+                "value": "right"
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
- updates the component-models.json to use the new multiselect for setting styles on a teaser

Before:
![image](https://github.com/adobe-experience-league/exlm/assets/37147400/e8f25f1c-d3e7-42bb-b730-e469df75cc79)
https://experience.adobe.com/#/@amc/aem/editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/teaser-test-page.html

After:
![image](https://github.com/adobe-experience-league/exlm/assets/37147400/714fa631-d861-413a-994b-f040249f12c9)
https://experience.adobe.com/#/@amc/aem/editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/teaser-test-page.html?ref=teaser-new-ui
