### PR TITLE
Revert "EXLM-17 Browse filters"

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -987,7 +987,23 @@
   },
   {
     "id": "browse-filters",
-    "fields": []
+    "fields": [
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "name": "heading",
+        "value": "",
+        "label": "Heading",
+        "description": "Sets the heading for Browse Filters."
+      },
+      {
+        "component": "text-area",
+        "valueType": "string",
+        "name": "description",
+        "value": "",
+        "label": "Sets the description for Browse Filters"
+      }
+    ]
   },
   {
     "id": "featured-cards",


### PR DESCRIPTION
Reverts adobe-experience-league/exlm#255

Jira ID: EXLM-17

Test URLs:

Before: https://main--exlm--adobe-experience-league.hlx.live/en/browse-filters
After: https://revert-255-feature-EXLM-17--exlm--adobe-experience-league.hlx.live/en/browse-filters
https://experience.adobe.com/#/@amc/aem/editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/browse-filters.html?ref=revert-255-feature-EXLM-17