### PR TITLE
EXLM 1580 Page metadata to include Page Title

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -2466,6 +2466,13 @@
     "id": "page-metadata",
     "fields": [
       {
+        "component": "text",
+        "valueType": "string",
+        "name": "jcr:title",
+        "label": "Page Title",
+        "description": "Sets the title of the page in page meta."
+      },
+      {
         "component": "select",
         "valueType": "string",
         "name": "article-theme",


### PR DESCRIPTION
Updated page metadata to include page title 

Jira ID: https://jira.corp.adobe.com/browse/EXLM-1580

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live
- After: https://feature-exlm-1580-page-title--exlm--adobe-experience-league.hlx.live

<img width="388" alt="image" src="https://github.com/adobe-experience-league/exlm/assets/30936827/7cc97497-e9a3-4ff2-8cfb-b74de5113ced">

<img width="659" alt="image" src="https://github.com/adobe-experience-league/exlm/assets/30936827/a279c020-4d24-4734-b8f3-25bb28d2a753">



