### PR TITLE
EXLM-1132:  fedsConfig.privacy must be defined before privacy-standaone.js executes

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -438,6 +438,7 @@ const loadMartech = async (headerPromise, footerPromise) => {
   } else {
     launchScriptSrc = 'https://assets.adobedtm.com/a7d65461e54e/6e9802a06173/launch-e6bd665acc0a-development.min.js';
   }
+  oneTrust();
 
   const oneTrustPromise = loadScript(`${window.hlx.codeBasePath}/scripts/analytics/privacy-standalone.js`, {
     async: true,
@@ -453,7 +454,6 @@ const loadMartech = async (headerPromise, footerPromise) => {
     ([launch, libAnalyticsModule, headPr, footPr]) => {
       const { lang } = getPathDetails();
       const { pageLoadModel, linkClickModel, pageName } = libAnalyticsModule;
-      oneTrust();
       document.querySelector('[href="#onetrust"]').addEventListener('click', (e) => {
         e.preventDefault();
         window.adobePrivacy.showConsentPopup();


### PR DESCRIPTION
fedsConfig.privacy must be defined before privacy-standaone.js executes

Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: EXLM-1132

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live/
- After: https://bugfix-exlm-1132--exlm--adobe-experience-league.hlx.live/