### PR TITLE
remove hero auto blocking

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-bitwise */
 import {
   sampleRUM,
-  buildBlock,
   loadHeader,
   loadFooter,
   decorateIcons,
@@ -18,21 +17,6 @@ import {
 } from './lib-franklin.js';
 
 const LCP_BLOCKS = ['marquee']; // add your LCP blocks to the list
-
-/**
- * Builds hero block and prepends to main in a new section.
- * @param {Element} main The container element
- */
-function buildHeroBlock(main) {
-  const h1 = main.querySelector('h1');
-  const picture = main.querySelector('picture');
-  // eslint-disable-next-line no-bitwise
-  if (h1 && picture && h1.compareDocumentPosition(picture) & Node.DOCUMENT_POSITION_PRECEDING) {
-    const section = document.createElement('div');
-    section.append(buildBlock('hero', { elems: [picture, h1] }));
-    main.prepend(section);
-  }
-}
 
 /**
  * load fonts.css and set a session storage flag
@@ -110,7 +94,6 @@ export function buildSyntheticBlocks(main) {
  */
 function buildAutoBlocks(main) {
   try {
-    buildHeroBlock(main);
     buildSyntheticBlocks(main);
   } catch (error) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
If  a page has an image (`<picture>`) followed by a heading 1 (`<h1>`) the default franklin boilerplate code will try to generate a hero block, which is not what we want. This PR removes this auto blocking.

Jira ID: [EXLM-604](https://jira.corp.adobe.com/browse/EXLM-604)

Editor Before:  https://author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/marquee-issue-test.html
Editor After: https://author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/marquee-issue-test.html?ref=exlm-604
