### PR TITLE
Move configuration to page instead of dam

### DIFF
--- a/paths.json
+++ b/paths.json
@@ -6,7 +6,7 @@
     "/content/exlm/redirects:/redirects.json",
     "/content/exlm/languages:/languages.json",
     "/content/exlm/global/en/top-products:/en/top-products.json",
-    "/content/dam/exlm/franklin/config.json:/.helix/config.json",
+    "/content/exlm/configuration.json:/.helix/config.json",
     "/content/exlm.resource/fragments/:/fragments/",
     "/content/exlm.resource/docs/:/docs/",
     "/content/exlm/global/en/placeholders:/en/placeholders.json",

--- a/paths.yaml
+++ b/paths.yaml
@@ -6,7 +6,7 @@ mappings:
   - /content/exlm/redirects:/redirects.json
   - /content/exlm/languages:/languages.json
   - /content/exlm/global/en/top-products:/en/top-products.json
-  - /content/dam/exlm/franklin/config.json:/.helix/config.json
+  - /content/exlm/configuration.json:/.helix/config.json
   # force load some paths as resource from codebus in the editor (sw.js)
   - /content/exlm.resource/fragments/:/fragments/
   - /content/exlm.resource/docs/:/docs/


### PR DESCRIPTION
Move helix config to page instead of dam file.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://feature-move-config-to-page--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
