### PR TITLE
EXLM-76: Add Tabs

### DIFF
--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -54,3 +54,8 @@
 .tabs .tab-content .tabpanel.active {
   display: block;
 }
+
+body:not([class=docs]) .tabs .tab-list button.tab-title,
+body:not([class=docs]) .tabs .tab-content .tabpanel {
+  font-size: var(--exlm-font-size-content);
+}

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -26,7 +26,7 @@
   line-height: 56px;
   white-space: nowrap;
   font-family: var(--body-font-family);
-  font-size: var(--spectrum-body-size-m);
+  font-size: var(--exlm-font-size-content);
   font-weight: 400;
   border: 0;
   border-radius: 0;
@@ -44,7 +44,7 @@
   padding: 10.5px 0;
   color: var(--spectrum-gray-800);
   font-family: var(--body-font-family);
-  font-size: var(--spectrum-body-size-m);
+  font-size: var(--exlm-font-size-content);
   font-weight: 400;
 }
 .tabs .tab-content .tabpanel {
@@ -53,9 +53,4 @@
 }
 .tabs .tab-content .tabpanel.active {
   display: block;
-}
-
-body:not([class=docs]) .tabs .tab-list button.tab-title,
-body:not([class=docs]) .tabs .tab-content .tabpanel {
-  font-size: var(--exlm-font-size-content);
 }

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -29,8 +29,13 @@ export default function decorate(block) {
 
   const tabNames = [];
   const tabContents = [];
+  // list of Universal Editor instrumented 'tab content' divs
+  const tabInstrumentedDiv = [];
 
   [...block.children].forEach((child) => {
+    // keep the div that has been instrumented for UE
+    tabInstrumentedDiv.push(child);
+
     [...child.children].forEach((el, index) => {
       if (index === 0) {
         tabNames.push(el.textContent.trim());
@@ -70,7 +75,13 @@ export default function decorate(block) {
       'aria-labelledby': `tab-${initCount}-${nameId}`,
     };
 
-    const tabContentDiv = createTag('div', tabContentAttributes);
+    // get the instrumented div
+    const tabContentDiv = tabInstrumentedDiv[i];
+    // add all additional attributes
+    Object.entries(tabContentAttributes).forEach(([key, val]) => {
+      tabContentDiv.setAttribute(key, val);
+    });
+
     // default first tab is active
     if (i === 0) tabContentDiv.classList.add('active');
     tabContentDiv.innerHTML = content;

--- a/blocks/tabs/tabs.scss
+++ b/blocks/tabs/tabs.scss
@@ -28,7 +28,7 @@
     line-height: 56px;
     white-space: nowrap;
     font-family: var(--body-font-family);
-    font-size: var(--spectrum-body-size-m);
+    font-size: var(--exlm-font-size-content);
     font-weight: 400;
     border: 0;
     border-radius: 0;
@@ -49,7 +49,7 @@
     padding: 10.5px 0;
     color: var(--spectrum-gray-800);
     font-family: var(--body-font-family);
-    font-size: var(--spectrum-body-size-m);
+    font-size: var(--exlm-font-size-content);
     font-weight: 400;
   }
 
@@ -61,10 +61,4 @@
   .tab-content .tabpanel.active {
     display: block;
   }
-}
-
-// on non /docs pages font size is 18px
-body:not([class='docs']) .tabs .tab-list button.tab-title,
-body:not([class='docs']) .tabs .tab-content .tabpanel {
-  font-size: var(--exlm-font-size-content);
 }

--- a/blocks/tabs/tabs.scss
+++ b/blocks/tabs/tabs.scss
@@ -62,3 +62,9 @@
     display: block;
   }
 }
+
+// on non /docs pages font size is 18px
+body:not([class='docs']) .tabs .tab-list button.tab-title,
+body:not([class='docs']) .tabs .tab-content .tabpanel {
+  font-size: var(--exlm-font-size-content);
+}

--- a/component-definition.json
+++ b/component-definition.json
@@ -475,14 +475,14 @@
           }
         },
         {
-          "title": "Tab Group",
+          "title": "Tabs",
           "id": "tabs",
           "plugins": {
             "aem": {
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
-                  "name": "Tab Group",
+                  "name": "Tabs",
                   "model": "tabs",
                   "allowedComponents": "tab",
                   "item1": {

--- a/component-definition.json
+++ b/component-definition.json
@@ -475,14 +475,14 @@
           }
         },
         {
-          "title": "Tabs",
+          "title": "Tab Group",
           "id": "tabs",
           "plugins": {
             "aem": {
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
-                  "name": "Tabs",
+                  "name": "Tab Group",
                   "model": "tabs",
                   "allowedComponents": "tab",
                   "item1": {

--- a/component-definition.json
+++ b/component-definition.json
@@ -473,6 +473,46 @@
               }
             }
           }
+        },
+        {
+          "title": "Tabs",
+          "id": "tabs",
+          "plugins": {
+            "aem": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Tabs",
+                  "model": "tabs",
+                  "allowedComponents": "tab",
+                  "item1": {
+                    "sling:resourceType": "core/franklin/components/block/v1/block/item",
+                    "name": "Tab",
+                    "model": "tab",
+                    "title": "Tab",
+                    "content": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Tab",
+          "id": "tab",
+          "plugins": {
+            "aem": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block/item",
+                "template": {
+                  "name": "Tab",
+                  "model": "tab",
+                  "title": "Tab",
+                  "content": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."
+                }
+              }
+            }
+          }
         }
       ]
     }

--- a/component-models.json
+++ b/component-models.json
@@ -1372,5 +1372,28 @@
         ]
       }
     ]
+  },
+  {
+    "id": "tabs",
+    "fields": []
+  },
+  {
+    "id": "tab",
+    "fields": [
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "name": "title",
+        "value": "",
+        "label": "Heading"
+      },
+      {
+        "component": "text-area",
+        "valueType": "string",
+        "name": "content",
+        "value": "",
+        "label": "Body"
+      }
+    ]
   }
 ]

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -17,7 +17,6 @@ function setSelectedTab(id,newBlock) {
 }
 
 function handleEditorUpdate(event) {
-  console.log(`editor update`);
   const {
     detail: { itemids },
   } = event;
@@ -26,7 +25,6 @@ function handleEditorUpdate(event) {
       .map((itemId) => document.querySelector(`[itemid="${itemId}"]`))
       .map(async (element) => {
         const block = element.closest('.block');
-        console.log(block);
         const blockItemId = block?.getAttribute('itemid');
         if (block && blockItemId?.startsWith(connectionPrefix)) {
           const path = blockItemId.substring(connectionPrefix.length);
@@ -37,7 +35,6 @@ function handleEditorUpdate(event) {
           const resp = await fetch(`${path}.html${window.location.search}`);
           if (resp.ok) {
             const text = await resp.text();
-            console.log('hello world');
             const newBlock = new DOMParser().parseFromString(text, 'text/html').body.firstElementChild;
             // hide the new block, and insert it after the existing one
             newBlock.style.display = 'none';
@@ -51,9 +48,6 @@ function handleEditorUpdate(event) {
             // remove the old block and show the new one
             block.remove();
             newBlock.style.display = null;
-
-            console.log(`active Tab ID : ${activeTabId}`);
-            console.log(newBlock.querySelector(`[data-tab-id="${activeTabId}"]`));
 
             if(activeTabId) setSelectedTab(activeTabId,newBlock);
 

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -11,7 +11,7 @@ function getSelectedTab(block) {
 }
 
 // reactivates the previously active tab on the new edited block
-function setSelectedTab(id,newBlock) {
+function setSelectedTab(id, newBlock) {
   // click the previously slected tab
   newBlock.querySelector(`[data-tab-id="${id}"]`).click();
 }
@@ -49,7 +49,7 @@ function handleEditorUpdate(event) {
             block.remove();
             newBlock.style.display = null;
 
-            if(activeTabId) setSelectedTab(activeTabId,newBlock);
+            if (activeTabId) setSelectedTab(activeTabId, newBlock);
 
             return Promise.resolve();
           }


### PR DESCRIPTION
- Extended existing Tabs block used in `/docs` to make it available in markting pages and editable in UE.
- Changed font size for content and tab title to 18px to be in line with font sizes on marketing pages.
- Extended event handler for UE change event to keep the proper tab open after an edit.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-76

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/tab-group-test-page
- After: https://exlm-76--exlm--adobe-experience-league.hlx.page/en/tab-group-test-page

AEM authoring:

https://experience.adobe.com/#/@amc/aem/editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/tab-group-test-page.html?ref=exlm-76

The changes should not affect the current rendering of the tabs block on docs pages:
- without this changes: https://main--exlm--adobe-experience-league.hlx.live/docs/authoring-guide-exl/using/markdown/cheatsheet#tabs
- with the changes: https://exlm-76--exlm--adobe-experience-league.hlx.live/docs/authoring-guide-exl/using/markdown/cheatsheet#tabs

Testing Notes:
- **add tab**: selects `Tabs` block  , add a Tab block ->  due to currently missing add event from UE ([SITES-17895](https://jira.corp.adobe.com/browse/SITES-17895))  it jumps back to first panel
- **edit tab**: select content area of tab , open properties panel, tab updates when changed
- **change tab**: go into preview mode, change tab, go back into edit, select content area of tab -> due to currently missing select event from UE [(SITES-17905)](https://jira.corp.adobe.com/browse/SITES-17905) you can't make the tab visible from page tree view.
- **reorder tab**: reorder in page tree view -> due to currently missing move event from UE ([SITES-17897](https://jira.corp.adobe.com/browse/SITES-17897)) this requires a manual reload.
- **delete tab**: select tab, click delete -> due to currently missing remove event from UE ([SITES-17916](https://jira.corp.adobe.com/browse/SITES-17916)) only the tab content area is removed, manual reload is required to remove the tab title from the parent `tabs` block.