### PR TITLE
EXLM-2818 Placeholders fix for recommendation marquee

### DIFF
--- a/blocks/recommendation-marquee/recommendation-marquee.js
+++ b/blocks/recommendation-marquee/recommendation-marquee.js
@@ -156,8 +156,6 @@ async function findEmptyFilters(targetCriteriaId, profileInterests = []) {
 
 const interestDataPromise = fetchInterestData();
 
-const ALL_ADOBE_OPTIONS_KEY = placeholders?.allAdobeProducts || 'All Adobe Products';
-
 const renderCardPlaceholders = (contentDiv, renderCardsFlag = true) => {
   const cardDiv = document.createElement('div');
   cardDiv.classList.add('card-wrapper');
@@ -179,6 +177,15 @@ const renderCardPlaceholders = (contentDiv, renderCardsFlag = true) => {
  */
 export default async function decorate(block) {
   const placeholderPromise = fetchLanguagePlaceholders();
+  try {
+    placeholders = await placeholderPromise;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching placeholders:', err);
+  }
+
+  const ALL_ADOBE_OPTIONS_KEY = placeholders?.allAdobeProducts || 'All Adobe Products';
+
   // Extracting elements from the block
   const htmlElementData = [...block.children].map((row) => row.firstElementChild);
 
@@ -747,13 +754,6 @@ export default async function decorate(block) {
         },
       });
     });
-  }
-
-  try {
-    placeholders = await placeholderPromise;
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error('Error fetching placeholders:', err);
   }
 
   targetEventEmitter.on('dataChange', async (data) => {

--- a/blocks/recommendation-marquee/recommendation-marquee.js
+++ b/blocks/recommendation-marquee/recommendation-marquee.js
@@ -176,9 +176,8 @@ const renderCardPlaceholders = (contentDiv, renderCardsFlag = true) => {
  * @param {HTMLElement} block - The block of data to process.
  */
 export default async function decorate(block) {
-  const placeholderPromise = fetchLanguagePlaceholders();
   try {
-    placeholders = await placeholderPromise;
+    placeholders = await fetchLanguagePlaceholders();
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error('Error fetching placeholders:', err);


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID:

> NOTE: `- After: https://exlm-2818--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs: EXLM-2818

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2818--exlm--adobe-experience-league.aem.page
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2818--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off