### PR TITLE
Fix extra vertical spacing between playlist items and header

### DIFF
--- a/blocks/playlist/playlist.css
+++ b/blocks/playlist/playlist.css
@@ -83,6 +83,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  margin: 0 !important;
 }
 
 .playlist {


### PR DESCRIPTION
Please always provide the Jira Issue your PR is for, as well as test URLs where your change can be observed (before and after):

Jira ID:

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/playlists/advanced-tasks-in-adobe-acrobat?martech=off
- After: https://ugp-11746--exlm--adobe-experience-league.hlx.page/en/playlists/advanced-tasks-in-adobe-acrobat?martech=off
