### PR TITLE
Add content-patch event handling for default content

### DIFF
--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -67,9 +67,8 @@ async function handleEditorUpdate(event) {
 
       restoreState(newBlock, uiState);
     }
-  }
-  // if its default content
-  if (element && !block) {
+    // if its default content
+  } else if (element) {
     // parent container is section
     const updatedSection = new DOMParser().parseFromString(content, 'text/html');
     // get updated element


### PR DESCRIPTION
Currently changing properties for default content (title, text, image, button) require manual reload due to the new UE eventing.
This PR adds the necessary code to trigger the page update for changes made to this elements.


Test URLs:

- Before: 
https://author-p122525-e1200861.adobeaemcloud.com/ui#/@amc/aem/universal-editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/uat/mirko-test.html
- After: 
https://author-p122525-e1200861.adobeaemcloud.com/ui#/@amc/aem/universal-editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/uat/mirko-test.html?ref=default-content-event