### PR TITLE
EXLM 1042 ADLS Card

### DIFF
--- a/blocks/adls-cards/adls-cards.js
+++ b/blocks/adls-cards/adls-cards.js
@@ -4,6 +4,7 @@ import { htmlToElement } from '../../scripts/scripts.js';
 import { buildCard } from '../../scripts/browse-card/browse-card.js';
 import { createTooltip, hideTooltipOnScroll } from '../../scripts/browse-card/browse-card-tooltip.js';
 import BuildPlaceholder from '../../scripts/browse-card/browse-card-placeholder.js';
+import { CONTENT_TYPES } from '../../scripts/browse-card/browse-cards-constants.js';
 
 /**
  * Decorate function to process and log the mapped data.
@@ -14,7 +15,8 @@ export default async function decorate(block) {
   const [headingElement, toolTipElement, linkTextElement, ...configs] = [...block.children].map(
     (row) => row.firstElementChild,
   );
-  const [solutions, roles, sortBy, contentType] = configs.map((cell) => cell.textContent.trim());
+  const [solutions, roles, sortBy] = configs.map((cell) => cell.textContent.trim());
+  const contentType = CONTENT_TYPES.INSTRUCTOR_LED_TRANING.MAPPING_KEY;
   const noOfResults = 4;
 
   headingElement.firstElementChild?.classList.add('h2');


### PR DESCRIPTION
Added the missing content Type from ADLS post-Dirk's changes  and removed the default content type

Jira ID:https://jira.corp.adobe.com/browse/EXLM-1042

Test URLs:

Before: https://main--exlm--adobe-experience-league.hlx.page/en/adls-test-1042
After: https://feature-exlm-1042-adls--exlm--adobe-experience-league.hlx.live/en/adls-test-1042

<img width="908" alt="image" src="https://github.com/adobe-experience-league/exlm/assets/30936827/63084b9e-326f-4cc4-af8b-89501fa5c76f">

