### PR TITLE
fix: prevent truncation of description in JS, allow it via css exlm-2591

### DIFF
--- a/scripts/browse-card/browse-card.js
+++ b/scripts/browse-card/browse-card.js
@@ -192,13 +192,14 @@ const buildCardContent = async (card, model) => {
     inProgressText,
     inProgressStatus = {},
     failedToLoad = false,
+    truncateDescription = true
   } = model;
   const contentType = type?.toLowerCase();
   const cardContent = card.querySelector('.browse-card-content');
   const cardFooter = card.querySelector('.browse-card-footer');
 
   if (description) {
-    const stringContent = description.length > 100 ? `${description.substring(0, 100).trim()}...` : description;
+    const stringContent = description.length > 100 && truncateDescription ? `${description.substring(0, 100).trim()}...` : description;
     const descriptionElement = document.createElement('p');
     descriptionElement.classList.add('browse-card-description-text');
     descriptionElement.innerHTML = stripScriptTags(stringContent);

--- a/scripts/browse-card/browse-card.js
+++ b/scripts/browse-card/browse-card.js
@@ -192,14 +192,15 @@ const buildCardContent = async (card, model) => {
     inProgressText,
     inProgressStatus = {},
     failedToLoad = false,
-    truncateDescription = true
+    truncateDescription = true,
   } = model;
   const contentType = type?.toLowerCase();
   const cardContent = card.querySelector('.browse-card-content');
   const cardFooter = card.querySelector('.browse-card-footer');
 
   if (description) {
-    const stringContent = description.length > 100 && truncateDescription ? `${description.substring(0, 100).trim()}...` : description;
+    const stringContent =
+      description.length > 100 && truncateDescription ? `${description.substring(0, 100).trim()}...` : description;
     const descriptionElement = document.createElement('p');
     descriptionElement.classList.add('browse-card-description-text');
     descriptionElement.innerHTML = stripScriptTags(stringContent);


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-2591

> NOTE: `- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2591-tr--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off