### PR TITLE
Add Config Path to serve .helix/config 

### DIFF
--- a/paths.yaml
+++ b/paths.yaml
@@ -6,6 +6,7 @@ mappings:
   - /content/exlm/redirects:/redirects.json
   - /content/exlm/placeholders:/placeholders.json
   - /content/exlm/global/en/top-products:/en/top-products.json
+  - /content/dam/exlm/franklin/config.json:/.helix/config.json
   # force load some paths as resource from codebus in the editor (sw.js)
   - /content/exlm.resource/fragments/:/fragments/
   - /content/exlm.resource/docs/:/docs/


### PR DESCRIPTION

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://feature-enable-config--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
