### PR TITLE
fix top padding for browse rail > 1440px

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1412,8 +1412,8 @@ body[class^=browse-] .browse-filters-full-container .browse-filters-pagination, 
   body.browse-product main {
     max-width: 1440px;
   }
-  body.browse-all main > div.section,
-  body.browse-product main > div.section {
+  body.browse-all main > div.section:not(.browse-rail),
+  body.browse-product main > div.section:not(.browse-rail) {
     padding: 30px 32px;
   }
   body.browse-all main > div.section.browse-breadcrumb-container,

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -1424,7 +1424,7 @@ body[class^='browse-'] .browse-filters-full-container {
       max-width: 1440px;
     }
 
-    & main > div.section {
+    & main > div.section:not(.browse-rail) {
       padding: 30px 32px;
     }
 


### PR DESCRIPTION
There is an unwanted top padding added for the browse rail above 1440px

Before:
![image](https://github.com/adobe-experience-league/exlm/assets/37147400/47fe527f-03ef-45a0-ba59-72b198152a96)


After:
![image](https://github.com/adobe-experience-league/exlm/assets/37147400/1a0443c8-72be-485c-a204-457b8d6cb760)

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live/en/browse/experience-manager
- After: https://browse-rail-padding--exlm--adobe-experience-league.hlx.live/en/browse/experience-manager
