### PR TITLE
EXLM-1696:  enable the Browse Filters block on Article Landing pages

### DIFF
--- a/component-filters.json
+++ b/component-filters.json
@@ -53,7 +53,8 @@
       "callout",
       "featured-authors",
       "inline-survey",
-      "featured-content"
+      "featured-content",
+      "browse-filters"
     ]
   },
   {

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -33,19 +33,19 @@ function restoreState(newBlock, state) {
   }
 }
 
-
 function setIdsforRTETitles(articleContentSection) {
   // find all titles with no id in the article content section
-  articleContentSection.querySelectorAll("h1:not([id]),h2:not([id],h3:not([id],h4:not([id],h5:not([id],h6:not([id]")
-      .forEach((title) => {
-        title.id = title.textContent
-          .toLowerCase()
-            .trim()
-            .replaceAll("[^a-z0-9-]", "-")
-            .replaceAll("-{2,}", "-")
-            .replaceAll("^-+","")
-            .replaceAll("-+$","");    
-      });
+  articleContentSection
+    .querySelectorAll('h1:not([id]),h2:not([id],h3:not([id],h4:not([id],h5:not([id],h6:not([id]')
+    .forEach((title) => {
+      title.id = title.textContent
+        .toLowerCase()
+        .trim()
+        .replaceAll('[^a-z0-9-]', '-')
+        .replaceAll('-{2,}', '-')
+        .replaceAll('^-+', '')
+        .replaceAll('-+$', '');
+    });
 }
 
 // set the filter for an UE editable
@@ -293,4 +293,3 @@ if (signUpBlock) {
 
 // update UE component filters on page load
 updateUEInstrumentation();
-


### PR DESCRIPTION
Hi Team - the only change related to this was the first commit (component-filters.json). The editor-support.js change was because code quality was complaining to an earlier PR.

Jira ID: EXLM-1696

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live/
- After: https://feature-exlm-1696--exlm--adobe-experience-league.hlx.live/

