### PR TITLE
Feature UGP-10847 - Improve Visibility of Active Page in Table of Contents

### DIFF
--- a/blocks/toc/toc.js
+++ b/blocks/toc/toc.js
@@ -196,10 +196,14 @@ export default async function decorate(block) {
     });
     // Prevents active elements to be hidden below the overflow
     const activeElement = tocContent.querySelector('.toc-item.is-active');
+    const offset = 100;
+
     if (activeElement) {
-      const activeElementOffset = activeElement.offsetTop;
-      const desiredOffset = 100;
-      tocContent.scrollTop = activeElementOffset - desiredOffset;
+        const activeElementTop = activeElement.getBoundingClientRect().top;
+        const tocContentTop = tocContent.getBoundingClientRect().top;
+        const scrollPosition = activeElementTop - tocContentTop - offset;
+
+        tocContent.scrollTop = scrollPosition;
     }
   });
 


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: UGP-10847

**Problem:**
For users seeing a very long TOC, the active page may not be in view of the TOC when the page loads, especially on smaller browser window sizes.

**Proposed Solution:**
Enhance the current implementation to ensure the active page is visible in the TOC when the page loads. This involves scrolling the TOC to the active item with an appropriate offset to ensure it is in view.


Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/experience-manager-65/content/implementing/developing/introduction/getting-started
- After: https://feature-ugp-10847--exlm--adobe-experience-league.hlx.page/en/docs/experience-manager-65/content/implementing/developing/introduction/getting-started
