### PR TITLE
Exlm-896: Marquee CTA updates

### DIFF
--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -20,7 +20,6 @@ export default function decorate(block) {
 
   // get signed in status 
   const isSignedIn = window.adobeIMS?.isSignedInUser();
-  console.log(`isSignedIn: ${isSignedIn}`);
 
   // Build DOM
   const marqueeDOM = document.createRange().createContextualFragment(`

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -1,4 +1,3 @@
-
 /* eslint-disable no-plusplus */
 import { decorateIcons } from '../../scripts/lib-franklin.js';
 
@@ -18,7 +17,7 @@ export default function decorate(block) {
   const secondCTAText = props[count++].textContent.trim();
   const secondCTALink = props[count++].textContent.trim();
 
-  // get signed in status 
+  // get signed in status
   const isSignedIn = window.adobeIMS?.isSignedInUser();
 
   // Build DOM
@@ -29,9 +28,7 @@ export default function decorate(block) {
         <div class='marquee-title'>${title}</div>
         <div class='marquee-long-description'>${longDescr}</div>
         <div class='marquee-cta'>${
-          firstCTAText && firstCTALink
-            ? `<a class='button secondary' href='${firstCTALink}'>${firstCTAText}</a>`
-            : ``
+          firstCTAText && firstCTALink ? `<a class='button secondary' href='${firstCTALink}'>${firstCTAText}</a>` : ``
         }${
           secondCTAText && secondCTALink && !isSignedIn
             ? `<a class='button primary' href='${secondCTALink}'>${secondCTAText}</a>`

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -20,6 +20,7 @@ export default function decorate(block) {
 
   // get signed in status 
   const isSignedIn = window.adobeIMS?.isSignedInUser();
+  console.log(`isSignedIn: ${isSignedIn}`);
 
   // Build DOM
   const marqueeDOM = document.createRange().createContextualFragment(`

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -1,22 +1,25 @@
+
+/* eslint-disable no-plusplus */
 import { decorateIcons } from '../../scripts/lib-franklin.js';
 
 export default function decorate(block) {
   // Extract properties
   // always same order as in model, empty string if not set
   const props = [...block.querySelectorAll(':scope div > div')];
-
-  const subjectPicture = props[0].innerHTML.trim();
-  const subjectImageDescr = props[1].textContent.trim();
-  const bgColor = props[2].textContent.trim();
-  const eyebrow = props[3].textContent.trim();
-  const title = props[4].textContent.trim();
-  const longDescr = props[5].innerHTML.trim();
-  const firstCTAType = props[6].textContent.trim();
-  const firstCTAText = props[7].textContent.trim();
-  const firstCTALink = props[8].textContent.trim();
-  const secondCTAType = props[9].textContent.trim();
-  const secondCTAText = props[10].textContent.trim();
+  let count = 0;
+  const subjectPicture = props[count++].innerHTML.trim();
+  const subjectImageDescr = props[count++].textContent.trim();
+  const bgColor = props[count++].textContent.trim();
+  const eyebrow = props[count++].textContent.trim();
+  const title = props[count++].textContent.trim();
+  const longDescr = props[count++].innerHTML.trim();
+  const firstCTAText = props[count++].textContent.trim();
+  const firstCTALink = props[count++].textContent.trim();
+  const secondCTAText = props[count++].textContent.trim();
   const secondCTALink = props[11].textContent.trim();
+
+  // get signed in status 
+  const isSignedIn = window.adobeIMS?.isSignedInUser();
 
   // Build DOM
   const marqueeDOM = document.createRange().createContextualFragment(`
@@ -27,11 +30,11 @@ export default function decorate(block) {
         <div class='marquee-long-description'>${longDescr}</div>
         <div class='marquee-cta'>${
           firstCTAText && firstCTALink
-            ? `<a class='button ${firstCTAType}' href='${firstCTALink}'>${firstCTAText}</a>`
+            ? `<a class='button secondary' href='${firstCTALink}'>${firstCTAText}</a>`
             : ``
         }${
-          secondCTAText && secondCTALink
-            ? `<a class='button ${secondCTAType}' href='${secondCTALink}'>${secondCTAText}</a>`
+          secondCTAText && secondCTALink && !isSignedIn
+            ? `<a class='button primary' href='${secondCTALink}'>${secondCTAText}</a>`
             : ``
         }</div>
       </div>

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -16,7 +16,7 @@ export default function decorate(block) {
   const firstCTAText = props[count++].textContent.trim();
   const firstCTALink = props[count++].textContent.trim();
   const secondCTAText = props[count++].textContent.trim();
-  const secondCTALink = props[11].textContent.trim();
+  const secondCTALink = props[count++].textContent.trim();
 
   // get signed in status 
   const isSignedIn = window.adobeIMS?.isSignedInUser();

--- a/component-models.json
+++ b/component-models.json
@@ -683,24 +683,6 @@
         "description": "The description shown in Desktop and Tablet view."
       },
       {
-        "component": "select",
-        "name": "cta1Type",
-        "value": "primary",
-        "label": "First CTA Type",
-        "description": "'Primary' will render button filled, 'Secondary' with an outline.",
-        "valueType": "string",
-        "options": [
-          {
-            "name": "Primary",
-            "value": "primary"
-          },
-          {
-            "name": "Secondary",
-            "value": "secondary"
-          }
-        ]
-      },
-      {
         "component": "text-input",
         "valueType": "string",
         "name": "cta1Text",
@@ -717,29 +699,11 @@
         "description": "What link to open when clicking the button."
       },
       {
-        "component": "select",
-        "name": "cta2Type",
-        "value": "primary",
-        "label": "Second CTA Type",
-        "description": "'Primary' will render button filled, 'Secondary' with an outline.",
-        "valueType": "string",
-        "options": [
-          {
-            "name": "Primary",
-            "value": ""
-          },
-          {
-            "name": "Secondary",
-            "value": "secondary"
-          }
-        ]
-      },
-      {
         "component": "text-input",
         "valueType": "string",
         "name": "cta2Text",
         "value": "",
-        "label": "Second CTA Text",
+        "label": "Sign up CTA Text",
         "description": "Text to be shown inside button."
       },
       {
@@ -747,7 +711,7 @@
         "valueType": "string",
         "name": "cta2Url",
         "value": "",
-        "label": "Second CTA Link",
+        "label": "Sign up CTA Link",
         "description": "What link to open when clicking the button."
       }
     ]


### PR DESCRIPTION
- Remove First CTA Type from properties panel
- Hard-code First CTA as 'secondary' style
- Remove Second CTA Type from properties panel
- Hard-code Second CTA as 'primary' style
- Change the field label 'Second CTA Text' to 'Sign up CTA text'
- Caption: 'Button text to prompt unauthenticated visitors to sign in' 
- Change the field label 'Second CTA Link' to 'Sign up CTA link'
- Hide the second CTA (now 'Sign up CTA') from authenticated visitors, like the 'Sign up' button in the Header

Jira ID: https://jira.corp.adobe.com/browse/EXLM-896

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en
- After: https://exlm-896--exlm--adobe-experience-league.hlx.page/en
