### PR TITLE
UGP-10031: Back to Browsing button

### DIFF
--- a/blocks/back-to-browsing/back-to-browsing.css
+++ b/blocks/back-to-browsing/back-to-browsing.css
@@ -1,0 +1,7 @@
+.back-to-browse { 
+  display: none;
+}
+
+.back-to-browse.show {
+  display: block;
+}

--- a/blocks/back-to-browsing/back-to-browsing.css
+++ b/blocks/back-to-browsing/back-to-browsing.css
@@ -1,7 +1,14 @@
-.back-to-browse { 
+.back-to-browsing { 
   display: none;
+  a { 
+    font-size: 14px;
+    font-style: italic;
+    color: var(--spectrum-gray-800);
+    text-decoration: none;
+  }
 }
 
-.back-to-browse.show {
+.back-to-browsing.show {
   display: block;
+  padding-bottom: 15px;
 }

--- a/blocks/back-to-browsing/back-to-browsing.js
+++ b/blocks/back-to-browsing/back-to-browsing.js
@@ -1,9 +1,9 @@
-import { fetchLanguagePlaceholders } from "../../scripts/scripts";
+import { fetchLanguagePlaceholders } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
   if (document.referrer.search('/browse') >= 0) {
-    const anchorTag =  block.querySelector('a');
-    let text = 'Back to browsing';
+    const anchorTag = block.querySelector('a');
+    const text = 'Back to browsing';
 
     try {
       const placeholders = await fetchLanguagePlaceholders();
@@ -14,9 +14,10 @@ export default async function decorate(block) {
 
     anchorTag.addEventListener('click', (e) => {
       e.preventDefault();
+      // eslint-disable-next-line no-restricted-globals
       history.back();
     });
 
-    anchorTag.classList.add('show');
+    block.classList.add('show');
   }
 }

--- a/blocks/back-to-browsing/back-to-browsing.js
+++ b/blocks/back-to-browsing/back-to-browsing.js
@@ -1,0 +1,22 @@
+import { fetchLanguagePlaceholders } from "../../scripts/scripts";
+
+export default async function decorate(block) {
+  if (document.referrer.search('/browse') >= 0) {
+    const anchorTag =  block.querySelector('a');
+    let text = 'Back to browsing';
+
+    try {
+      const placeholders = await fetchLanguagePlaceholders();
+      anchorTag.textContent = placeholders['back-to-browsing'] || text;
+    } catch {
+      /* empty */
+    }
+
+    anchorTag.addEventListener('click', (e) => {
+      e.preventDefault();
+      history.back();
+    });
+
+    anchorTag.classList.add('show');
+  }
+}

--- a/scripts/editor-support-rte.js
+++ b/scripts/editor-support-rte.js
@@ -14,12 +14,7 @@ export function decorateRichtext(container = document) {
   let element;
   // eslint-disable-next-line no-cond-assign
   while ((element = container.querySelector('[data-richtext-resource]:not(div)'))) {
-    const { 
-      richtextResource,
-      richtextProp,
-      richtextFilter,
-      richtextLabel,
-    } = element.dataset;
+    const { richtextResource, richtextProp, richtextFilter, richtextLabel } = element.dataset;
     deleteInstrumentation(element);
     const siblings = [];
     let sibling = element;


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Navigating to a document page that has been rebuilt with the latest converter changes should show a "Back to browsing" link at the top of the page. The link should be hidden any other time.

I've been using: https://main--exlm--adobe-experience-league.hlx.live/en/docs/analytics/analyze/admin-overview/analytics-overview as the test page by changing the CTA anchor in the banner on the browse page to this and navigating to the docs page that way.

Jira ID: https://jira.corp.adobe.com/browse/UGP-10031

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/analytics/analyze/admin-overview/analytics-overview as the test page
- After: https://UGP-10031--exlm--adobe-experience-league.hlx.page/en/docs/analytics/analyze/admin-overview/analytics-overview as the test page
