### PR TITLE
Handle images are inline elements, not blocks - handle erroring images

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -419,15 +419,23 @@ export function decorateInlineText(textNode) {
  */
 export function decoratePreviousImage(textNode) {
   // if previous element is image, and textNode contains { and }, decorate the image
-  const { previousSibling: picture, textContent } = textNode;
-  const isPrecededByPicture = picture?.tagName.toLowerCase() === 'picture';
-  if (isPrecededByPicture && textContent.startsWith('{') && textContent.includes('}')) {
-    const attrsStr = textContent.substring(1, textContent.indexOf('}'));
-    // remove the attributes from textNode
-    textNode.textContent = textContent.substring(textContent.indexOf('}') + 1);
-    const img = picture?.querySelector('img');
-    const attrsObj = parseInlineAttributes(attrsStr);
+  const { previousSibling, textContent } = textNode;
+  if (textContent.startsWith('{') && textContent.includes('}')) {
+    const isPrecededByPicture = previousSibling?.tagName.toLowerCase() === 'picture';
+    const isPrecededByImg = previousSibling?.tagName.toLowerCase() === 'img';
+    let picture;
+    let img;
+    if (isPrecededByPicture) {
+      picture = previousSibling;
+      img = picture.querySelector('img');
+    } else if (isPrecededByImg) {
+      img = previousSibling;
+    } else return; // only decorate if preceded by picture or img
 
+    const attrsStr = textContent.substring(1, textContent.indexOf('}'));
+    textNode.textContent = textContent.substring(textContent.indexOf('}') + 1);
+    if (img.src === 'about:error') return; // do not decorate broken images
+    const attrsObj = parseInlineAttributes(attrsStr);
     let newPicture = picture;
     if (attrsObj.width) {
       // author defined width


### PR DESCRIPTION
Second PR to handle image errors

see: https://github.com/adobe-experience-league/exlm-converter/pull/306


Jira ID: UGP-10614

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://ugp-10614--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
