### PR TITLE
EXLM-843 - better fix for IOS input zoom issue

### DIFF
--- a/blocks/browse-filters/browse-filters.css
+++ b/blocks/browse-filters/browse-filters.css
@@ -49,12 +49,16 @@
   border-radius: 4px;
   padding: 9px 12px;
   width: 100%;
-  font-size: var(--spectrum-body-size-s);
+  font-size: 16px; /* https://defensivecss.dev/tip/input-zoom-safari/ */
   text-align: left;
   color: var(--spectrum-gray-800);
   line-height: 10px;
   font-weight: normal;
   margin: 0;
+}
+
+.filter-input > input::placeholder {
+  font-size: var(--spectrum-body-size-m);
 }
 
 .filter-input .icon-search {

--- a/head.html
+++ b/head.html
@@ -1,5 +1,5 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="theme-color" content="#EAEAEA" />
 <meta charset="UTF-8" />
 <meta name="google" content="notranslate" />


### PR DESCRIPTION
EXLM-843
Better fix for the IOS input zoom issue while removing maximum-scale=1 from "viewport" meta which is not accessible (per page speed insights) 

Test URLs:


- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://bugfix-exlm-843-friendlier-fix--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
