### PR TITLE
feature/EXLM-1042-adls

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -469,7 +469,8 @@
                 "template": {
                   "name": "ADLS Cards",
                   "model": "adls-cards",
-                  "headingType": "h2"
+                  "headingType": "h2",
+                  "sortby": "recommended"
                 }
               }
             }


### PR DESCRIPTION
Updated the default sort by the option to recommended in the component definition for adls block 

Jira ID:https://jira.corp.adobe.com/browse/EXLM-1042

Test URLs:

Before: https://main--exlm--adobe-experience-league.hlx.page/en/adls-test-1042
After: https://feature-exlm-1042-adls--exlm--adobe-experience-league.hlx.live/en/adls-test-1042

<img width="908" alt="image" src="https://github.com/adobe-experience-league/exlm/assets/30936827/3c30cf45-36bb-4799-9fc1-e377e1c58fb9">

<img width="386" alt="image" src="https://github.com/adobe-experience-league/exlm/assets/30936827/68e5b657-7ef9-4ce9-87ed-ba1a92947335">

