### PR TITLE
fix: responsive pill list ipad css issues exlm-2656

### DIFF
--- a/scripts/responsive-pill-list/responsive-pill-list.css
+++ b/scripts/responsive-pill-list/responsive-pill-list.css
@@ -30,6 +30,7 @@
   border: 1px solid rgba(177, 177, 177, 0.6);
   box-shadow: 0px 1px 4px #00000026;
   cursor: default;
+  min-width: 120px;
 }
 
 .responsive-pill-list .responsive-pill-list-items-wrapper {
@@ -80,6 +81,7 @@
 
 .responsive-pill-list .responsive-pill-list-option-overlay li {
   width: calc(100% - 48px);
+  text-align: center;
 }
 
 .responsive-pill-list ul li {

--- a/scripts/responsive-pill-list/responsive-pill-list.js
+++ b/scripts/responsive-pill-list/responsive-pill-list.js
@@ -178,7 +178,8 @@ export default class ResponsivePillList {
       if (moreOptionsOverlay.classList.contains('responsive-pill-list-option-overlay-visible')) {
         e.stopPropagation();
         moreOptionsButton.classList.add('responsive-pill-list-btn-active');
-        const rightEdge = moreOptionsOverlay.getBoundingClientRect().right;
+        const edgeScrollBuffer = 20;
+        const rightEdge = moreOptionsOverlay.getBoundingClientRect().right + edgeScrollBuffer;
         const delta = rightEdge > window.innerWidth ? rightEdge - window.innerWidth : 0;
         if (delta) {
           moreOptionsOverlay.style.left = `-${delta + 24}px`;


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-2656

> NOTE: `- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://EXLM-2656-css--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off