### PR TITLE
fix: decoreate richtext after blocks

### DIFF
--- a/scripts/editor-support-rte.js
+++ b/scripts/editor-support-rte.js
@@ -14,12 +14,7 @@ export function decorateRichtext(container = document) {
   let element;
   // eslint-disable-next-line no-cond-assign
   while ((element = container.querySelector('[data-richtext-resource]:not(div)'))) {
-    const { 
-      richtextResource,
-      richtextProp,
-      richtextFilter,
-      richtextLabel,
-    } = element.dataset;
+    const { richtextResource, richtextProp, richtextFilter, richtextLabel } = element.dataset;
     deleteInstrumentation(element);
     const siblings = [];
     let sibling = element;

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -81,6 +81,7 @@ async function applyChanges(event) {
         decorateButtons(newBlock);
         decorateIcons(newBlock);
         decorateBlock(newBlock);
+        decorateRichtext(newBlock);
         await loadBlock(newBlock);
         block.remove();
         newBlock.style.display = null;
@@ -100,9 +101,9 @@ async function applyChanges(event) {
           element.insertAdjacentElement('afterend', newSection);
           decorateButtons(newSection);
           decorateIcons(newSection);
-          decorateRichtext(newSection);
           decorateSections(parentElement);
           decorateBlocks(parentElement);
+          decorateRichtext(newSection);
           await loadBlocks(parentElement);
           element.remove();
           newSection.style.display = null;


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://<BRANCH NAME>--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
