### PR TITLE
fix: defer ffetch, lib-analyitics and profile-service

### DIFF
--- a/scripts/analytics/lib-analytics.js
+++ b/scripts/analytics/lib-analytics.js
@@ -1,6 +1,3 @@
-// eslint-disable-next-line import/no-cycle
-import { profile } from '../data-service/profile-service.js';
-
 export const microsite = /^\/(developer|events|landing|overview|tools|welcome)/.test(window.location.pathname);
 export const search = window.location.pathname === '/search.html';
 export const docs = window.location.pathname.indexOf('/docs') !== -1;
@@ -50,6 +47,8 @@ export async function pageLoadModel(language) {
   user.userDetails.orgs = [];
 
   try {
+    // eslint-disable-next-line import/no-cycle
+    const { profile } = await import('../data-service/profile-service.js');
     const userData = await profile();
     if (userData) {
       user.userDetails.userAccountType = userData.account_type;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -19,11 +19,6 @@ import {
 } from './lib-franklin.js';
 // eslint-disable-next-line import/no-cycle
 
-const ffetchModulePromise = import('./ffetch.js');
-
-// eslint-disable-next-line import/no-cycle
-const libAnalyticsModulePromise = import('./analytics/lib-analytics.js');
-
 const LCP_BLOCKS = ['marquee']; // add your LCP blocks to the list
 
 export const timers = new Map();
@@ -451,8 +446,11 @@ const loadMartech = async (headerPromise, footerPromise) => {
   const launchPromise = loadScript(launchScriptSrc, {
     async: true,
   });
+  
+  // eslint-disable-next-line import/no-cycle
+  const libAnalyticsPromise = import('./analytics/lib-analytics.js');
 
-  Promise.all([launchPromise, libAnalyticsModulePromise, headerPromise, footerPromise, oneTrustPromise]).then(
+  Promise.all([launchPromise, libAnalyticsPromise, headerPromise, footerPromise, oneTrustPromise]).then(
     // eslint-disable-next-line no-unused-vars
     ([launch, libAnalyticsModule, headPr, footPr]) => {
       const { lang } = getPathDetails();
@@ -654,7 +652,7 @@ export async function fetchLanguagePlaceholders() {
 
 export async function getLanguageCode() {
   const { lang } = getPathDetails();
-  const ffetch = (await ffetchModulePromise).default;
+  const { default: ffetch } = await import('./ffetch.js');
   const langMap = await ffetch(`/languages.json`).all();
   const langObj = langMap.find((item) => item.key === lang);
   const langCode = langObj ? langObj.value : lang;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -446,7 +446,7 @@ const loadMartech = async (headerPromise, footerPromise) => {
   const launchPromise = loadScript(launchScriptSrc, {
     async: true,
   });
-  
+
   // eslint-disable-next-line import/no-cycle
   const libAnalyticsPromise = import('./analytics/lib-analytics.js');
 


### PR DESCRIPTION
This saves bytes on the critical path to LCP, but still loads these things as early as needed. 

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live/?martech=off
- After: https://defer-scripts--exlm--adobe-experience-league.hlx.live/?martech=off

Loading Seq. before

<img width="1524" alt="Screenshot 2024-03-08 at 16 59 11" src="https://github.com/adobe-experience-league/exlm/assets/558094/af01da1d-9aa8-4be9-b377-b367d92566e6">

Loading Seq. after

<img width="1524" alt="Screenshot 2024-03-08 at 16 59 55" src="https://github.com/adobe-experience-league/exlm/assets/558094/7dc92f35-f2e0-471e-b9f6-c6c14ecd0cea">

Details for detailed PSI reports see: https://thinktanked.org/tools/deep-psi/deep-psi.html?url1=https%3A%2F%2Fmain--exlm--adobe-experience-league.hlx.live%2F%3Fmartech%3Doff&url2=https%3A%2F%2Fdefer-scripts--exlm--adobe-experience-league.hlx.live%2F%3Fmartech%3Doff

main (fcp, si, lcp, tti, tbt, cls)
<img width="1286" alt="Screenshot 2024-03-08 at 17 09 44" src="https://github.com/adobe-experience-league/exlm/assets/558094/ce33e109-7154-47f9-8b14-e3c81e2093c5">

defer-scripts (fcp, si, lcp, tti, tbt, cls)
<img width="943" alt="Screenshot 2024-03-08 at 17 10 27" src="https://github.com/adobe-experience-league/exlm/assets/558094/333e45d1-2afd-4a71-bcee-8fe402a78cd2">

the main difference I am looking at is in LCP avg: *(1391 ± 400.352)*  vs *(1220 ± 232.057)*
