### PR TITLE
Media Block: remove :scope from querySelector

### DIFF
--- a/blocks/media/media.js
+++ b/blocks/media/media.js
@@ -38,7 +38,7 @@ export default function decorate(block) {
 
   // set image description
   if (imageDescr) {
-    mediaDOM.querySelector(':scope .image picture img').setAttribute('alt', imageDescr);
+    mediaDOM.querySelector('.image picture img').setAttribute('alt', imageDescr);
   }
 
   // attach DOM


### PR DESCRIPTION
you can't use `:scope` on a document fragment selector in Safari+Firefox.

Jira ID: EXLM-618

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/media
- After: https://exlm-618--exlm--adobe-experience-league.hlx.page/en/media
