### PR TITLE
Pull common coveo logic out of browse card 

### DIFF
--- a/blocks/adls-cards/adls-cards.js
+++ b/blocks/adls-cards/adls-cards.js
@@ -4,7 +4,7 @@ import { htmlToElement } from '../../scripts/scripts.js';
 import { buildCard } from '../../scripts/browse-card/browse-card.js';
 import { createTooltip, hideTooltipOnScroll } from '../../scripts/browse-card/browse-card-tooltip.js';
 import BuildPlaceholder from '../../scripts/browse-card/browse-card-placeholder.js';
-import { CONTENT_TYPES } from '../../scripts/browse-card/browse-cards-constants.js';
+import { CONTENT_TYPES } from '../../scripts/data-service/coveo/coveo-exl-pipeline-constants.js';
 
 /**
  * Decorate function to process and log the mapped data.

--- a/blocks/bookmarks/bookmarks.js
+++ b/blocks/bookmarks/bookmarks.js
@@ -3,11 +3,11 @@ import { buildCard } from '../../scripts/browse-card/browse-card.js';
 import { htmlToElement, fetchLanguagePlaceholders, getPathDetails } from '../../scripts/scripts.js';
 import { defaultProfileClient } from '../../scripts/auth/profile.js';
 import { fetchArticleByID } from '../../scripts/data-service/article-data-service.js';
-import { CONTENT_TYPES } from '../../scripts/browse-card/browse-cards-constants.js';
 import BuildPlaceholder from '../../scripts/browse-card/browse-card-placeholder.js';
 import { bookmarksEventEmitter } from '../../scripts/events.js';
 import { getCardData, convertToTitleCase } from '../../scripts/browse-card/browse-card-utils.js';
 import Pagination from '../../scripts/pagination/pagination.js';
+import { CONTENT_TYPES } from '../../scripts/data-service/coveo/coveo-exl-pipeline-constants.js';
 
 const BOOKMARKS_BY_PG_CONFIG = {};
 const CARDS_MODEL = {};

--- a/blocks/browse-filters/browse-filter-utils.js
+++ b/blocks/browse-filters/browse-filter-utils.js
@@ -1,5 +1,5 @@
+import { COMMUNITY_SEARCH_FACET } from '../../scripts/data-service/coveo/coveo-exl-pipeline-constants.js';
 import { fetchLanguagePlaceholders, isFeatureEnabled } from '../../scripts/scripts.js';
-import { COMMUNITY_SEARCH_FACET } from '../../scripts/browse-card/browse-cards-constants.js';
 
 const SUB_FACET_MAP = {
   Community: COMMUNITY_SEARCH_FACET,

--- a/blocks/events-cards/events-cards.js
+++ b/blocks/events-cards/events-cards.js
@@ -4,7 +4,7 @@ import { htmlToElement } from '../../scripts/scripts.js';
 import { buildCard } from '../../scripts/browse-card/browse-card.js';
 import { createTooltip, hideTooltipOnScroll } from '../../scripts/browse-card/browse-card-tooltip.js';
 import BuildPlaceholder from '../../scripts/browse-card/browse-card-placeholder.js';
-import { CONTENT_TYPES } from '../../scripts/browse-card/browse-cards-constants.js';
+import { CONTENT_TYPES } from '../../scripts/data-service/coveo/coveo-exl-pipeline-constants.js';
 
 /**
  * formattedSolutionTags returns the solution type by stripping off the exl:solution/ string

--- a/blocks/featured-cards/featured-cards.js
+++ b/blocks/featured-cards/featured-cards.js
@@ -4,9 +4,10 @@ import { htmlToElement, toPascalCase, fetchLanguagePlaceholders, getPathDetails 
 import { buildCard, buildNoResultsContent } from '../../scripts/browse-card/browse-card.js';
 import BuildPlaceholder from '../../scripts/browse-card/browse-card-placeholder.js';
 import { hideTooltipOnScroll } from '../../scripts/browse-card/browse-card-tooltip.js';
-import { CONTENT_TYPES, COVEO_SORT_OPTIONS } from '../../scripts/browse-card/browse-cards-constants.js';
+import { COVEO_SORT_OPTIONS } from '../../scripts/browse-card/browse-cards-constants.js';
 import { roleOptions } from '../browse-filters/browse-filter-utils.js';
 import Dropdown from '../../scripts/dropdown/dropdown.js';
+import { CONTENT_TYPES } from '../../scripts/data-service/coveo/coveo-exl-pipeline-constants.js';
 // eslint-disable-next-line import/no-cycle
 const ffetchModulePromise = import('../../scripts/ffetch.js');
 

--- a/scripts/browse-card/browse-card-utils.js
+++ b/scripts/browse-card/browse-card-utils.js
@@ -1,5 +1,5 @@
+import { CONTENT_TYPES } from '../data-service/coveo/coveo-exl-pipeline-constants.js';
 import { getConfig } from '../scripts.js';
-import { CONTENT_TYPES } from './browse-cards-constants.js';
 
 const domParser = new DOMParser();
 const { prodAssetsCdnOrigin, cdnOrigin } = getConfig();

--- a/scripts/browse-card/browse-card.js
+++ b/scripts/browse-card/browse-card.js
@@ -1,9 +1,10 @@
 import { decorateIcons, loadCSS } from '../lib-franklin.js';
 import { createTag, htmlToElement, fetchLanguagePlaceholders, getPathDetails } from '../scripts.js';
 import { createTooltip } from './browse-card-tooltip.js';
-import { CONTENT_TYPES, RECOMMENDED_COURSES_CONSTANTS, AUTHOR_TYPE } from './browse-cards-constants.js';
+import { AUTHOR_TYPE, RECOMMENDED_COURSES_CONSTANTS } from './browse-cards-constants.js';
 import { sendCoveoClickEvent } from '../coveo-analytics.js';
 import UserActions from '../user-actions/user-actions.js';
+import { CONTENT_TYPES } from '../data-service/coveo/coveo-exl-pipeline-constants.js';
 
 loadCSS(`${window.hlx.codeBasePath}/scripts/browse-card/browse-card.css`);
 

--- a/scripts/browse-card/browse-cards-adls-adaptor.js
+++ b/scripts/browse-card/browse-cards-adls-adaptor.js
@@ -1,5 +1,5 @@
 import browseCardDataModel from '../data-model/browse-cards-model.js';
-import { CONTENT_TYPES } from './browse-cards-constants.js';
+import { CONTENT_TYPES } from '../data-service/coveo/coveo-exl-pipeline-constants.js';
 import { fetchLanguagePlaceholders, getConfig } from '../scripts.js';
 
 const { adlsUrl } = getConfig();

--- a/scripts/browse-card/browse-cards-constants.js
+++ b/scripts/browse-card/browse-cards-constants.js
@@ -10,49 +10,6 @@ try {
   console.error('Error fetching placeholders:', err);
 }
 
-export const CONTENT_TYPES = Object.freeze({
-  COURSE: {
-    MAPPING_KEY: 'course',
-    LABEL: placeholders.browseCardCourseLabel || 'Course',
-  },
-  TUTORIAL: {
-    MAPPING_KEY: 'tutorial',
-    LABEL: placeholders.browseCardTutorialLabel || 'Tutorial',
-  },
-  DOCUMENTATION: {
-    MAPPING_KEY: 'documentation',
-    LABEL: placeholders.browseCardDocumentationLabel || 'Documentation',
-  },
-  TROUBLESHOOTING: {
-    MAPPING_KEY: 'troubleshooting',
-    LABEL: placeholders.browseCardTroubleshootingLabel || 'Troubleshooting',
-  },
-  EVENT: {
-    MAPPING_KEY: 'event',
-    LABEL: placeholders.browseCardEventLabel || 'On-Demand Event',
-  },
-  COMMUNITY: {
-    MAPPING_KEY: 'community',
-    LABEL: placeholders.browseCardCommunityLabel || 'Community',
-  },
-  CERTIFICATION: {
-    MAPPING_KEY: 'certification',
-    LABEL: placeholders.browseCardCertificationLabel || 'Certification',
-  },
-  LIVE_EVENT: {
-    MAPPING_KEY: 'live-event',
-    LABEL: placeholders.browseCardLiveEventLabel || 'Live Event',
-  },
-  INSTRUCTOR_LED: {
-    MAPPING_KEY: 'instructor-led-training',
-    LABEL: placeholders.browseCardInstructorLedLabel || 'Instructor-Led',
-  },
-  PERSPECTIVE: {
-    MAPPING_KEY: 'perspective',
-    LABEL: placeholders.browseCardPerspectiveLabel || 'Perspective',
-  },
-});
-
 export const COVEO_SORT_OPTIONS = Object.freeze({
   RELEVANCE: 'relevancy',
   MOST_RECENT: 'date descending',
@@ -72,25 +29,6 @@ export const ROLE_OPTIONS = Object.freeze({
   LEADER: 'Leader',
   USER: 'User',
 });
-
-export const COMMUNITY_SEARCH_FACET = Object.freeze([
-  {
-    value: 'Questions',
-    state: 'selected',
-  },
-  {
-    value: 'Discussions',
-    state: 'selected',
-  },
-  {
-    value: 'Ideas',
-    state: 'selected',
-  },
-  {
-    value: 'Blogs',
-    state: 'selected',
-  },
-]);
 
 export const RECOMMENDED_COURSES_CONSTANTS = Object.freeze({
   IN_PROGRESS: {

--- a/scripts/browse-card/browse-cards-coveo-data-adaptor.js
+++ b/scripts/browse-card/browse-cards-coveo-data-adaptor.js
@@ -1,5 +1,5 @@
 import browseCardDataModel from '../data-model/browse-cards-model.js';
-import { CONTENT_TYPES } from './browse-cards-constants.js';
+import { CONTENT_TYPES } from '../data-service/coveo/coveo-exl-pipeline-constants.js';
 import { rewriteDocsPath, fetchLanguagePlaceholders } from '../scripts.js';
 
 /**

--- a/scripts/browse-card/browse-cards-delegate.js
+++ b/scripts/browse-card/browse-cards-delegate.js
@@ -14,6 +14,58 @@ const { liveEventsUrl, adlsUrl, pathsUrl } = getConfig();
 
 const { lang } = getPathDetails();
 
+const fieldsToInclude = [
+  '@foldingchild',
+  '@foldingcollection',
+  '@foldingparent',
+  'author',
+  'author_bio_page',
+  'author_name',
+  'author_type',
+  'authorname',
+  'authortype',
+  'collection',
+  'connectortype',
+  'contenttype',
+  'date',
+  'documenttype',
+  'el_author_type',
+  'el_contenttype',
+  'el_id',
+  'el_interactionstyle',
+  'el_kudo_status',
+  'el_lirank',
+  'el_product',
+  'el_rank_icon',
+  'el_reply_status',
+  'el_solution',
+  'el_solutions_authored',
+  'el_type',
+  'el_usergenerictext',
+  'el_version',
+  'el_view_status',
+  'exl_description',
+  'exl_thumbnail',
+  'filetype',
+  'id',
+  'language',
+  'liMessageLabels',
+  'liboardinteractionstyle',
+  'licommunityurl',
+  'lithreadhassolution',
+  'objecttype',
+  'outlookformacuri',
+  'outlookuri',
+  'permanentid',
+  'role',
+  'source',
+  'sourcetype',
+  'sysdocumenttype',
+  'type',
+  'urihash',
+  'video_url',
+];
+
 /**
  * @module BrowseCardsDelegate
  * @description A module that handles the delegation of fetching card data based on content types.
@@ -33,7 +85,7 @@ const BrowseCardsDelegate = (() => {
    * @private
    */
   const handleCoveoService = async () => {
-    const dataSource = getExlPipelineDataSourceParams(param);
+    const dataSource = getExlPipelineDataSourceParams(param, fieldsToInclude);
     const coveoService = new CoveoDataService(dataSource);
     const cardData = await coveoService.fetchDataFromSource();
     if (!cardData) {

--- a/scripts/browse-card/browse-cards-delegate.js
+++ b/scripts/browse-card/browse-cards-delegate.js
@@ -4,73 +4,16 @@ import ADLSDataService from '../data-service/adls-data-service.js';
 import BrowseCardsCoveoDataAdaptor from './browse-cards-coveo-data-adaptor.js';
 import BrowseCardsLiveEventsAdaptor from './browse-cards-live-events-adaptor.js';
 import BrowseCardsADLSAdaptor from './browse-cards-adls-adaptor.js';
-import { CONTENT_TYPES, COMMUNITY_SEARCH_FACET, RECOMMENDED_COURSES_CONSTANTS } from './browse-cards-constants.js';
+import { CONTENT_TYPES } from '../data-service/coveo/coveo-exl-pipeline-constants.js';
 import PathsDataService from '../data-service/paths-data-service.js';
-import { getConfig, getPathDetails } from '../scripts.js';
+import { URL_SPECIAL_CASE_LOCALES, getConfig, getPathDetails } from '../scripts.js';
+import { getExlPipelineDataSourceParams } from '../data-service/coveo/coveo-exl-pipeline-helpers.js';
+import { RECOMMENDED_COURSES_CONSTANTS } from './browse-cards-constants.js';
 
-const { coveoSearchResultsUrl, liveEventsUrl, adlsUrl, pathsUrl } = getConfig();
+const { liveEventsUrl, adlsUrl, pathsUrl } = getConfig();
 
 const { lang } = getPathDetails();
 
-// Most of these are copied from an existing call. I do not believe we need all of them, so this list could probably be pruned.
-const fieldsToInclude = [
-  '@foldingchild',
-  '@foldingcollection',
-  '@foldingparent',
-  'author',
-  'author_bio_page',
-  'author_name',
-  'author_type',
-  'authorname',
-  'authortype',
-  'collection',
-  'connectortype',
-  'contenttype',
-  'date',
-  'documenttype',
-  'el_author_type',
-  'el_contenttype',
-  'el_id',
-  'el_interactionstyle',
-  'el_kudo_status',
-  'el_lirank',
-  'el_product',
-  'el_rank_icon',
-  'el_reply_status',
-  'el_solution',
-  'el_solutions_authored',
-  'el_type',
-  'el_usergenerictext',
-  'el_version',
-  'el_view_status',
-  'exl_description',
-  'exl_thumbnail',
-  'filetype',
-  'id',
-  'language',
-  'liMessageLabels',
-  'liboardinteractionstyle',
-  'licommunityurl',
-  'lithreadhassolution',
-  'objecttype',
-  'outlookformacuri',
-  'outlookuri',
-  'permanentid',
-  'role',
-  'source',
-  'sourcetype',
-  'sysdocumenttype',
-  'type',
-  'urihash',
-  'video_url',
-];
-
-const locales = new Map([
-  ['es', 'es-ES'],
-  ['pt-br', 'pt-BR'],
-  ['zh-hans', 'zh-CN'],
-  ['zh-hant', 'zh-TW'],
-]);
 /**
  * @module BrowseCardsDelegate
  * @description A module that handles the delegation of fetching card data based on content types.
@@ -84,103 +27,13 @@ const BrowseCardsDelegate = (() => {
   let param = {};
 
   /**
-   * Constructs Coveo facet structure based on provided facets.
-   * @param {Array} facets - An array of facet objects.
-   * @returns {Array} Array of Coveo facet objects.
-   * @private
-   */
-  const constructCoveoFacet = (facets) => {
-    const facetsArray = facets.map((facet) => ({
-      facetId: `@${facet.id}`,
-      field: facet.id,
-      type: facet.type,
-      numberOfValues: facet.currentValues?.length || 2,
-      currentValues: facet.currentValues.map((value) => ({
-        value,
-        state: value === CONTENT_TYPES.COMMUNITY.MAPPING_KEY ? 'idle' : 'selected',
-        ...(value === CONTENT_TYPES.COMMUNITY.MAPPING_KEY ? { children: COMMUNITY_SEARCH_FACET } : []),
-      })),
-    }));
-    return facetsArray;
-  };
-
-  /**
-   * Constructs advanced query for Coveo data service based on query parameters.
-   * @returns {Object} Object containing the advanced query.
-   * @private
-   */
-  const constructCoveoAdvancedQuery = () => {
-    const featureQuery = param.feature
-      ? `(${param.feature.map((type) => `@el_features=="${type}"`).join(' OR ')})`
-      : '';
-    const contentTypeQuery = param.contentType
-      ? `AND (${param.contentType.map((type) => `@el_contenttype=="${type}"`).join(' OR ')})`
-      : '';
-    const productQuery = param.product
-      ? `AND (${param.product.map((type) => `@el_product=="${type}"`).join(' OR ')})`
-      : '';
-    const versionQuery = param.version
-      ? `AND (${param.version.map((type) => `@el_version=="${type}"`).join(' OR ')})`
-      : '';
-    const roleQuery = param.role ? `AND (${param.role.map((type) => `@el_role=="${type}"`).join(' OR ')})` : '';
-    const levelQuery = param.level ? `AND (${param.level.map((type) => `@el_level=="${type}"`).join(' OR ')})` : '';
-    const authorTypeQuery = param.authorType
-      ? `AND (${param.authorType.map((type) => `@author_type=="${type}"`).join(' OR ')})`
-      : '';
-    const query = `${featureQuery} ${contentTypeQuery} ${productQuery} ${versionQuery} ${roleQuery} ${levelQuery} ${authorTypeQuery}`;
-    return query;
-  };
-
-  /**
-   * Constructs advanced query for Coveo data service based on date array.
-   * @param {Array} dateCriteria - Array of date values.
-   * @returns {string} Advanced query string for date.
-   */
-  const contructDateAdvancedQuery = (dateCriteria) => `@date==(${dateCriteria.join(',')})`;
-
-  /**
    * Handles Coveo data service to fetch card data.
    * @returns {Array} Array of card data.
    * @throws {Error} Throws an error if an issue occurs during data fetching.
    * @private
    */
   const handleCoveoService = async () => {
-    const facets = [
-      ...(param.contentType
-        ? [
-            {
-              id: 'el_contenttype',
-              type: param.contentType[0] === CONTENT_TYPES.COMMUNITY.MAPPING_KEY ? 'hierarchical' : 'specific',
-              currentValues: param.contentType,
-            },
-          ]
-        : []),
-      ...(param.product ? [{ id: 'el_product', type: 'specific', currentValues: param.product }] : []),
-      ...(param.version ? [{ id: 'el_version', type: 'specific', currentValues: param.version }] : []),
-      ...(param.role ? [{ id: 'el_role', type: 'specific', currentValues: param.role }] : []),
-      ...(param.authorType ? [{ id: 'author_type', type: 'specific', currentValues: param.authorType }] : []),
-      ...(param.level ? [{ id: 'el_level', type: 'specific', currentValues: param.level }] : []),
-    ];
-
-    const dataSource = {
-      url: coveoSearchResultsUrl,
-      param: {
-        locale: locales.get(document.querySelector('html').lang) || document.querySelector('html').lang || 'en',
-        searchHub: `Experience League Learning Hub`,
-        numberOfResults: param.noOfResults,
-        excerptLength: 200,
-        sortCriteria: param.sortCriteria,
-        context: { entitlements: {}, role: {}, interests: {}, industryInterests: {} },
-        filterField: '@foldingcollection',
-        parentField: '@foldingchild',
-        childField: '@foldingparent',
-        ...(param.q && !param.feature ? { q: param.q } : ''),
-        ...(param.dateCriteria && !param.feature ? { aq: contructDateAdvancedQuery(param.dateCriteria) } : ''),
-        ...(!param.feature ? { facets: constructCoveoFacet(facets) } : ''),
-        ...(param.feature ? { aq: constructCoveoAdvancedQuery() } : ''),
-        fieldsToInclude,
-      },
-    };
+    const dataSource = getExlPipelineDataSourceParams(param);
     const coveoService = new CoveoDataService(dataSource);
     const cardData = await coveoService.fetchDataFromSource();
     if (!cardData) {
@@ -260,7 +113,7 @@ const BrowseCardsDelegate = (() => {
    * @private
    */
   const constructPathsSearchParams = () => {
-    const languageParam = locales.get(lang) || lang;
+    const languageParam = URL_SPECIAL_CASE_LOCALES.get(lang) || lang;
     const urlSearchParams = new URLSearchParams();
     urlSearchParams.append('page_size', '200');
     urlSearchParams.append('sort', 'Order,Solution,ID');

--- a/scripts/browse-card/browse-cards-live-events-adaptor.js
+++ b/scripts/browse-card/browse-cards-live-events-adaptor.js
@@ -1,6 +1,6 @@
 import browseCardDataModel from '../data-model/browse-cards-model.js';
+import { CONTENT_TYPES } from '../data-service/coveo/coveo-exl-pipeline-constants.js';
 import { fetchLanguagePlaceholders } from '../scripts.js';
-import { CONTENT_TYPES } from './browse-cards-constants.js';
 
 /**
  * Module that provides functionality for adapting live event results to BrowseCards data model.

--- a/scripts/browse-card/browse-cards-paths-adaptor.js
+++ b/scripts/browse-card/browse-cards-paths-adaptor.js
@@ -1,6 +1,7 @@
 import browseCardDataModel from '../data-model/browse-cards-model.js';
-import { CONTENT_TYPES, RECOMMENDED_COURSES_CONSTANTS } from './browse-cards-constants.js';
+import {RECOMMENDED_COURSES_CONSTANTS } from './browse-cards-constants.js';
 import { fetchLanguagePlaceholders, getConfig } from '../scripts.js';
+import { CONTENT_TYPES } from '../data-service/coveo/coveo-exl-pipeline-constants.js';
 
 const { recommendedCoursesUrl, prodAssetsCdnOrigin } = getConfig();
 /**

--- a/scripts/browse-card/browse-cards-paths-adaptor.js
+++ b/scripts/browse-card/browse-cards-paths-adaptor.js
@@ -1,5 +1,5 @@
 import browseCardDataModel from '../data-model/browse-cards-model.js';
-import {RECOMMENDED_COURSES_CONSTANTS } from './browse-cards-constants.js';
+import { RECOMMENDED_COURSES_CONSTANTS } from './browse-cards-constants.js';
 import { fetchLanguagePlaceholders, getConfig } from '../scripts.js';
 import { CONTENT_TYPES } from '../data-service/coveo/coveo-exl-pipeline-constants.js';
 

--- a/scripts/data-service/coveo/coveo-exl-pipeline-constants.js
+++ b/scripts/data-service/coveo/coveo-exl-pipeline-constants.js
@@ -1,0 +1,71 @@
+import { fetchLanguagePlaceholders } from '../../scripts.js';
+
+let placeholders = {};
+try {
+  placeholders = await fetchLanguagePlaceholders();
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.error('Error fetching placeholders:', err);
+}
+
+export const COMMUNITY_SEARCH_FACET = Object.freeze([
+  {
+    value: 'Questions',
+    state: 'selected',
+  },
+  {
+    value: 'Discussions',
+    state: 'selected',
+  },
+  {
+    value: 'Ideas',
+    state: 'selected',
+  },
+  {
+    value: 'Blogs',
+    state: 'selected',
+  },
+]);
+
+export const CONTENT_TYPES = Object.freeze({
+  COURSE: {
+    MAPPING_KEY: 'course',
+    LABEL: placeholders.browseCardCourseLabel || 'Course',
+  },
+  TUTORIAL: {
+    MAPPING_KEY: 'tutorial',
+    LABEL: placeholders.browseCardTutorialLabel || 'Tutorial',
+  },
+  DOCUMENTATION: {
+    MAPPING_KEY: 'documentation',
+    LABEL: placeholders.browseCardDocumentationLabel || 'Documentation',
+  },
+  TROUBLESHOOTING: {
+    MAPPING_KEY: 'troubleshooting',
+    LABEL: placeholders.browseCardTroubleshootingLabel || 'Troubleshooting',
+  },
+  EVENT: {
+    MAPPING_KEY: 'event',
+    LABEL: placeholders.browseCardEventLabel || 'On-Demand Event',
+  },
+  COMMUNITY: {
+    MAPPING_KEY: 'community',
+    LABEL: placeholders.browseCardCommunityLabel || 'Community',
+  },
+  CERTIFICATION: {
+    MAPPING_KEY: 'certification',
+    LABEL: placeholders.browseCardCertificationLabel || 'Certification',
+  },
+  LIVE_EVENT: {
+    MAPPING_KEY: 'live-event',
+    LABEL: placeholders.browseCardLiveEventLabel || 'Live Event',
+  },
+  INSTRUCTOR_LED: {
+    MAPPING_KEY: 'instructor-led-training',
+    LABEL: placeholders.browseCardInstructorLedLabel || 'Instructor-Led',
+  },
+  PERSPECTIVE: {
+    MAPPING_KEY: 'perspective',
+    LABEL: placeholders.browseCardPerspectiveLabel || 'Perspective',
+  },
+});

--- a/scripts/data-service/coveo/coveo-exl-pipeline-helpers.js
+++ b/scripts/data-service/coveo/coveo-exl-pipeline-helpers.js
@@ -303,7 +303,7 @@ export async function exlPipelineCoveoDataAdaptor(params) {
 
   const queryData = {
     searchUid: data.searchUid,
-    totalCount: data.totalCount
-  }
+    totalCount: data.totalCount,
+  };
   return data.map((result, index) => mapResultsDataModel(result, index, queryData)) || [];
 }

--- a/scripts/data-service/coveo/coveo-exl-pipeline-helpers.js
+++ b/scripts/data-service/coveo/coveo-exl-pipeline-helpers.js
@@ -1,0 +1,298 @@
+import { URL_SPECIAL_CASE_LOCALES, fetchLanguagePlaceholders, getConfig, rewriteDocsPath } from '../../scripts.js';
+import CoveoDataService from './coveo-data-service.js';
+import { CONTENT_TYPES, COMMUNITY_SEARCH_FACET } from './coveo-exl-pipeline-constants.js';
+
+const { coveoSearchResultsUrl } = getConfig();
+
+// Most of these are copied from an existing call. I do not believe we need all of them, so this list could probably be pruned.
+const fieldsToInclude = [
+  '@foldingchild',
+  '@foldingcollection',
+  '@foldingparent',
+  'author',
+  'author_bio_page',
+  'author_name',
+  'author_type',
+  'authorname',
+  'authortype',
+  'collection',
+  'connectortype',
+  'contenttype',
+  'date',
+  'documenttype',
+  'el_author_type',
+  'el_contenttype',
+  'el_id',
+  'el_interactionstyle',
+  'el_kudo_status',
+  'el_lirank',
+  'el_product',
+  'el_rank_icon',
+  'el_reply_status',
+  'el_solution',
+  'el_solutions_authored',
+  'el_type',
+  'el_usergenerictext',
+  'el_version',
+  'el_view_status',
+  'exl_description',
+  'exl_thumbnail',
+  'filetype',
+  'id',
+  'language',
+  'liMessageLabels',
+  'liboardinteractionstyle',
+  'licommunityurl',
+  'lithreadhassolution',
+  'objecttype',
+  'outlookformacuri',
+  'outlookuri',
+  'permanentid',
+  'role',
+  'source',
+  'sourcetype',
+  'sysdocumenttype',
+  'type',
+  'urihash',
+  'video_url',
+];
+
+/**
+ * Constructs advanced query for Coveo data service based on date array.
+ * @param {Array} dateCriteria - Array of date values.
+ * @returns {string} Advanced query string for date.
+ */
+function contructDateAdvancedQuery(dateCriteria) {
+  return `@date==(${dateCriteria.join(',')})`;
+}
+
+/**
+ * Constructs Coveo facet structure based on provided facets.
+ * @param {Array} facets - An array of facet objects.
+ * @returns {Array} Array of Coveo facet objects.
+ * @private
+ */
+function constructCoveoFacet(facets) {
+  const facetsArray = facets.map((facet) => ({
+    facetId: `@${facet.id}`,
+    field: facet.id,
+    type: facet.type,
+    numberOfValues: facet.currentValues?.length || 2,
+    currentValues: facet.currentValues.map((value) => ({
+      value,
+      state: value === CONTENT_TYPES.COMMUNITY.MAPPING_KEY ? 'idle' : 'selected',
+      ...(value === CONTENT_TYPES.COMMUNITY.MAPPING_KEY ? { children: COMMUNITY_SEARCH_FACET } : []),
+    })),
+  }));
+  return facetsArray;
+}
+
+/**
+ * Constructs advanced query for Coveo data service based on query parameters.
+ * @returns {Object} Object containing the advanced query.
+ * @private
+ */
+function constructCoveoAdvancedQuery(param) {
+  const featureQuery = param.feature ? `(${param.feature.map((type) => `@el_features=="${type}"`).join(' OR ')})` : '';
+  const contentTypeQuery = param.contentType
+    ? `AND (${param.contentType.map((type) => `@el_contenttype=="${type}"`).join(' OR ')})`
+    : '';
+  const productQuery = param.product
+    ? `AND (${param.product.map((type) => `@el_product=="${type}"`).join(' OR ')})`
+    : '';
+  const versionQuery = param.version
+    ? `AND (${param.version.map((type) => `@el_version=="${type}"`).join(' OR ')})`
+    : '';
+  const roleQuery = param.role ? `AND (${param.role.map((type) => `@el_role=="${type}"`).join(' OR ')})` : '';
+  const levelQuery = param.level ? `AND (${param.level.map((type) => `@el_level=="${type}"`).join(' OR ')})` : '';
+  const authorTypeQuery = param.authorType
+    ? `AND (${param.authorType.map((type) => `@author_type=="${type}"`).join(' OR ')})`
+    : '';
+  const query = `${featureQuery} ${contentTypeQuery} ${productQuery} ${versionQuery} ${roleQuery} ${levelQuery} ${authorTypeQuery}`;
+  return query;
+}
+
+/**
+ * Get facet array based off a param object
+ * @param {*} param
+ * @returns
+ */
+export function getFacets(param) {
+  const facets = [
+    ...(param.contentType
+      ? [
+          {
+            id: 'el_contenttype',
+            type: param.contentType[0] === CONTENT_TYPES.COMMUNITY.MAPPING_KEY ? 'hierarchical' : 'specific',
+            currentValues: param.contentType,
+          },
+        ]
+      : []),
+    ...(param.product ? [{ id: 'el_product', type: 'specific', currentValues: param.product }] : []),
+    ...(param.version ? [{ id: 'el_version', type: 'specific', currentValues: param.version }] : []),
+    ...(param.role ? [{ id: 'el_role', type: 'specific', currentValues: param.role }] : []),
+    ...(param.authorType ? [{ id: 'author_type', type: 'specific', currentValues: param.authorType }] : []),
+    ...(param.level ? [{ id: 'el_level', type: 'specific', currentValues: param.level }] : []),
+  ];
+
+  return constructCoveoFacet(facets);
+}
+
+export function getExlPipelineDataSourceParams(param) {
+  return {
+    url: coveoSearchResultsUrl,
+    param: {
+      locale:
+        URL_SPECIAL_CASE_LOCALES.get(document.querySelector('html').lang) ||
+        document.querySelector('html').lang ||
+        'en',
+      searchHub: `Experience League Learning Hub`,
+      numberOfResults: param.noOfResults,
+      excerptLength: 200,
+      sortCriteria: param.sortCriteria,
+      context: { entitlements: {}, role: {}, interests: {}, industryInterests: {} },
+      filterField: '@foldingcollection',
+      parentField: '@foldingchild',
+      childField: '@foldingparent',
+      ...(param.q && !param.feature ? { q: param.q } : ''),
+      ...(param.dateCriteria && !param.feature ? { aq: contructDateAdvancedQuery(param.dateCriteria) } : ''),
+      ...(!param.feature ? { facets: getFacets(param) } : ''),
+      ...(param.feature ? { aq: constructCoveoAdvancedQuery(param) } : ''),
+      fieldsToInclude,
+    },
+  };
+}
+
+export async function exlPipelineCoveoDataAdaptor(params) {
+  let placeholders = {};
+
+  try {
+    placeholders = await fetchLanguagePlaceholders();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching placeholders:', err);
+  }
+
+  const dataSourceParams = getExlPipelineDataSourceParams(params);
+  const coveoService = new CoveoDataService(dataSourceParams);
+  const data = await coveoService.fetchDataFromSource();
+
+  /**
+   * Converts a string to title case.
+   * @param {string} str - The input string.
+   * @returns {string} The string in title case.
+   */
+  const convertToTitleCase = (str) => (str ? str.replace(/\b\w/g, (match) => match.toUpperCase()) : '');
+
+  /**
+   * Creates tags based on the result and content type.
+   * @param {Object} result - The result object.
+   * @param {string} contentType - The content type.
+   * @returns {Array} An array of tags.
+   */
+  const createTags = (result, contentType) => {
+    const tags = [];
+    const role = result?.raw?.role ? result.raw.role.replace(/,/g, ', ') : '';
+    if (contentType === CONTENT_TYPES.COURSE.MAPPING_KEY) {
+      tags.push({ icon: 'user', text: role || '' });
+      /* TODO: Will enable once we have the API changes ready from ExL */
+      // tags.push({ icon: 'book', text: `0 ${placeholders.lesson}` });
+    } else {
+      tags.push({
+        icon: result?.parentResult?.raw?.el_view_status || result?.raw?.el_view_status ? 'view' : '',
+        text: result?.parentResult?.raw?.el_view_status || result?.raw?.el_view_status || '',
+      });
+      tags.push({
+        icon: result?.parentResult?.raw?.el_reply_status || result?.raw?.el_reply_status ? 'reply' : '',
+        text: result?.parentResult?.raw?.el_reply_status || result?.raw?.el_reply_status || '',
+      });
+    }
+    return tags;
+  };
+
+  /**
+   * Removes duplicate items from an array of products/solutions (with sub-solutions)
+   * @param {Array} products - Array of products to remove duplicates from.
+   * @returns {Array} - Array of unique products.
+   */
+  const removeProductDuplicates = (products) => {
+    const filteredProducts = [];
+    for (let outerIndex = 0; outerIndex < products.length; outerIndex += 1) {
+      const currentItem = products[outerIndex];
+      let isDuplicate = false;
+      for (let innerIndex = 0; innerIndex < products.length; innerIndex += 1) {
+        if (outerIndex !== innerIndex && products[innerIndex].startsWith(currentItem)) {
+          isDuplicate = true;
+          break;
+        }
+      }
+      if (!isDuplicate) {
+        const product = products[outerIndex].replace(/\|/g, ' ');
+        filteredProducts.push(product);
+      }
+    }
+    return filteredProducts;
+  };
+
+  /**
+   * Maps a result to the data model.
+   * @param {Object} result - The result object.
+   * @param {Number} index - The index of the result object in the source array.
+   * @param {string} searchUid - If the data comes from coveo, provide the searchUid
+   * @returns {Object} The BrowseCards data model.
+   */
+  const mapResultsDataModel = (result, index, searchUid) => {
+    const { raw, parentResult, title, excerpt, clickUri, uri } = result || {};
+    /* eslint-disable camelcase */
+
+    const { el_id, el_contenttype, el_product, el_solution, el_type } = parentResult?.raw || raw || {};
+    let contentType;
+    if (el_type) {
+      contentType = el_type.trim();
+    } else {
+      contentType = Array.isArray(el_contenttype) ? el_contenttype[0]?.trim() : el_contenttype?.trim();
+    }
+    let products;
+    if (el_solution) {
+      products = Array.isArray(el_solution) ? el_solution : el_solution.split(/,\s*/);
+    } else if (el_product) {
+      products = Array.isArray(el_product) ? el_product : el_product.split(/,\s*/);
+    }
+    const tags = createTags(result, contentType?.toLowerCase());
+    let url = parentResult?.clickUri || parentResult?.uri || clickUri || uri || '';
+    url = rewriteDocsPath(url);
+    const contentTypeTitleCase = convertToTitleCase(contentType?.toLowerCase());
+
+    return {
+      ...raw,
+      id: parentResult?.el_id || el_id || '',
+      contentType,
+      badgeTitle: contentType ? CONTENT_TYPES[contentType.toUpperCase()]?.LABEL : '',
+      thumbnail:
+        raw?.exl_thumbnail ||
+        (raw?.video_url &&
+          (raw.video_url.includes('?')
+            ? raw.video_url.replace(/\?.*/, '?format=jpeg')
+            : `${raw.video_url}?format=jpeg`)) ||
+        '',
+      product: products && removeProductDuplicates(products),
+      title: parentResult?.title || title || '',
+      description:
+        contentType?.toLowerCase() === CONTENT_TYPES.PERSPECTIVE.MAPPING_KEY
+          ? raw?.exl_description || parentResult?.excerpt || ''
+          : parentResult?.excerpt || excerpt || raw?.description || raw?.exl_description || '',
+      tags,
+      copyLink: url,
+      viewLink: url,
+      viewLinkText: placeholders[`browseCard${contentTypeTitleCase}ViewLabel`] || 'View',
+      searchUid,
+      index,
+      authorInfo: {
+        name: raw?.author_name || '',
+        type: raw?.author_type || '',
+      },
+    };
+  };
+
+  return data.map((result, index) => mapResultsDataModel(result, index, data.searchUid)) || [];
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -857,6 +857,13 @@ export const locales = new Map([
   ['sv', 'sv_SE'],
 ]);
 
+export const URL_SPECIAL_CASE_LOCALES = new Map([
+  ['es', 'es-ES'],
+  ['pt-br', 'pt-BR'],
+  ['zh-hans', 'zh-CN'],
+  ['zh-hant', 'zh-TW'],
+]);
+
 export async function loadIms() {
   const { ims } = getConfig();
   window.imsLoaded =


### PR DESCRIPTION
This is to enable the creation of wrappers for additional pipelines or other data sources in the future and the ability to fetch exl pipeline queries without relying on browse card specific code.

Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://browse-card-split--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
