### PR TITLE
Fix: Avoid dublication of autogenerated content after UE edit

### DIFF
--- a/blocks/browse-breadcrumb/browse-breadcrumb.js
+++ b/blocks/browse-breadcrumb/browse-breadcrumb.js
@@ -2,6 +2,9 @@ import ffetch from '../../scripts/ffetch.js';
 import { getEDSLink, getLink, getPathDetails, fetchLanguagePlaceholders } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
+  // to avoid dublication when editing
+  block.textContent = '';
+  
   // fallback text
   let browseText = 'Browse';
 

--- a/blocks/browse-breadcrumb/browse-breadcrumb.js
+++ b/blocks/browse-breadcrumb/browse-breadcrumb.js
@@ -4,7 +4,7 @@ import { getEDSLink, getLink, getPathDetails, fetchLanguagePlaceholders } from '
 export default async function decorate(block) {
   // to avoid dublication when editing
   block.textContent = '';
-  
+
   // fallback text
   let browseText = 'Browse';
 

--- a/blocks/browse-rail/browse-rail.js
+++ b/blocks/browse-rail/browse-rail.js
@@ -153,6 +153,9 @@ async function displayAllProducts(block, placeholders) {
 
 // Main function to decorate the block
 export default async function decorate(block) {
+  // to avoid dublication when editing
+  block.textContent = '';
+
   const theme = getMetadata('theme');
   const label = getMetadata('og:title');
   const placeholders = await fetchLanguagePlaceholders();


### PR DESCRIPTION
- After doing an edit with UE that affects a section (add , remove section, add remove blocks to a section), it will cause a reloading of the blocks.
- There 2 blocks , browse-breadcrumb and browse-rail that are auto blocks and dynamically generate content. 
- Currently this causes a new instance of the generated content added after each edit.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live/en/browse
- After: https://fix-autoblock-ue-edit--exlm--adobe-experience-league.hlx.live/en/browse

Author URLS:
- Before:
https://author-p122525-e1200861.adobeaemcloud.com/ui#/@amc/aem/universal-editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/browse.html
- After:
https://author-p122525-e1200861.adobeaemcloud.com/ui#/@amc/aem/universal-editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/browse.html?ref=fix-autoblock-ue-edit
