### PR TITLE
UGP-10839 Removing transition that causes bug on mouse over, other CSS Fixes

### DIFF
--- a/blocks/toc/toc.css
+++ b/blocks/toc/toc.css
@@ -8,15 +8,23 @@
 .toc-content  {
     display: none;
     scroll-behavior: smooth;
-    transition: padding 0.2s ease;
     max-height: 60vh;
-    overflow: hidden;
-    &:hover {
+    overflow-y: auto;
+
+    &::-webkit-scrollbar {
+        width: 0;
+    }
+
+    &:hover::-webkit-scrollbar, &:hover {
         touch-action: pan-y;
-        padding-right: 8px;
         overflow-y: auto;
         scrollbar-width: thin;
         scrollbar-color: var(--spectrum-gray-200) var(--spectrum-gray-100);
+    }
+
+    &:hover::-webkit-scrollbar-thumb {
+        background-color: var(--spectrum-gray-200);
+        border-radius: 6px;
     }
 }
 
@@ -81,6 +89,7 @@
         background-color: var(--spectrum-gray-50);
         z-index: 1;
     }
+
     align-items: center;
     display: flex;
     box-sizing: border-box;


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: UGP-10839

**User Story:** As a user of documentation and tutorials table of contents, I want the often long table of contents to have an independent scroll from the rest of the page so that I don't have to sacrifice my current reading location on the page to explore the TOC.

**Acceptance Criteria:**

- The scroll bar only appears when the user scrolls within the TOC area.
- The scroll bar is not visible when the TOC area is not being scrolled.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/experience-manager-65/content/implementing/deploying/restructuring/dynamicmedia-repository-restructuring-in-aem-6-5
- After: https://ugp-10839-2--exlm--adobe-experience-league.hlx.page/en/docs/experience-manager-65/content/implementing/deploying/restructuring/dynamicmedia-repository-restructuring-in-aem-6-5


