### PR TITLE
EXLM-2819 Removed prehiding snippet for the existing home page

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1190,16 +1190,6 @@ async function loadPage() {
   }
 }
 
-/**
- * A simple shorter impl of alloy prehide script.
- * This is used for target A/B testing of home page, and should be removed after the test is done.
- */
-function prehidePageForTarget() {
-  const styleEl = htmlToElement(`<style> body { opacity: 0 !important } </style>`);
-  document.head.appendChild(styleEl);
-  setTimeout(() => styleEl?.parentNode?.removeChild(styleEl), 5000);
-}
-
 // load the page unless DO_NOT_LOAD_PAGE is set - used for existing EXLM pages POC
 (async () => {
   if (window.hlx.DO_NOT_LOAD_PAGE) return;
@@ -1242,15 +1232,9 @@ function prehidePageForTarget() {
     try {
       const signedIn = await isUserSignedIn();
       const { personalizedHomeLink } = getConfig() || {};
-      if (signedIn) {
-        // Execute the prehiding function
-        if (!sessionStorage.getItem(PHP_AB)) {
-          prehidePageForTarget();
-        }
-        if (personalizedHomeLink && sessionStorage.getItem(PHP_AB) === 'authHP') {
-          window.location.pathname = `${lang}${personalizedHomeLink}`;
-          return;
-        }
+      if (signedIn && personalizedHomeLink && sessionStorage.getItem(PHP_AB) === 'authHP') {
+        window.location.pathname = `${lang}${personalizedHomeLink}`;
+        return;
       }
     } catch (error) {
       console.error('Error during redirect process:', error);


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: EXLM-2819

> NOTE: `- After: https://exlm-2819--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2819--exlm--adobe-experience-league.aem.page
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2819--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off