### PR TITLE
EXLM-1293:  Detailed teasers in carousel broken

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -1,4 +1,5 @@
 @import "../teaser/teaser.css";
+@import "../detailed-teaser/detailed-teaser.css";
 
 /* carousel wrapper stretches over complete width */
 .section div.carousel-wrapper {


### PR DESCRIPTION
The css import for the `detailed-teaser.css` inside `carousel.css` was missing. 
Initially only discovered on stage, its also reproducible on dev env, when cache is cleared in developer tools.

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page
- After: https://exlm-1293--exlm--adobe-experience-league.hlx.page

Dev Author:
- Before : https://author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en.html
- After: https://author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en.html?ref=exlm-1293
