### PR TITLE
Exlm 979: remove editing of sign in link, add sign in event handler instead

### DIFF
--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -37,7 +37,7 @@ export default async function decorate(block) {
           firstCTAText && firstCTALink ? `<a class='button secondary' href='${firstCTALink}'>${firstCTAText}</a>` : ``
         }${
           secondCTAText && !isSignedIn
-            ? `<a class='button primary' href='#'>${secondCTAText}</a>`
+            ? `<a class='button primary signin' href='#'>${secondCTAText}</a>`
             : ``
         }</div>
       </div>
@@ -56,6 +56,13 @@ export default async function decorate(block) {
       })" d="M752.813-1495s115.146 210.072 471.053 309.516 291.355 261.7 291.355 261.7h150.039V-1495Z" data-name="Path 1" transform="translate(-103.26 1495)"></path></svg>
     </div>
   `);
+
+  // add sign in event handler for second cta if set
+  if (secondCTAText && !isSignedIn ) {
+    marqueeDOM.querySelector('.signin').addEventListener('click', async () => {
+      window.adobeIMS.signIn();
+    });
+  }
 
   if (subjectPicture && subjectImageDescr) {
     marqueeDOM.querySelector('.marquee-subject picture img').setAttribute('alt', subjectImageDescr);

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -35,11 +35,7 @@ export default async function decorate(block) {
         <div class='marquee-long-description'>${longDescr}</div>
         <div class='marquee-cta'>${
           firstCTAText && firstCTALink ? `<a class='button secondary' href='${firstCTALink}'>${firstCTAText}</a>` : ``
-        }${
-          secondCTAText && !isSignedIn
-            ? `<a class='button primary signin' href='#'>${secondCTAText}</a>`
-            : ``
-        }</div>
+        }${secondCTAText && !isSignedIn ? `<a class='button primary signin' href='#'>${secondCTAText}</a>` : ``}</div>
       </div>
       ${
         subjectPicture
@@ -58,7 +54,7 @@ export default async function decorate(block) {
   `);
 
   // add sign in event handler for second cta if set
-  if (secondCTAText && !isSignedIn ) {
+  if (secondCTAText && !isSignedIn) {
     marqueeDOM.querySelector('.signin').addEventListener('click', async () => {
       window.adobeIMS.signIn();
     });

--- a/blocks/marquee/marquee.js
+++ b/blocks/marquee/marquee.js
@@ -16,7 +16,6 @@ export default async function decorate(block) {
   const firstCTAText = props[count++].textContent.trim();
   const firstCTALink = props[count++].textContent.trim();
   const secondCTAText = props[count++].textContent.trim();
-  const secondCTALink = props[count++].textContent.trim();
 
   // get signed in status
   try {
@@ -37,8 +36,8 @@ export default async function decorate(block) {
         <div class='marquee-cta'>${
           firstCTAText && firstCTALink ? `<a class='button secondary' href='${firstCTALink}'>${firstCTAText}</a>` : ``
         }${
-          secondCTAText && secondCTALink && !isSignedIn
-            ? `<a class='button primary' href='${secondCTALink}'>${secondCTAText}</a>`
+          secondCTAText && !isSignedIn
+            ? `<a class='button primary' href='#'>${secondCTAText}</a>`
             : ``
         }</div>
       </div>

--- a/component-models.json
+++ b/component-models.json
@@ -705,14 +705,6 @@
         "value": "",
         "label": "Sign up CTA Text",
         "description": "Text to be shown inside button."
-      },
-      {
-        "component": "text-input",
-        "valueType": "string",
-        "name": "cta2Url",
-        "value": "",
-        "label": "Sign up CTA Link",
-        "description": "What link to open when clicking the button."
       }
     ]
   },


### PR DESCRIPTION
Second CTA is always fixed sign in click event. Only Text of button is editable.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-979

Test URLs: 

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/exlm-896
- After: https://exlm-979--exlm--adobe-experience-league.hlx.page/en/exlm-896
