### PR TITLE
EXLM-2734 Default content tree for new perspectives page

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -73,7 +73,35 @@
                   "filter": "article-content-section",
                   "name": "Article Content Section",
                   "model": "article-content-section",
-                  "style": "article-content-section"
+                  "style": "article-content-section",
+                  "text1": {
+                    "sling:resourceType": "core/franklin/components/text/v1/text",
+                    "name": "Text",
+                    "model": "text",
+                    "text": "<p>[Insert page summary here]</p>"
+                  },
+                  "article-tags": {
+                    "sling:resourceType": "core/franklin/components/block/v1/block",
+                    "name": "Tags",
+                    "model": "article-tags"
+                  },
+                  "text2": {
+                    "sling:resourceType": "core/franklin/components/text/v1/text",
+                    "name": "Text",
+                    "model": "text",
+                    "text": "<p>[Insert article body content here. Add additional blocks below as needed]</p>"
+                  },
+                  "social-share": {
+                    "sling:resourceType": "core/franklin/components/block/v1/block",
+                    "name": "Social Share",
+                    "model": "social-share",
+                    "social network": ["facebook", "twitter", "linkedin"]
+                  },
+                  "author-summary": {
+                    "sling:resourceType": "core/franklin/components/block/v1/block",
+                    "name": "Author Summary",
+                    "model": "author-summary"
+                  }
                 }
               }
             }


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: EXLM-2734

> NOTE: `- After: https://exlm-2734--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2734--exlm--adobe-experience-league.aem.page
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off