### PR TITLE
Qualtrics clears retry interval on error

### DIFF
--- a/scripts/feedback/feedback.js
+++ b/scripts/feedback/feedback.js
@@ -446,6 +446,7 @@ function checkInterceptLoaded() {
       checkInterval = setInterval(checkInterceptLoaded, RETRY_DELAY);
     }
   } else {
+    clearInterval(checkInterval);
     feedbackError();
   }
 }


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

eds-dev has an outdated qualtrics.json that is causing errors. This resolves the issue where the error would continually print to console every 500 ms.

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://feedback-fix--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
