### PR TITLE
Disable Perspective in Prod Only

### DIFF
--- a/blocks/browse-filters/browse-filter-utils.js
+++ b/blocks/browse-filters/browse-filter-utils.js
@@ -1,5 +1,7 @@
-import { fetchLanguagePlaceholders } from '../../scripts/scripts.js';
+import { fetchLanguagePlaceholders, getConfig } from '../../scripts/scripts.js';
 import { COMMUNITY_SEARCH_FACET } from '../../scripts/browse-card/browse-cards-constants.js';
+
+const { isProd } = getConfig();
 
 const SUB_FACET_MAP = {
   Community: COMMUNITY_SEARCH_FACET,
@@ -96,6 +98,7 @@ const contentTypes = [
     value: 'Perspective',
     title: 'Perspectives',
     description: 'Real-world inspiration from Experience Cloud customers and Adobe experts.',
+    disabled: isProd,
   },
   {
     id: 'Troubleshooting',
@@ -110,15 +113,17 @@ const contentTypes = [
     description:
       'Brief instructional material with step-by-step instructions to learn a specific skill or accomplish a specific task.',
   },
-].map((contentType) => ({
-  ...contentType,
-  ...(placeholders[`filterContentType${contentType.id}Title`] && {
-    title: placeholders[`filterContentType${contentType.id}Title`],
-  }),
-  ...(placeholders[`filterContentType${contentType.id}Description`] && {
-    description: placeholders[`filterContentType${contentType.id}Description`],
-  }),
-}));
+]
+  .filter((type) => !type.disabled)
+  .map((contentType) => ({
+    ...contentType,
+    ...(placeholders[`filterContentType${contentType.id}Title`] && {
+      title: placeholders[`filterContentType${contentType.id}Title`],
+    }),
+    ...(placeholders[`filterContentType${contentType.id}Description`] && {
+      description: placeholders[`filterContentType${contentType.id}Description`],
+    }),
+  }));
 
 /**
  * Array containing expLevel (Experience Level) with associated metadata.

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -12,7 +12,7 @@ import {
 import getProducts from '../../scripts/utils/product-utils.js';
 
 const languageModule = import('../../scripts/language.js');
-const { khorosProfileUrl } = getConfig();
+const { khorosProfileUrl, isProd } = getConfig();
 
 let searchElementPromise = null;
 
@@ -470,6 +470,14 @@ const searchDecorator = async (searchBlock) => {
   const searchOptions = getCell(searchBlock, 1, 3)?.firstElementChild?.children || [];
   const options = [...searchOptions].map((option) => option.textContent);
 
+  const parsedOptions = options
+    .map((option) => {
+      const [label, value] = option.split(':');
+      return { label, value };
+    })
+    // TODO - remove this filter once perspectives need to be live on Prod.
+    .filter((option) => !isProd || option?.value?.toLowerCase() !== 'perspective');
+
   searchBlock.innerHTML = '';
   const searchWrapper = htmlToElement(
     `<div class="search-wrapper">
@@ -491,23 +499,19 @@ const searchDecorator = async (searchBlock) => {
           </div>
         </div>
         <button type="button" class="search-picker-button" aria-haspopup="true" aria-controls="search-picker-popover">
-          <span class="search-picker-label" data-filter-value="${options[0].split(':')[1]}">${
-            options[0].split(':')[0] || ''
+          <span class="search-picker-label" data-filter-value="${parsedOptions[0]?.value}">${
+            parsedOptions[0]?.label || ''
           }</span>
         </button>
         <div class="search-picker-popover" id="search-picker-popover">
           <ul role="listbox">
-            ${options
+            ${parsedOptions
               .map(
-                (option, index) =>
-                  `<li tabindex="0" role="option" class="search-picker-label" data-filter-value="${
-                    option.split(':')[1]
-                  }">${
+                ({ label, value }, index) =>
+                  `<li tabindex="0" role="option" class="search-picker-label" data-filter-value="${value}">${
                     index === 0
-                      ? `<span class="icon icon-checkmark"></span> <span data-filter-value="${option.split(':')[1]}">${
-                          option.split(':')[0]
-                        }</span>`
-                      : `<span data-filter-value="${option.split(':')[1]}">${option.split(':')[0]}</span>`
+                      ? `<span class="icon icon-checkmark"></span> <span data-filter-value="${value}">${label}</span>`
+                      : `<span data-filter-value="${value}">${label}</span>`
                   }</li>`,
               )
               .join('')}


### PR DESCRIPTION
 PR to hide the "Perspectives" from header search dropdown and Browse Filters in Prod.
https://github.com/adobe-experience-league/exlm/pull/935
https://github.com/adobe-experience-league/exlm/pull/931

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live
- After: https://remove-perspectives--exlm--adobe-experience-league.hlx.live
