### PR TITLE
Improve LCP

### DIFF
--- a/head.html
+++ b/head.html
@@ -6,7 +6,6 @@
 <meta property="og:type" content="website" />
 <script src="/scripts/lib-franklin.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
-<link rel="stylesheet" href="/styles/print/print.css" media="print" />
 <link rel="stylesheet" href="/styles/styles.css" />
 <script>
   /*to prevent Firefox FOUC, this must be here*/

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-cycle
-import { sampleRUM } from './lib-franklin.js';
+import { loadCSS, sampleRUM } from './lib-franklin.js';
 // add more delayed functionality here
 
 // Core Web Vitals RUM collection
@@ -28,5 +28,7 @@ function loadPrism(document) {
     // eslint-disable-next-line no-console
     .catch((err) => console.error(err));
 }
+
+loadCSS('/styles/print/print.css');
 
 loadPrism(document);

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -109,12 +109,13 @@ export function sampleRUM(checkpoint, data = {}) {
  * Loads a CSS file.
  * @param {string} href URL to the CSS file
  */
-export async function loadCSS(href) {
+export async function loadCSS(href, media) {
   return new Promise((resolve, reject) => {
     if (!document.querySelector(`head > link[href="${href}"]`)) {
       const link = document.createElement('link');
       link.rel = 'stylesheet';
       link.href = href;
+      if (media) link.media = media;
       link.onload = resolve;
       link.onerror = reject;
       document.head.append(link);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -271,8 +271,8 @@ export async function loadIms() {
  */
 async function loadLazy(doc) {
   const main = doc.querySelector('main');
-  loadIms(); // start it early, asyncronously
   await loadBlocks(main);
+  loadIms(); // start it early, asyncronously
 
   const { hash } = window.location;
   const element = hash ? doc.getElementById(hash.substring(1)) : false;


### PR DESCRIPTION
improve LCP score just a bit by:

1. dynamically importing analytics scripts so that `scripts.js` does not depend on it immediately
2. delay print.css loading to delayed.js 

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://improve-lcp--exlm--adobe-experience-league.hlx.page/docs/integrations-learn/experience-cloud/solution-categories/content-management
