### PR TITLE
Handle images are inline elements, not blocks.

### DIFF
--- a/blocks/img-md/img-md.css
+++ b/blocks/img-md/img-md.css
@@ -1,3 +1,4 @@
+/* TODO: This is obselete and should be removed when all pages have been seeded and the old badge is no longer used */
 .img-md {
   display: flex;
 }

--- a/blocks/img-md/img-md.js
+++ b/blocks/img-md/img-md.js
@@ -1,3 +1,5 @@
+/* TODO: This is obselete and should be removed when all pages have been seeded and the old badge is no longer used */
+
 import { htmlToElement } from '../../scripts/scripts.js';
 
 const IMAGE_MODAL_CLASS = 'img-modal';

--- a/blocks/img-md/img-md.scss
+++ b/blocks/img-md/img-md.scss
@@ -1,3 +1,5 @@
+/* TODO: This is obselete and should be removed when all pages have been seeded and the old badge is no longer used */
+
 .img-md {
   display: flex;
 

--- a/scripts/image-modal.js
+++ b/scripts/image-modal.js
@@ -1,0 +1,31 @@
+import { createOptimizedPicture } from './lib-franklin.js';
+// eslint-disable-next-line import/no-cycle
+import { htmlToElement } from './scripts.js';
+
+/**
+ * @param {HTMLImageElement} picture
+ */
+export default function showImageModal(img) {
+  let modal = document.querySelector('.image-modal');
+  if (!modal) {
+    modal = htmlToElement(`<dialog class="image-modal">
+        <button autofocus class="image-modal-close"><span aria-label="close"></button>
+        <div class="image-modal-content"></div>
+      </dialog>`);
+    document.body.prepend(modal);
+    document.body.style.overflow = 'hidden';
+    modal.addEventListener('close', () => {
+      document.body.style.overflow = '';
+    });
+    modal.addEventListener('click', (event) => event.target === modal && modal.close());
+    modal.querySelector('button').addEventListener('click', () => modal.close());
+    document.addEventListener('keydown', (event) => event.code === 'Escape' && modal.close());
+  }
+  // remove existing content
+  const content = modal.querySelector('.image-modal-content');
+  content.innerHTML = '';
+  // add new content
+  const picture = createOptimizedPicture(img.src, img.alt);
+  content.appendChild(picture);
+  modal.showModal();
+}

--- a/styles/image-modal.css
+++ b/styles/image-modal.css
@@ -1,0 +1,82 @@
+::backdrop {
+    background: rgb(10 10 10 / 86%);
+    height: 100%;
+    left: 0;
+    position: fixed;
+    transition: all 200ms;
+    top: 0;
+    width: 100%;
+    z-index: 12;
+}
+
+.image-modal {
+    --modal-max-height: calc(100vh - 40px);
+
+    border: 0;
+    align-items: center;
+    position: fixed;
+    left: 0;
+    overflow: hidden;
+    z-index: 99999;
+    background: transparent;
+}
+
+.image-modal .image-modal-content {
+    border-radius: 7px;
+    max-height: var(--modal-max-height);
+    margin: 0 auto;
+    padding: 5px;
+    position: relative;
+    z-index: 14;
+    display: flex;
+    justify-content: center;
+}
+
+.image-modal .image-modal-content * {
+    display: block;
+    max-height: var(--modal-max-height);
+}
+
+
+
+.image-modal .image-modal-close {
+    background: transparent;
+    border-radius: 50px;
+    cursor: pointer;
+    display: inline-block;
+    height: 32px;
+    position: fixed;
+    right: 20px;
+    top: 20px;
+    width: 32px;
+    z-index: 99;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    text-align: left;
+    font-weight: initial;
+}
+
+.image-modal .image-modal-close::before,
+.image-modal .image-modal-close::after {
+    background-color: var(--spectrum-gray-50);
+    box-sizing: inherit;
+    content: "";
+    display: block;
+    height: 2px;
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translateX(-50%) translateY(-50%) rotate(45deg);
+    transform-origin: center center;
+    width: 50%;
+}
+
+.image-modal .image-modal-close::after {
+    height: 50%;
+    width: 2px;
+}
+
+.image-modal .image-modal-close:hover {
+    background: rgb(10 10 10 / 30%);
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -775,6 +775,30 @@ img {
   height: auto;
 }
 
+picture[width] {
+  display: inline-flex;
+}
+picture[modal] {
+  cursor: zoom-in;
+}
+picture[modal]:hover {
+  cursor: zoom-in;
+  opacity: 0.95;
+}
+picture[align=left] {
+  float: left;
+  vertical-align: baseline;
+}
+picture[align=center] {
+  display: flex;
+  justify-content: center;
+  margin: 0 auto;
+}
+picture[align=right] {
+  float: right;
+  vertical-align: baseline;
+}
+
 .icon {
   display: inline-block;
   height: 24px;
@@ -1050,7 +1074,7 @@ body[class^=browse-] .browse-filters-full-container .browse-filters-pagination, 
 }
 @media (min-width: 600px) {
   .docs.docs-landing main {
-    padding: 28px 46px 48px 46px;
+    padding: 28px 46px 48px;
   }
 }
 @media (min-width: 900px) {

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -660,6 +660,37 @@ img {
   height: auto;
 }
 
+picture {
+  &[width] {
+    display: inline-flex;
+  }
+
+  &[modal] {
+    cursor: zoom-in;
+  }
+
+  &[modal]:hover {
+    cursor: zoom-in;
+    opacity: 0.95;
+  }
+
+  &[align='left'] {
+    float: left;
+    vertical-align: baseline;
+  }
+
+  &[align='center'] {
+    display: flex;
+    justify-content: center;
+    margin: 0 auto;
+  }
+
+  &[align='right'] {
+    float: right;
+    vertical-align: baseline;
+  }
+}
+
 .icon {
   display: inline-block;
   height: 24px;


### PR DESCRIPTION
This PR handles images as inline elements with image options provided as a sibling text node.

see: https://github.com/adobe-experience-league/exlm-converter/pull/306


Jira ID: UGP-10614

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/support-resources/data-sheets/test-page
- After: https://ugp-10614--exlm--adobe-experience-league.hlx.page/en/docs/support-resources/data-sheets/test-page