### PR TITLE
add /en/top-products.json to paths.yaml

### DIFF
--- a/paths.yaml
+++ b/paths.yaml
@@ -5,6 +5,7 @@ mappings:
   # spreadsheets
   - /content/exlm/redirects:/redirects.json
   - /content/exlm/placeholders:/placeholders.json
+  - /content/exlm/global/en/top-products:/en/top-products.json
   # force load some paths as resource from codebus in the editor (sw.js)
   - /content/exlm.resource/fragments/:/fragments/
   - /content/exlm.resource/docs/:/docs/


### PR DESCRIPTION
updates paths.yaml to return the /en/top-products.json product list maintained by the AEM author.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-898

Test URLs:

(cant be tested on a branch)
