### PR TITLE
UGP-10849 Expand All Switch

### DIFF
--- a/blocks/switch/switch.css
+++ b/blocks/switch/switch.css
@@ -1,0 +1,87 @@
+.spectrum-switch {
+  display: inline-flex;
+  align-items: flex-start;
+  position: relative;
+  min-block-size: 24px; /* Small size height */
+  max-inline-size: 100%;
+  vertical-align: top;
+  /* Hover state */
+  /* Checked state */
+  /* Focus-visible state */
+  /* Disabled state */
+}
+.spectrum-switch .spectrum-switch-input {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  z-index: 1;
+  cursor: pointer;
+}
+.spectrum-switch .spectrum-switch-input:disabled {
+  cursor: default;
+}
+.spectrum-switch .spectrum-switch-switch {
+  display: inline-block;
+  position: relative;
+  box-sizing: border-box;
+  width: 32px; /* Small size width */
+  height: 16px; /* Small size height */
+  background-color: #e6e6e6;
+  border-radius: 8px;
+  transition: background 0.2s ease-in-out, border 0.2s ease-in-out;
+}
+.spectrum-switch .spectrum-switch-switch::before {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background-color: white;
+  border-radius: 50%;
+  transition: transform 0.2s ease-in-out;
+  top: 0;
+  left: 0;
+  border-width: 2px;
+  border-style: solid;
+}
+.spectrum-switch .spectrum-switch-switch::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 12px;
+  margin: 0;
+  transition: opacity 0.2s ease-out, margin 0.2s ease-out;
+}
+.spectrum-switch:hover .spectrum-switch-switch {
+  background-color: #d9d9d9;
+}
+.spectrum-switch:hover .spectrum-switch-switch::before {
+  border-color: #999;
+}
+.spectrum-switch .spectrum-switch-input:checked + .spectrum-switch-switch {
+  background-color: #007acb;
+}
+.spectrum-switch .spectrum-switch-input:checked + .spectrum-switch-switch::before {
+  background-color: #fff;
+  border-color: #007acb;
+  transform: translateX(100%);
+}
+.spectrum-switch .spectrum-switch-input:focus-visible + .spectrum-switch-switch::after {
+  margin: -3px;
+}
+.spectrum-switch .spectrum-switch-input:disabled + .spectrum-switch-switch {
+  background-color: #cccccc;
+}
+.spectrum-switch .spectrum-switch-input:disabled + .spectrum-switch-switch::before {
+  border-color: #999;
+}
+.spectrum-switch .spectrum-switch-label {
+  margin-inline: 8px;
+  font-size: 12px; /* Small font size */
+  line-height: 1.5;
+  color: #333;
+  transition: color 0.2s ease-in-out;
+}

--- a/blocks/switch/switch.scss
+++ b/blocks/switch/switch.scss
@@ -1,0 +1,101 @@
+.spectrum-switch {
+  display: inline-flex;
+  align-items: flex-start;
+  position: relative;
+  min-block-size: 24px; /* Small size height */
+  max-inline-size: 100%;
+  vertical-align: top;
+
+  .spectrum-switch-input {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    z-index: 1;
+    cursor: pointer;
+
+    &:disabled {
+      cursor: default;
+    }
+  }
+
+  .spectrum-switch-switch {
+    display: inline-block;
+    position: relative;
+    box-sizing: border-box;
+    width: 32px; /* Small size width */
+    height: 16px; /* Small size height */
+    background-color: #e6e6e6;
+    border-radius: 8px;
+    transition:
+      background 0.2s ease-in-out,
+      border 0.2s ease-in-out;
+
+    &::before {
+      content: '';
+      position: absolute;
+      width: 12px;
+      height: 12px;
+      background-color: white;
+      border-radius: 50%;
+      transition: transform 0.2s ease-in-out;
+      top: 0;
+      left: 0;
+      border-width: 2px;
+      border-style: solid;
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: 12px;
+      margin: 0;
+      transition:
+        opacity 0.2s ease-out,
+        margin 0.2s ease-out;
+    }
+  }
+
+  /* Hover state */
+  &:hover .spectrum-switch-switch {
+    background-color: #d9d9d9;
+
+    &::before {
+      border-color: #999;
+    }
+  }
+
+  /* Checked state */
+  .spectrum-switch-input:checked + .spectrum-switch-switch {
+    background-color: #007acb;
+
+    &::before {
+      background-color: #fff;
+      border-color: #007acb;
+      transform: translateX(100%);
+    }
+  }
+
+  /* Focus-visible state */
+  .spectrum-switch-input:focus-visible + .spectrum-switch-switch::after {
+    margin: -3px;
+  }
+
+  /* Disabled state */
+  .spectrum-switch-input:disabled + .spectrum-switch-switch {
+    background-color: #ccc;
+
+    &::before {
+      border-color: #999;
+    }
+  }
+
+  .spectrum-switch-label {
+    margin-inline: 8px;
+    font-size: 12px; /* Small font size */
+    line-height: 1.5;
+    color: #333;
+    transition: color 0.2s ease-in-out;
+  }
+}

--- a/blocks/toc/toc.css
+++ b/blocks/toc/toc.css
@@ -1,4 +1,5 @@
 @import './toc-solutions.css';
+@import '../switch/switch.css';
 
 .toc {
     position: relative;
@@ -64,16 +65,26 @@
 }
 
 .toc-header {
-    align-items: center;
     display: flex;
+    flex-direction: column;
+    align-self: normal;
     box-sizing: border-box;
     width: 100%;
     min-height: 32px;
-    padding: 1em 0 2em 8px;
+    padding: 1em 0 1em var(--spectrum-spacing-200);
+}
+
+.toc-header > .toc-header-content {
+    display: flex;
+    align-items: center;
+}
+
+.toc-header > .toc-header-actions {
+    margin-top: var(--spectrum-spacing-300);
 }
 
 
-.toc-header > span.icon {
+.toc-header-content > span.icon {
     width: 42px;
     height: 42px;
     border-radius: 50%;
@@ -84,7 +95,7 @@
     flex: none;
 }
 
-.toc-header > h3 {
+.toc-header-content > h3 {
     font-size: var(--spectrum-font-size-300);
     margin: 0;
 }


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID: UGP-10849

As an experienced user of documentation who is familiar with my product(s) tables of content, I want to be able to always see all items in the table of contents so that I have to expend less effort clicking to find the headlines I want. 

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/experience-manager-65/content/commerce/storefront/authoring/authoring-commerce-experiences
- After: https://feature-ugp-10849--exlm--adobe-experience-league.hlx.page/en/docs/experience-manager-65/content/commerce/storefront/authoring/authoring-commerce-experiences
