### PR TITLE
EXLM-76: add new tabs and tab block to component-model

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -1372,5 +1372,28 @@
         ]
       }
     ]
+  },
+  {
+    "id": "tabs",
+    "fields": []
+  },
+  {
+    "id": "tab",
+    "fields": [
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "name": "title",
+        "value": "",
+        "label": "Heading"
+      },
+      {
+        "component": "text-area",
+        "valueType": "string",
+        "name": "content",
+        "value": "",
+        "label": "Body"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
To be able to work with before/after urls when creating new components we need to push the components-model.json to main branch first since the converter always loads the model definition from this branch. If not then any content for new components will not be visible/rendered on the Before/After pages.