### PR TITLE
EXLM-1217: Browse: Authorable headings for left navigation 

### DIFF
--- a/blocks/browse-rail/browse-rail.js
+++ b/blocks/browse-rail/browse-rail.js
@@ -151,8 +151,7 @@ async function displayAllProducts(block, placeholders) {
   }
 }
 
-async function  displayProductNav(block, currentPagePath, results, placeholders) {
-
+async function displayProductNav(block, currentPagePath, results, placeholders) {
   // Find the parent page for product sub-pages
   const parentPage = results.find((page) => page.path === getPathUntilLevel(currentPagePath, 3));
   let parentPageTitle = '';
@@ -197,24 +196,24 @@ async function  displayProductNav(block, currentPagePath, results, placeholders)
   }
 }
 
-function displayManualNav(manualNav,block){
+function displayManualNav(manualNav, block) {
   // get root ul
-  const rootUL  = manualNav.querySelector('ul');
+  const rootUL = manualNav.querySelector('ul');
   rootUL.classList.add('subPages');
 
   // every li entry that is not a link gets a span
   [...rootUL.querySelectorAll('li')]
-    .filter((li) => li.firstChild.nodeName === "#text")
-    .forEach((li)  => {
+    .filter((li) => li.firstChild.nodeName === '#text')
+    .forEach((li) => {
       const span = document.createElement('span');
       span.appendChild(li.firstChild);
-      li.insertBefore(span,li.firstChild);
+      li.insertBefore(span, li.firstChild);
     });
 
   // set class for li with sub pages, add collapse icon
   [...rootUL.querySelectorAll('li')]
     .filter((li) => li.querySelector('ul'))
-    .forEach((li) => { 
+    .forEach((li) => {
       li.classList.add('hasSubPages');
       const toggleIcon = document.createElement('span');
       toggleIcon.classList.add('js-toggle');
@@ -251,7 +250,7 @@ export default async function decorate(block) {
     block.append(browseByUL);
     // Show All Products
     if (manualNav) {
-      displayManualNav(manualNav,block);
+      displayManualNav(manualNav, block);
     } else {
       await displayAllProducts(block, placeholders);
     }
@@ -276,13 +275,13 @@ export default async function decorate(block) {
 
     // For Products and sub-pages
     if (manualNav) {
-        displayManualNav(manualNav,block);
+      displayManualNav(manualNav, block);
     } else {
       // dynamically create sub page nav or if empty show products list
-      await displayProductNav(block,currentPagePath, results, placeholders);
+      await displayProductNav(block, currentPagePath, results, placeholders);
     }
   }
-    
+
   // Toggle functionality for products/sub-pages
   const toggleElements = block.querySelectorAll('.js-toggle');
   if (toggleElements) {

--- a/blocks/browse-rail/browse-rail.js
+++ b/blocks/browse-rail/browse-rail.js
@@ -151,16 +151,7 @@ async function displayAllProducts(block, placeholders) {
   }
 }
 
-// Main function to decorate the block
-export default async function decorate(block) {
-  // to avoid dublication when editing
-  block.textContent = '';
-
-  const theme = getMetadata('theme');
-  const label = getMetadata('og:title');
-  const placeholders = await fetchLanguagePlaceholders();
-  const results = await ffetch(`/${getPathDetails().lang}/browse-index.json`).all();
-  const currentPagePath = getEDSLink(window.location.pathname);
+async function  displayProductNav(block, currentPagePath, results, placeholders) {
 
   // Find the parent page for product sub-pages
   const parentPage = results.find((page) => page.path === getPathUntilLevel(currentPagePath, 3));
@@ -169,6 +160,85 @@ export default async function decorate(block) {
   if (parentPage) {
     parentPageTitle = parentPage.title;
   }
+
+  const parts = currentPagePath.split('/');
+  // Product sub page
+  if (parts.length >= 5 && parts[3] === currentPagePath.split('/')[3]) {
+    const pagePath = getPathUntilLevel(currentPagePath, 3);
+    const subPages = filterSubPages(results, pagePath);
+    const resultMultiMap = convertToMultiMap(subPages, currentPagePath.split('/')[3]);
+    const htmlList = convertToULList(resultMultiMap);
+    block.appendChild(htmlList);
+    sortFirstLevelList('.subPages');
+    const subPagesBrowseByLinkText = `${placeholders.all} ${parentPageTitle} ${placeholders.content}`;
+    block.querySelector(
+      '.browse-by > li',
+    ).innerHTML = `<span>${placeholders.browseBy}</span><ul><li><a href="${pagePath}">${subPagesBrowseByLinkText}</a></li></ul>`;
+
+    // Hightlight the current page title in the left rail
+    const targetElement = block.querySelector(`[href="${currentPagePath}"]`);
+    if (targetElement) {
+      targetElement.classList.add('is-active');
+    }
+  } else {
+    // Product page
+    const result = hasDirectLeafNodes(results, currentPagePath);
+    if (result) {
+      const subPages = filterSubPages(results, currentPagePath);
+      const resultMultiMap = convertToMultiMap(subPages, currentPagePath.split('/')[3]);
+      const htmlList = convertToULList(resultMultiMap);
+
+      block.appendChild(htmlList);
+      sortFirstLevelList('.subPages');
+    } else {
+      // In case of no sub-pages, show all products
+      await displayAllProducts(block, placeholders);
+    }
+  }
+}
+
+function displayManualNav(manualNav,block){
+  // get root ul
+  const rootUL  = manualNav.querySelector('ul');
+  rootUL.classList.add('subPages');
+
+  // every li entry that is not a link gets a span
+  [...rootUL.querySelectorAll('li')]
+    .filter((li) => li.firstChild.nodeName === "#text")
+    .forEach((li)  => {
+      const span = document.createElement('span');
+      span.appendChild(li.firstChild);
+      li.insertBefore(span,li.firstChild);
+    });
+
+  // set class for li with sub pages, add collapse icon
+  [...rootUL.querySelectorAll('li')]
+    .filter((li) => li.querySelector('ul'))
+    .forEach((li) => { 
+      li.classList.add('hasSubPages');
+      const toggleIcon = document.createElement('span');
+      toggleIcon.classList.add('js-toggle');
+      li.querySelector('ul').before(toggleIcon);
+    });
+
+  // add manual nav to rail
+  block.append(rootUL);
+}
+
+// Main function to decorate the block
+export default async function decorate(block) {
+  // get any defined manual navigation
+  const [manualNav] = block.querySelectorAll(':scope div > div');
+
+  // to avoid dublication when editing
+  block.textContent = '';
+
+  const theme = getMetadata('theme');
+
+  const label = getMetadata('og:title');
+  const placeholders = await fetchLanguagePlaceholders();
+  const results = await ffetch(`/${getPathDetails().lang}/browse-index.json`).all();
+  const currentPagePath = getEDSLink(window.location.pathname);
 
   // For Browse All Page
   if (theme === 'browse-all') {
@@ -180,7 +250,11 @@ export default async function decorate(block) {
     browseByUL.append(browseByLI);
     block.append(browseByUL);
     // Show All Products
-    await displayAllProducts(block, placeholders);
+    if (manualNav) {
+      displayManualNav(manualNav,block);
+    } else {
+      await displayAllProducts(block, placeholders);
+    }
   }
 
   // For Browse Product Pages
@@ -201,42 +275,14 @@ export default async function decorate(block) {
     block.append(browseByUL);
 
     // For Products and sub-pages
-    const parts = currentPagePath.split('/');
-    // Product sub page
-    if (parts.length >= 5 && parts[3] === currentPagePath.split('/')[3]) {
-      const pagePath = getPathUntilLevel(currentPagePath, 3);
-      const subPages = filterSubPages(results, pagePath);
-      const resultMultiMap = convertToMultiMap(subPages, currentPagePath.split('/')[3]);
-      const htmlList = convertToULList(resultMultiMap);
-      block.appendChild(htmlList);
-      sortFirstLevelList('.subPages');
-      const subPagesBrowseByLinkText = `${placeholders.all} ${parentPageTitle} ${placeholders.content}`;
-      block.querySelector(
-        '.browse-by > li',
-      ).innerHTML = `<span>${placeholders.browseBy}</span><ul><li><a href="${pagePath}">${subPagesBrowseByLinkText}</a></li></ul>`;
-
-      // Hightlight the current page title in the left rail
-      const targetElement = block.querySelector(`[href="${currentPagePath}"]`);
-      if (targetElement) {
-        targetElement.classList.add('is-active');
-      }
+    if (manualNav) {
+        displayManualNav(manualNav,block);
     } else {
-      // Product page
-      const result = hasDirectLeafNodes(results, currentPagePath);
-      if (result) {
-        const subPages = filterSubPages(results, currentPagePath);
-        const resultMultiMap = convertToMultiMap(subPages, currentPagePath.split('/')[3]);
-        const htmlList = convertToULList(resultMultiMap);
-
-        block.appendChild(htmlList);
-        sortFirstLevelList('.subPages');
-      } else {
-        // In case of no sub-pages, show all products
-        await displayAllProducts(block, placeholders);
-      }
+      // dynamically create sub page nav or if empty show products list
+      await displayProductNav(block,currentPagePath, results, placeholders);
     }
   }
-
+    
   // Toggle functionality for products/sub-pages
   const toggleElements = block.querySelectorAll('.js-toggle');
   if (toggleElements) {

--- a/component-definition.json
+++ b/component-definition.json
@@ -77,6 +77,29 @@
               }
             }
           }
+        },
+        {
+          "title": "Editable Browse Rail Section",
+          "id": "browse-rail-section",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/section/v1/section",
+                "template": {
+                  "filter": "browse-rail-section",
+                  "name": "Browse Rail Section",
+                  "model": "browse-rail-section",
+                  "style": "browse-rail-section",
+                  "browserail": {
+                    "sling:resourceType": "core/franklin/components/block/v1/block",
+                    "name": "Browse Rail",
+                    "model": "browse-rail",
+                    "navigation": "<ul><li><a href='/content/exlm/global/en/browse.html'>Title with Link</a><br><ul><li><a href='/content/exlm/global/en/browse.html'>Subtitle with link</a></li></ul></li><li>Title with no link<ul><li>Subtitle with no link</li></ul></li></ul>"
+                  }
+                }
+              }
+            }
+          }
         }
       ]
     },
@@ -568,6 +591,22 @@
                   "name": "Recommended Courses",
                   "model": "recommended-courses",
                   "headingType": "h2"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Browse Rail",
+          "id": "browse-rail",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Browse Rail",
+                  "model": "browse-rail",
+                  "title": "Browse Rail"
                 }
               }
             }

--- a/component-filters.json
+++ b/component-filters.json
@@ -44,7 +44,7 @@
   },
   {
     "id": "browse-rail-section",
-    "components": ["browse-rail"]
+    "components": []
   },
   {
     "id": "text",

--- a/component-filters.json
+++ b/component-filters.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "main",
-    "components": ["section"]
+    "components": ["section","browse-rail-section"]
   },
   {
     "id": "columns",
@@ -40,6 +40,12 @@
       "tabbed-cards",
       "tabs",
       "recommended-courses"
+    ]
+  },
+  {
+    "id": "browse-rail-section",
+    "components": [
+      "browse-rail"
     ]
   },
   {

--- a/component-filters.json
+++ b/component-filters.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "main",
-    "components": ["section","browse-rail-section"]
+    "components": ["section", "browse-rail-section"]
   },
   {
     "id": "columns",
@@ -44,9 +44,7 @@
   },
   {
     "id": "browse-rail-section",
-    "components": [
-      "browse-rail"
-    ]
+    "components": ["browse-rail"]
   },
   {
     "id": "text",

--- a/component-models.json
+++ b/component-models.json
@@ -600,8 +600,7 @@
         "description": "The section style",
         "valueType": "string",
         "hidden": true,
-        "options": [
-        ]
+        "options": []
       }
     ]
   },

--- a/component-models.json
+++ b/component-models.json
@@ -590,6 +590,22 @@
     ]
   },
   {
+    "id": "browse-rail-section",
+    "fields": [
+      {
+        "component": "select",
+        "name": "style",
+        "value": "",
+        "label": "Style",
+        "description": "The section style",
+        "valueType": "string",
+        "hidden": true,
+        "options": [
+        ]
+      }
+    ]
+  },
+  {
     "id": "icon-card",
     "fields": [
       {
@@ -2257,6 +2273,19 @@
         "value": "",
         "label": "Link URL",
         "description": "Sets the text url."
+      }
+    ]
+  },
+  {
+    "id": "browse-rail",
+    "fields": [
+      {
+        "component": "richtext",
+        "valueType": "string",
+        "name": "navigation",
+        "value": "",
+        "label": "Product Navigation",
+        "description": "Override default behaviour with custom Navigation"
       }
     ]
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -167,7 +167,7 @@ export function isBrowsePage() {
  */
 function addBrowseRail(main) {
   // if there is already editable browse rail stored
-  if (main.querySelector("div.browse-rail")) return;
+  if (main.querySelector('div.browse-rail')) return;
 
   // default: create a dynamic uneditable browse rail
   const leftRailSection = document.createElement('div');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -16,6 +16,7 @@ import {
   getMetadata,
   loadScript,
   fetchPlaceholders,
+  readBlockConfig,
 } from './lib-franklin.js';
 // eslint-disable-next-line import/no-cycle
 
@@ -167,7 +168,11 @@ export function isBrowsePage() {
  */
 function addBrowseRail(main) {
   // if there is already editable browse rail stored
-  if (main.querySelector('div.browse-rail')) return;
+  const browseRailSectionFound = [...main.querySelectorAll('.section-metadata')]
+    .find((sMeta) => 
+      readBlockConfig(sMeta)?.style.split(',').includes('browse-rail-section')
+    )
+  if (browseRailSectionFound) return;
 
   // default: create a dynamic uneditable browse rail
   const leftRailSection = document.createElement('div');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -168,10 +168,9 @@ export function isBrowsePage() {
  */
 function addBrowseRail(main) {
   // if there is already editable browse rail stored
-  const browseRailSectionFound = [...main.querySelectorAll('.section-metadata')]
-    .find((sMeta) => 
-      readBlockConfig(sMeta)?.style.split(',').includes('browse-rail-section')
-    )
+  const browseRailSectionFound = [...main.querySelectorAll('.section-metadata')].find((sMeta) =>
+    readBlockConfig(sMeta)?.style.split(',').includes('browse-rail-section'),
+  );
   if (browseRailSectionFound) return;
 
   // default: create a dynamic uneditable browse rail

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -166,8 +166,12 @@ export function isBrowsePage() {
  * add a section for the left rail when on a browse page.
  */
 function addBrowseRail(main) {
+  // if there is already editable browse rail stored
+  if (main.querySelector("div.browse-rail")) return;
+
+  // default: create a dynamic uneditable browse rail
   const leftRailSection = document.createElement('div');
-  leftRailSection.classList.add('browse-rail', isBrowsePage());
+  leftRailSection.classList.add('browse-rail-section', isBrowsePage());
   leftRailSection.append(buildBlock('browse-rail', []));
   main.append(leftRailSection);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1396,7 +1396,7 @@ body[class^=browse-] .browse-filters-full-container .browse-filters-pagination, 
   main > div.section {
     grid-column: 2;
   }
-  main > div.section.browse-rail {
+  main > div.section.browse-rail-section {
     display: initial;
     grid-column: 1;
     grid-row: 1/100;
@@ -1413,8 +1413,8 @@ body[class^=browse-] .browse-filters-full-container .browse-filters-pagination, 
   body.browse-product main {
     max-width: 1440px;
   }
-  body.browse-all main > div.section:not(.browse-rail),
-  body.browse-product main > div.section:not(.browse-rail) {
+  body.browse-all main > div.section:not(.browse-rail-section),
+  body.browse-product main > div.section:not(.browse-rail-section) {
     padding: 30px 32px;
   }
   body.browse-all main > div.section.browse-breadcrumb-container,

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -1401,7 +1401,7 @@ body[class^='browse-'] .browse-filters-full-container {
     grid-column: 2;
   }
 
-  main > div.section.browse-rail {
+  main > div.section.browse-rail-section {
     display: initial;
     grid-column: 1;
     grid-row: 1 / 100;
@@ -1424,7 +1424,7 @@ body[class^='browse-'] .browse-filters-full-container {
       max-width: 1440px;
     }
 
-    & main > div.section:not(.browse-rail) {
+    & main > div.section:not(.browse-rail-section) {
       padding: 30px 32px;
     }
 


### PR DESCRIPTION
Currently the browse rail for browse pages is created completely dynamic via auto blocking.
The request is to be able to override this with a custom navigation per page. This PR makes the following proposal:

- On a browse page , add a new `Editable Browse Rail Section` to main

![image](https://github.com/adobe-experience-league/exlm/assets/37147400/2d5ccc6c-025c-40b8-a117-4c3ac1c46404)

- this will replace the autoblocking with `browse rail section` which contains a` browse rail` block:

![image](https://github.com/adobe-experience-league/exlm/assets/37147400/b9d92ca5-7811-4345-a978-1fd164e322a5)

- selecting the browse rail, you can edit the navigation via richtext:

![image](https://github.com/adobe-experience-league/exlm/assets/37147400/3a7209d0-48c8-409f-b8c0-e23184821b28)

![image](https://github.com/adobe-experience-league/exlm/assets/37147400/f7742270-5c56-4372-bf21-66f2e73ec9fa)

- This PR is backward compatible, meaing if you delete `Browse Rail Section` it reverts back to autoblocking a dynamic navigation as before.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-1217

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/browse/exlm-1217-test-product/exm-1217-product-version-page-1/exlm-1217-product-version-1-sub-page-1
- After: https://exlm-1217--exlm--adobe-experience-league.hlx.page/en/browse/exlm-1217-test-product/exm-1217-product-version-page-1/exlm-1217-product-version-1-sub-page-1

Authoring:
- Before:
https://author-p122525-e1200861.adobeaemcloud.com/ui#/@amc/aem/universal-editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/browse/exlm-1217-test-product.html
- After:
https://author-p122525-e1200861.adobeaemcloud.com/ui#/@amc/aem/universal-editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/browse/exlm-1217-test-product.html?ref=exlm-1217

