### PR TITLE
fixed eyebrow subtitle color for dark theme

### DIFF
--- a/blocks/detailed-teaser/detailed-teaser.css
+++ b/blocks/detailed-teaser/detailed-teaser.css
@@ -94,6 +94,10 @@
   margin: 0;
 }
 
+.detailed-teaser.block.dark > .foreground > .text > .eyebrow > .subtitle  {
+  color: #ccc;
+}
+
 /* the main title */
 /* stylelint-disable-next-line no-descending-specificity */
 .detailed-teaser.block > .foreground > .text > .title {


### PR DESCRIPTION
- Eyebrow sub-title, dark theme
- Color is #8C8C8C
- Appears too dark on some backgrounds, changing to #ccc

Jira ID: https://jira.corp.adobe.com/browse/EXLM-1127

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live/en/uat/exlm-1127-test-page
- After: https://detailed-teaser-color-fix--exlm--adobe-experience-league.hlx.live/en/uat/exlm-1127-test-page
