### PR TITLE
Better theme handling for docs and other pages/themes

### DIFF
--- a/blocks/browse-filters/browse-filters.js
+++ b/blocks/browse-filters/browse-filters.js
@@ -5,7 +5,7 @@ import {
   debounce,
   getPathDetails,
   fetchLanguagePlaceholders,
-  isArticleLandingPage,
+  matchesAnyTheme,
 } from '../../scripts/scripts.js';
 import {
   roleOptions,
@@ -52,6 +52,10 @@ try {
 } catch (err) {
   // eslint-disable-next-line no-console
   console.error('Error fetching placeholders:', err);
+}
+
+function isArticleLandingPage() {
+  return matchesAnyTheme(/^article-.*/);
 }
 
 // Helper function thats returns a list of all Featured Card Products //

--- a/blocks/mini-toc/mini-toc.js
+++ b/blocks/mini-toc/mini-toc.js
@@ -1,4 +1,4 @@
-import { debounce, fetchLanguagePlaceholders, isArticlePage } from '../../scripts/scripts.js';
+import { debounce, fetchLanguagePlaceholders, isPerspectivePage } from '../../scripts/scripts.js';
 import { highlight, setLevels, hashFragment } from './utils.js';
 import Dropdown, { DROPDOWN_VARIANTS } from '../../scripts/dropdown/dropdown.js';
 
@@ -29,7 +29,7 @@ function getHeadingLevels() {
 function buildMiniToc(block, placeholders) {
   const miniTOCHeading = placeholders?.onThisPage;
   const render = window.requestAnimationFrame;
-  const miniTocQuerySelection = isArticlePage() ? '.article-content-section' : 'main';
+  const miniTocQuerySelection = isPerspectivePage ? '.article-content-section' : 'main';
   const headingLevels = getHeadingLevels();
   const selectorQuery = headingLevels
     .split(',')
@@ -51,7 +51,7 @@ function buildMiniToc(block, placeholders) {
       let lactive = false;
       const anchors = Array.from(block.querySelectorAll('a'));
 
-      if (isArticlePage()) {
+      if (isPerspectivePage) {
         const anchorTexts = anchors.map((anchor) => {
           const content = anchor.textContent;
           return {
@@ -174,7 +174,7 @@ export default async function decorate(block) {
 
   if (window.hlx.aemRoot) {
     // This is strictly for UE flow for capturing the updates made to header tags and re-render Mini-TOC
-    const miniTocQuerySelection = isArticlePage() ? '.article-content-section' : 'main';
+    const miniTocQuerySelection = isPerspectivePage ? '.article-content-section' : 'main';
     const baseEl = block.closest(miniTocQuerySelection) ?? document;
     observeElementHeadingChanges(baseEl, block, placeholders);
   }

--- a/blocks/mini-toc/utils.js
+++ b/blocks/mini-toc/utils.js
@@ -1,4 +1,4 @@
-import { isDocPage } from '../../scripts/scripts.js';
+import { matchesAnyTheme } from '../../scripts/scripts.js';
 
 export function setLevels(val = 2) {
   const selectors = [];
@@ -9,7 +9,7 @@ export function setLevels(val = 2) {
   }
 
   for (let i = val; i >= 1; i -= 1) {
-    if (isDocPage('docs-solution-landing') && i + 1 >= 3) {
+    if (matchesAnyTheme(/docs-solution-landing/) && i + 1 >= 3) {
       // eslint-disable-next-line no-continue
       continue; // Skip levels h3, h4, h5, h6 on docs-solution-landing pages
     }

--- a/blocks/toc/toc.js
+++ b/blocks/toc/toc.js
@@ -5,6 +5,7 @@ import {
   getLanguageCode,
   createPlaceholderSpan,
   getConfig,
+  matchesAnyTheme,
 } from '../../scripts/scripts.js';
 import getSolutionByName from './toc-solutions.js';
 
@@ -163,6 +164,7 @@ function activateCurrentPage(tocContent) {
  * @param {Element} block The toc block element
  */
 export default async function decorate(block) {
+  if (matchesAnyTheme(/kb-article/)) return;
   const tocID = block.querySelector('.toc > div > div').textContent;
   if (!tocID && document.querySelector('.toc-dropdown')) return;
   block.innerHTML = ''; // start clean

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -9,7 +9,7 @@ import {
   getMetadata,
 } from './lib-franklin.js';
 import { decorateRichtext } from './editor-support-rte.js';
-import { decorateMain, isArticlePage, loadArticles, loadIms } from './scripts.js';
+import { decorateMain, isPerspectivePage, loadArticles, loadIms } from './scripts.js';
 
 // set aem content root
 window.hlx.aemRoot = '/content/exlm/global';
@@ -178,7 +178,7 @@ async function applyChanges(event) {
     if (element.matches('main')) {
       const newMain = parsedUpdate.querySelector(`[data-aue-resource="${resource}"]`);
       newMain.style.display = 'none';
-      if (isArticlePage()) {
+      if (isPerspectivePage) {
         element.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((heading) => {
           heading.classList.add('no-mtoc');
         });

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -358,7 +358,7 @@ export function decorateSections(main) {
  * @param {Element} main The container element
  */
 export function updateSectionsStatus(main) {
-  const sections = [...main.querySelectorAll(':scope > div.section')];
+  const sections = [...main.querySelectorAll('div.section')];
   for (let i = 0; i < sections.length; i += 1) {
     const section = sections[i];
     const status = section.dataset.sectionStatus;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -891,7 +891,7 @@ picture[align=right] {
   padding: 30px 16px;
   /* section metadata */
 }
-.section.browse-filters-container[data-section-status=loading], .section.browse-filters-container[data-section-status=initialized], .section.curated-cards-container[data-section-status=loading], .section.curated-cards-container[data-section-status=initialized], .section.events-cards-container[data-section-status=loading], .section.events-cards-container[data-section-status=initialized], .section.adls-cards-container[data-section-status=loading], .section.adls-cards-container[data-section-status=initialized], .section.authorable-card-container[data-section-status=loading], .section.authorable-card-container[data-section-status=initialized], .section.featured-cards-container[data-section-status=loading], .section.featured-cards-container[data-section-status=initialized] {
+.section:not([data-section-status=loaded]) {
   visibility: hidden;
 }
 .section > .default-content-wrapper:last-child > p:last-child {

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -785,18 +785,7 @@ picture {
 .section {
   padding: 30px 16px;
 
-  &.browse-filters-container[data-section-status='loading'],
-  &.browse-filters-container[data-section-status='initialized'],
-  &.curated-cards-container[data-section-status='loading'],
-  &.curated-cards-container[data-section-status='initialized'],
-  &.events-cards-container[data-section-status='loading'],
-  &.events-cards-container[data-section-status='initialized'],
-  &.adls-cards-container[data-section-status='loading'],
-  &.adls-cards-container[data-section-status='initialized'],
-  &.authorable-card-container[data-section-status='loading'],
-  &.authorable-card-container[data-section-status='initialized'],
-  &.featured-cards-container[data-section-status='loading'],
-  &.featured-cards-container[data-section-status='initialized'] {
+  &:not([data-section-status='loaded']) {
     visibility: hidden;
   }
 

--- a/styles/theme/docs-solution-landing.css
+++ b/styles/theme/docs-solution-landing.css
@@ -49,7 +49,7 @@
 .docs.docs-solution-landing main .section > div.default-content-wrapper {
   max-width: 100%;
 }
-.docs.docs-solution-landing main > div:first-child {
+.docs.docs-solution-landing main > div:nth-child(2) {
   border: none;
   gap: 0;
 }
@@ -57,7 +57,7 @@
   .docs.docs-solution-landing main {
     padding: 0;
   }
-  .docs.docs-solution-landing main > div:first-child {
+  .docs.docs-solution-landing main > div:nth-child(2) {
     padding: 54px 101px 50px 116px;
     border: none;
   }

--- a/styles/theme/docs-solution-landing.scss
+++ b/styles/theme/docs-solution-landing.scss
@@ -61,7 +61,7 @@
     max-width: 100%;
   }
 
-  & > div:first-child {
+  & > div:nth-child(2) {
     border: none;
     gap: 0;
   }
@@ -69,7 +69,7 @@
   @include breakpoint(desktop) {
     padding: 0;
 
-    & > div:first-child {
+    & > div:nth-child(2) {
       padding: 54px 101px 50px 116px;
       border: none;
     }


### PR DESCRIPTION
This PR enhanced theme handling and CLS issues in Doc pages specifically.
Also refactors how we determine which theme is which.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page
- After: https://theme-handling--exlm--adobe-experience-league.hlx.page?martech=off
- After: https://theme-handling--exlm--adobe-experience-league.hlx.page/en/docs?martech=off
- After: https://theme-handling--exlm--adobe-experience-league.hlx.page/en/docs/mix-modeler?martech=off
- After: https://theme-handling--exlm--adobe-experience-league.hlx.page/en/docs/mix-modeler/using/overview?martech=off
- After: https://theme-handling--exlm--adobe-experience-league.hlx.page/en/docs/mix-modeler/using/get-started/about?martech=off
- After: https://theme-handling--exlm--adobe-experience-league.hlx.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://theme-handling--exlm--adobe-experience-league.hlx.page/en/docs/home-tutorials?martech=off
- After: https://theme-handling--exlm--adobe-experience-league.hlx.page/en/docs/mix-modeler-learn/tutorials/overview?martech=off
- After: https://theme-handling--exlm--adobe-experience-league.hlx.page/en/docs/mix-modeler-learn/tutorials/intro/use-cases?martech=off
- After: https://theme-handling--exlm--adobe-experience-league.hlx.page/en/docs/experience-cloud-kcs/kbarticles/ka-16447?martech=off
