### PR TITLE
trivial: updating to dev data stream from prod

### DIFF
--- a/scripts/analytics/lib-analytics.js
+++ b/scripts/analytics/lib-analytics.js
@@ -49,7 +49,7 @@ function getAlloyInitScript() {
 function getDatastreamConfiguration() {
   // EXLM
   return {
-    edgeConfigId: 'a79fa341-435b-4dd8-86e0-a71d4d9ff0e2',
+    edgeConfigId: 'a79fa341-435b-4dd8-86e0-a71d4d9ff0e2:dev',
     orgId: '8F99160E571FC0427F000101@AdobeOrg',
   };
 }


### PR DESCRIPTION
Updating the data stream edge config id so it can pull in dev suite now instead of prod

Jira ID: EXLM-454

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en
- After: https://bugfix-datastream-analytics--exlm--rogerblanton.hlx.page/en