### PR TITLE
EXLM-1272: deselecting the browse topic, previous value is still in datalayer

### DIFF
--- a/scripts/analytics/lib-analytics.js
+++ b/scripts/analytics/lib-analytics.js
@@ -201,6 +201,14 @@ export function pushLinkClick(e) {
 
 export function assetInteractionModel(id, assetInteractionType, filters) {
   window.adobeDataLayer = window.adobeDataLayer || [];
+  const dataLayerFilters = {
+    Role: '',
+    ContentType: '',
+    ExperienceLevel: '',
+    KeywordSearch: '',
+    BrowseByTopic: '',
+  };
+  Object.assign(dataLayerFilters, filters);
 
   // assetId is set to the current docs page articleId if id param value is null
   const assetId = id || ((document.querySelector('meta[name="id"]') || {}).content || '').trim();
@@ -212,7 +220,7 @@ export function assetInteractionModel(id, assetInteractionType, filters) {
       linkType: '',
       solution: '',
     },
-    ...filters,
+    ...dataLayerFilters,
     event: 'assetInteraction',
     asset: {
       id: assetId,


### PR DESCRIPTION
EXLM-1272: deselecting the browse topic, previous value is still in datalayer

Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: EXLM-1272

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live/
- After: https://bugfix-exlm-1272--exlm--adobe-experience-league.hlx.live/
