### PR TITLE
Feature/ugp 10824

### DIFF
--- a/blocks/doc-actions/doc-actions.js
+++ b/blocks/doc-actions/doc-actions.js
@@ -107,7 +107,7 @@ async function getTranslatedDocContent() {
   const translatedDoc = await docResponse.text();
   const docElement = htmlToElement(`<div>${translatedDoc}</div>`);
   decorateMain(docElement);
-  await loadBlocks(docElement);
+  await loadBlocks(docElement.querySelector(':not(.mini-toc-container)'));
   return docElement.querySelector(':scope > div:first-child');
 }
 

--- a/blocks/doc-actions/doc-actions.js
+++ b/blocks/doc-actions/doc-actions.js
@@ -107,7 +107,7 @@ async function getTranslatedDocContent() {
   const translatedDoc = await docResponse.text();
   const docElement = htmlToElement(`<div>${translatedDoc}</div>`);
   decorateMain(docElement);
-  await loadBlocks(docElement.querySelector(':not(.mini-toc-container)'));
+  await loadBlocks(docElement);
   return docElement.querySelector(':scope > div:first-child');
 }
 
@@ -174,11 +174,14 @@ async function decorateLanguageToggle(block, placeholders) {
     const docContainer = document.querySelector('main > div:first-child');
 
     [...desktopAndMobileLangToggles].forEach((langToggle) => {
-      langToggle.addEventListener('change', async (e) => {
-        const { checked } = e.target;
-        await toggleContent(checked, docContainer);
-        assetInteractionModel(null, `automatic translation ${e.target.checked ? 'on' : 'off'}`);
-      });
+      if (!langToggle.parentElement.classList.contains('listener')) {
+        langToggle.addEventListener('change', async (e) => {
+          const { checked } = e.target;
+          await toggleContent(checked, docContainer);
+          assetInteractionModel(null, `automatic translation ${e.target.checked ? 'on' : 'off'}`);
+        });
+        langToggle.parentElement.classList.add('listener');
+      }
     });
 
     const desktopAndMobileRadioFeedback = document.querySelectorAll(

--- a/blocks/doc-actions/doc-actions.js
+++ b/blocks/doc-actions/doc-actions.js
@@ -177,6 +177,7 @@ async function decorateLanguageToggle(block, placeholders) {
       langToggle.addEventListener('change', async (e) => {
         const { checked } = e.target;
         await toggleContent(checked, docContainer);
+        assetInteractionModel(null, `automatic translation ${e.target.checked ? 'on' : 'off'}`);
       });
     });
 


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: UGP-10824

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live/
- After: https://feature-ugp-10824--exlm--adobe-experience-league.hlx.live/

Besides the change for the ask -> assetInteractionModel(null, `automatic translation ${e.target.checked ? 'on' : 'off'}`);
The addition of the "listener" class and check was due to 
the slider change listener is duplicated after you click the slider once so analytics events are sent twice . 

Feel free to suggest if there is an alternate approach for this duplicated/redundant event listener. I tried { once: true } but listener does not fire after 2nd click.

<img width="1177" alt="Screen Shot 2024-05-21 at 9 28 54 PM" src="https://github.com/adobe-experience-league/exlm/assets/129903184/4d002831-782e-4c12-9ade-280f63d4b318">

