### PR TITLE
EXLM 1364 Block Quote RTE Issue

### DIFF
--- a/blocks/block-quote/block-quote.css
+++ b/blocks/block-quote/block-quote.css
@@ -11,7 +11,7 @@
   border-bottom: 0px;
 }
 
-.block-quote-content {
+.block-quote-content *{
   font-style: italic;
   font-weight: normal;
   font-size: 22px;


### PR DESCRIPTION
Updated the CSS to override the default RTE styles with Block Quote content Style

Jira ID: https://jira.corp.adobe.com/browse/EXLM-1364

Test URLs:

Before: https://main--exlm--adobe-experience-league.hlx.live/en/articles/experience-manager
After: https://feature-exlm-1364-blocl--exlm--adobe-experience-league.hlx.live/en/articles/experience-manager

Before 
<img width="856" alt="image" src="https://github.com/adobe-experience-league/exlm/assets/30936827/fb0b9d36-6b94-420f-9aaf-700b5a5a2993">

After

<img width="955" alt="image" src="https://github.com/adobe-experience-league/exlm/assets/30936827/34fb9795-7207-427a-a147-40f90f3863fb">




