### PR TITLE
Sitemaps - Add en as href lang

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -6,6 +6,7 @@ sitemaps:
       en:
         source: /en/query-index.json
         destination: /en/sitemap.xml
+        alternate: /en/{path}
         hreflang: en
       fr:
         source: /fr/query-index.json


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://bugfix-sitema-include-en-lang--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
