### PR TITLE
EXLM 2087 - Retrieve profile from session storage due to issue in safari

### DIFF
--- a/scripts/profile/personalized-home.js
+++ b/scripts/profile/personalized-home.js
@@ -1,5 +1,4 @@
 import { getPathDetails, htmlToElement } from '../scripts.js';
-import { defaultProfileClient } from '../auth/profile.js';
 import { loadBlocks, decorateSections, decorateBlocks, decorateIcons } from '../lib-franklin.js';
 
 const { lang, suffix } = getPathDetails();
@@ -64,14 +63,18 @@ export default async function classifyProfileAndFetchContent() {
       );
       const loader = htmlToElement('<div class="section profile-shimmer"><span></span></div>');
       document.querySelector('main').appendChild(loader);
-      defaultProfileClient.getMergedProfile().then(async (profileData) => {
+      const profileDataString = sessionStorage.getItem('profile');
+      const profileData = JSON.parse(profileDataString);
+      if (profileData) {
         if (profileData.interests.length) {
           await fetchPageContent(paths.completePageURL, loader);
         } else {
           await fetchPageContent(paths.incompletePageURL, loader);
         }
         await fetchCommonContent(loader);
-      });
+      } else {
+        throw new Error('Profile Data not found in session storage');
+      }
     }
   } catch (err) {
     /* eslint-disable-next-line no-console */


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: https://jira.corp.adobe.com/browse/EXLM-2087 

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.live
- After: https://exlm-2087--exlm--adobe-experience-league.hlx.live
