### PR TITLE
IPad Pro : Marquee fix

### DIFF
--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -330,6 +330,7 @@ body[class ^= 'browse-'] .section div.marquee-wrapper {
     border: 1px solid var(--spectrum-gray-200);
     border-radius: 4px;
     box-sizing: border-box;
+    background-color: var(--background-color);
   }
 }
 

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -332,5 +332,10 @@ body[class ^= 'browse-'] .section div.marquee-wrapper {
     box-sizing: border-box;
     background-color: var(--background-color);
   }
+
+  body[class ^= 'browse-'] .section div.marquee-wrapper .marquee-background svg{
+    min-width: 130%;
+    min-height: 0%;
+  }
 }
 


### PR DESCRIPTION
The svg background for the marquee is not rendered correctly on ipad pro 12.9 safari

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/browse/acrobat
- After: https://fix-ipad3--exlm--adobe-experience-league.hlx.page/en/browse/acrobat