### PR TITLE
fix: adjust browse filters dropdown width to handle text overlap

### DIFF
--- a/blocks/browse-filters/browse-filters.css
+++ b/blocks/browse-filters/browse-filters.css
@@ -57,6 +57,10 @@
   margin: 0;
 }
 
+.filter-input>button {
+  padding-right: 24px;
+}
+
 .filter-input > input::placeholder {
   font-size: var(--spectrum-body-size-m);
 }


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: https://jira.corp.adobe.com/browse/EXLM-17

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live/en/browse
- After: https://exp-level-dropdown-width--exlm--adobe-experience-league.hlx.live/en/browse
