### PR TITLE
Remove lang parameter in interest url

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -694,7 +694,7 @@ export function getConfig() {
     communityAccountURL: isProd
       ? `https://experienceleaguecommunities.adobe.com/?profile.language=${communityLocale}`
       : `https://experienceleaguecommunities-dev.adobe.com/?profile.language=${communityLocale}`,
-    interestsUrl: `${cdnOrigin}/api/interests?page_size=200&sort=Order&lang=${lang}`,
+    interestsUrl: `${cdnOrigin}/api/interests?page_size=200&sort=Order`,
     // Param for localized Community Profile URL
     localizedCommunityProfileParam: `?profile.language=${communityLocale}`,
   };


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-2735

> NOTE: `$` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

$
$/en/docs?martech=off
$/en/docs?martech=off
$/en/docs/analytics?martech=off
$/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
$/en/playlists?martech=off
$/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
$/en/docs/home-tutorials?martech=off
$/en/docs/analytics-learn/tutorials/overview?martech=off
$/en/perspectives?martech=off
$/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
$/en/certification-home?martech=off
$/en/browse?martech=off
$/en/browse/analytics?martech=off
