### PR TITLE
fix: target event handler scope EXLM-2623

### DIFF
--- a/scripts/adobe-target/adobe-target.js
+++ b/scripts/adobe-target/adobe-target.js
@@ -85,7 +85,7 @@ class AdobeTargetClient {
    */
   handleTargetEvent() {
     return new Promise((resolve) => {
-      function targetEventHandler(event) {
+      const targetEventHandler = (event) => {
         if (!window?.exlm?.targetData) window.exlm.targetData = [];
         if (!window?.exlm?.recommendationMarqueeTargetData) window.exlm.recommendationMarqueeTargetData = [];
         if (!window?.exlm?.targetData.filter((data) => data?.meta?.scope === event?.detail?.meta?.scope).length) {

--- a/scripts/adobe-target/adobe-target.js
+++ b/scripts/adobe-target/adobe-target.js
@@ -96,7 +96,7 @@ class AdobeTargetClient {
           }
         }
         resolve(true);
-      }
+      };
       document.addEventListener(this.targetDataEventName, targetEventHandler);
       resolve(false);
     });


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-2623

> NOTE: `- After: https://exlm-2623--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2623--exlm--adobe-experience-league.aem.page
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2623--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off