### PR TITLE
EXLM-1055: desktop copy link event listener not working. rearrange code.

### DIFF
--- a/blocks/doc-actions/doc-actions.js
+++ b/blocks/doc-actions/doc-actions.js
@@ -107,18 +107,17 @@ function decorateCopyLink(block) {
   );
 
   block.appendChild(copyLinkDivNode);
-
-  const docActionsMobile = document.querySelector('.doc-actions-mobile');
-  if (docActionsMobile) {
-    docActionsMobile.appendChild(copyLinkDivNode.cloneNode(true));
-    // below 2 lines are unique to this method so cannot use addToDocActions()
-    const docActionsMobileIconCopy = docActionsMobile.querySelector('.copy-icon');
-    attachCopyLink(docActionsMobileIconCopy, window.location.href, placeholders.toastSet);
-  }
-
   const docActionsDesktopIconCopy = document.querySelector('.doc-actions .copy-icon');
+  const docActionsMobile = document.querySelector('.doc-actions-mobile');
+
   if (docActionsDesktopIconCopy) {
     attachCopyLink(docActionsDesktopIconCopy, window.location.href, placeholders.toastSet);
+  }
+
+  if (docActionsMobile) {
+    docActionsMobile.appendChild(copyLinkDivNode.cloneNode(true));
+    const docActionsMobileIconCopy = docActionsMobile.querySelector('.copy-icon');
+    attachCopyLink(docActionsMobileIconCopy, window.location.href, placeholders.toastSet);
   }
 }
 


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: EXLM-1055

Test URLs: 

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://bugfix-exlm-484-copylink--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
