### PR TITLE
Feature Flags

### DIFF
--- a/blocks/browse-filters/browse-filter-utils.js
+++ b/blocks/browse-filters/browse-filter-utils.js
@@ -1,7 +1,5 @@
-import { fetchLanguagePlaceholders, getConfig } from '../../scripts/scripts.js';
+import { fetchLanguagePlaceholders, isFeatureEnabled } from '../../scripts/scripts.js';
 import { COMMUNITY_SEARCH_FACET } from '../../scripts/browse-card/browse-cards-constants.js';
-
-const { isProd } = getConfig();
 
 const SUB_FACET_MAP = {
   Community: COMMUNITY_SEARCH_FACET,
@@ -98,7 +96,7 @@ const contentTypes = [
     value: 'Perspective',
     title: 'Perspectives',
     description: 'Real-world inspiration from Experience Cloud customers and Adobe experts.',
-    disabled: isProd,
+    disabled: !isFeatureEnabled('perspectives'),
   },
   {
     id: 'Troubleshooting',

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -8,11 +8,12 @@ import {
   getConfig,
   getLink,
   fetchFragment,
+  isFeatureEnabled,
 } from '../../scripts/scripts.js';
 import getProducts from '../../scripts/utils/product-utils.js';
 
 const languageModule = import('../../scripts/language.js');
-const { khorosProfileUrl, isProd } = getConfig();
+const { khorosProfileUrl } = getConfig();
 
 let searchElementPromise = null;
 
@@ -475,8 +476,8 @@ const searchDecorator = async (searchBlock) => {
       const [label, value] = option.split(':');
       return { label, value };
     })
-    // TODO - remove this filter once perspectives need to be live on Prod.
-    .filter((option) => !isProd || option?.value?.toLowerCase() !== 'perspective');
+    // TODO - remove dependecy on feature flag once perspectives are perminantely live
+    .filter((option) => option?.value?.toLowerCase() !== 'perspective' || isFeatureEnabled('perspectives'));
 
   searchBlock.innerHTML = '';
   const searchWrapper = htmlToElement(

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1197,6 +1197,13 @@ async function loadDefaultModule(jsPath) {
   }
 }
 
+export function isFeatureEnabled(name) {
+  return getMetadata('feature-flags')
+    .split(',')
+    .map((t) => t.toLowerCase().trim())
+    .includes(name);
+}
+
 /**
  * THIS IS TEMPORARY FOR SUMMIT
  */


### PR DESCRIPTION
Adds a simple API to check if a feature flag is enabled by metadata.
and an example usage for `perspectives`

Authors can update bulk metadata value for `feature-flags` which can be comma separated to enable features.



Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://feature-flag--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
