### PR TITLE
EXLM-2734 Updated placeholder text for Perspective template

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -78,7 +78,7 @@
                     "sling:resourceType": "core/franklin/components/text/v1/text",
                     "name": "Text",
                     "model": "text",
-                    "text": "<p>[Insert page summary here]</p>"
+                    "text": "<p>[Insert page summary here. 1-2 sentences are recommended for the page summary.]<br><br>To configure the page title, article author(s), and tags, navigate to Page-level properties by clicking Content Tree -&gt; Page -&gt; Properties. (remove this with text)</p>"
                   },
                   "article-tags": {
                     "sling:resourceType": "core/franklin/components/block/v1/block",


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: EXLM-2734

> NOTE: `- After: https://exlm-2734--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2734--exlm--adobe-experience-league.aem.page
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2734--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off