### PR TITLE
default heading for article marquee changed to h1

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -1227,7 +1227,7 @@
         "component": "select",
         "valueType": "string",
         "name": "titleType",
-        "value": "h3",
+        "value": "h1",
         "label": "Heading Type",
         "options": [
           {


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: https://jira.corp.adobe.com/browse/EXLM-1695

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page
- After: https://feat-exlm-1695--exlm--adobe-experience-league.hlx.page
