### PR TITLE
fix: block reloading behavior

### DIFF
--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -21,7 +21,7 @@ function restoreState(newBlock, state) {
     newBlock.querySelector(`[data-tab-id="${state.activeTabId}"]`).click();
   }
   if (state.scrollLeft) {
-    newBlock.querySelector('.panel-container').scrollLeft = state.scrollLeft;
+    newBlock.querySelector('.panel-container').scrollTo({left: state.scrollLeft, behavior: "instant"});
   }
 }
 

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -17,52 +17,43 @@ function setSelectedTab(id, newBlock) {
 }
 
 function handleEditorUpdate(event) {
-  const {
-    detail: { itemids },
-  } = event;
-  Promise.all(
-    itemids
-      .map((itemId) => document.querySelector(`[itemid="${itemId}"]`))
-      .map(async (element) => {
-        const block = element.closest('.block');
-        const blockItemId = block?.getAttribute('itemid');
-        if (block && blockItemId?.startsWith(connectionPrefix)) {
-          const path = blockItemId.substring(connectionPrefix.length);
+  const { detail } = event;
 
-          // keep info about currently selected tab
-          const activeTabId = block.classList.contains('tabs') ? getSelectedTab(block) : null;
+  const resource = detail?.requestData?.target?.resource;
+  if (!resource) return;
 
-          const resp = await fetch(`${path}.html${window.location.search}`);
-          if (resp.ok) {
-            const text = await resp.text();
-            const newBlock = new DOMParser().parseFromString(text, 'text/html').body.firstElementChild;
-            // hide the new block, and insert it after the existing one
-            newBlock.style.display = 'none';
-            block.insertAdjacentElement('afterend', newBlock);
-            // decorate buttons and icons
-            decorateButtons(newBlock);
-            decorateIcons(newBlock);
-            // decorate and load the block
-            decorateBlock(newBlock);
-            await loadBlock(newBlock);
-            // remove the old block and show the new one
-            block.remove();
-            newBlock.style.display = null;
+  const element = document.querySelector(`[data-aue-resource="${resource}"]`);
+  const block = element?.closest('.block');
+  const blockResource = block?.getAttribute('data-aue-resource');
+  if (!block || !blockResource?.startsWith(connectionPrefix)) return;
 
-            if (activeTabId) setSelectedTab(activeTabId, newBlock);
+  // keep info about currently selected tab
+  const activeTabId = block.classList.contains('tabs') ? getSelectedTab(block) : null;
 
-            return Promise.resolve();
-          }
-        }
-        return Promise.reject();
-      }),
-  ).catch(() => {
-    // fallback to a full reload if any item could not be reloaded
-    window.location.reload();
-  });
+  const updates = detail?.responseData?.updates;
+  if (updates.length > 0) {
+    const { content } = updates[0];
+    const newBlockDocument = new DOMParser().parseFromString(content, 'text/html');
+    const newBlock = newBlockDocument?.querySelector(`[data-aue-resource="${blockResource}"]`);
+    if (newBlock) {
+      newBlock.style.display = 'none';
+      block.insertAdjacentElement('afterend', newBlock);
+      // decorate buttons and icons
+      decorateButtons(newBlock);
+      decorateIcons(newBlock);
+      // decorate and load the block
+      decorateBlock(newBlock);
+      loadBlock(newBlock);
+      // remove the old block and show the new one
+      block.remove();
+      newBlock.style.display = null;
+
+      if (activeTabId) setSelectedTab(activeTabId, newBlock);
+    }
+  }
 }
 
-document.addEventListener('editor-update', handleEditorUpdate);
+document.querySelector('main')?.addEventListener('aue:content-patch', handleEditorUpdate);
 
 // group editable texts in single wrappers if applicable
 //

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -21,7 +21,7 @@ function restoreState(newBlock, state) {
     newBlock.querySelector(`[data-tab-id="${state.activeTabId}"]`).click();
   }
   if (state.scrollLeft) {
-    newBlock.querySelector('.panel-container').scrollTo({left: state.scrollLeft, behavior: "instant"});
+    newBlock.querySelector('.panel-container').scrollTo({ left: state.scrollLeft, behavior: 'instant' });
   }
 }
 

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -25,7 +25,7 @@ function restoreState(newBlock, state) {
   }
 }
 
-function handleEditorUpdate(event) {
+async function handleEditorUpdate(event) {
   const { detail } = event;
 
   const resource = detail?.requestData?.target?.resource;
@@ -52,7 +52,7 @@ function handleEditorUpdate(event) {
       decorateIcons(newBlock);
       // decorate and load the block
       decorateBlock(newBlock);
-      loadBlock(newBlock);
+      await loadBlock(newBlock);
       // remove the old block and show the new one
       block.remove();
       newBlock.style.display = null;

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -13,6 +13,7 @@ function getState(block) {
     const container = block.querySelector('.panel-container');
     state.scrollLeft = container.scrollLeft;
   }
+  return state;
 }
 
 function restoreState(newBlock, state) {
@@ -31,7 +32,7 @@ function handleEditorUpdate(event) {
   if (!resource) return;
 
   const element = document.querySelector(`[data-aue-resource="${resource}"]`);
-  const block = element?.closest('.block');
+  const block = element?.parentElement?.closest('.block') || element?.closest('.block');
   const blockResource = block?.getAttribute('data-aue-resource');
   if (!block || !blockResource?.startsWith(connectionPrefix)) return;
 


### PR DESCRIPTION
With this change instant block reloads with eventually guaranteed affinity for read after write will be implemented.

I also added some logic to restore the ui state. this was already in place for tabs and is now for carousels. there may be other blocks that have some ui state like scroll offsets etc that we may have to look at individually. 

kudos to @duynguyen for getting this sorted out.