### PR TITLE
add stylelint ignore to avoid incorrect autofixing

### DIFF
--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -663,7 +663,7 @@ main > div.browse-rail {
 }
 
 /* browse rail breakpoint same as main hamburger menu */
-@media (width >=1024px) {
+@media (width >= 1024px) {
   body[class^='browse-'] > main {
     display: grid;
     grid-template:

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -663,7 +663,9 @@ main > div.browse-rail {
 }
 
 /* browse rail breakpoint same as main hamburger menu */
-@media (width >= 1024px) {
+
+/* stylelint-disable-next-line media-feature-range-notation */
+@media (min-width: 1024px) {
   body[class^='browse-'] > main {
     display: grid;
     grid-template:


### PR DESCRIPTION
stylelinting automatically tries to replace min-width wit >= , which does not work on ipad pro safari.

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/browse/acrobat
- After: https://fix-ipad2--exlm--adobe-experience-league.hlx.page/en/browse/acrobat
