### PR TITLE
Use default event handler for richtext

### DIFF
--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -69,6 +69,8 @@ async function handleEditorUpdate(event) {
     }
     // if its default content
   } else if (element) {
+    // temporary workaroun 
+    if (element.dataset.aueType === "richtext") return;
     // parent container is section
     const updatedSection = new DOMParser().parseFromString(content, 'text/html');
     // get updated element


### PR DESCRIPTION
Until the new release

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://<BRANCH NAME>--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
