### PR TITLE
Custom Anchors

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -247,6 +247,23 @@ function decorateContentSections(main) {
 }
 
 /**
+ * see: https://github.com/adobe-experience-league/exlm-converter/pull/187
+ * @param {HTMLElement} main
+ */
+export function decorateAnchors(main) {
+  const anchorPrefix = 'icon-anchor-';
+  const anchorIcons = [...main.querySelectorAll(`span.icon[class*="${anchorPrefix}"]`)];
+  anchorIcons.forEach((icon) => {
+    const slugClass = icon.className.split(' ').find((c) => c.startsWith(anchorPrefix));
+    const slug = slugClass.substring(anchorPrefix.length);
+    if (slug) {
+      icon.parentElement.id = slug;
+      icon.remove();
+    }
+  });
+}
+
+/**
  * Decorates the main element.
  * @param {Element} main The main element
  */
@@ -256,6 +273,7 @@ export function decorateMain(main) {
   if (!isDocPage()) {
     decorateButtons(main);
   }
+  decorateAnchors(main); // must be run before decorateIcons
   decorateIcons(main);
   decorateExternalLinks(main);
   buildAutoBlocks(main);


### PR DESCRIPTION
see: https://github.com/adobe-experience-league/exlm-converter/pull/187

Custom anchors will be present in headings at the end, as icons, and will have the special prefix `icon-anchor-` in the icon class name. We then use that class name (sans prefix) as the custom anchor for the heading.

Jira ID: EXLM-1117

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://feature-custom-anchors--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
