### PR TITLE
fixed media defition for rail

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -778,7 +778,7 @@ main > div.browse-rail {
 }
 
 /* browse rail breakpoint same as main hamburger menu */
-@media (width >= 1024px) {
+@media (min-width: 1024px) {
   body[class^=browse-] > main {
     display: grid;
     grid-template: "browse-rail main"/256px 1fr;

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -663,7 +663,7 @@ main > div.browse-rail {
 }
 
 /* browse rail breakpoint same as main hamburger menu */
-@media (width >= 1024px) {
+@media (width >=1024px) {
   body[class^='browse-'] > main {
     display: grid;
     grid-template:


### PR DESCRIPTION
fixes the @media defintion for browse rails. the old definition didnt trigger on ipad pro 

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/browse/acrobat
- After: https://fix-ipad--exlm--adobe-experience-league.hlx.page/en/browse/acrobat
