### PR TITLE
Exclude JSON files from sitemap

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -461,7 +461,7 @@ indices:
       - '/en/docs/experience-cloud-kcs/**'
       - '/en/docs/experience-manager-learn/**'
       - '/en/docs/experience-manager-cloud-service/**'
-      - '/en/*.json'
+      - '/en/**.json'
     properties:
       robots:
         select: head > meta[name="robots"]
@@ -500,7 +500,7 @@ indices:
       - '/fr/docs/experience-cloud-kcs/**'
       - '/fr/docs/experience-manager-learn/**'
       - '/fr/docs/experience-manager-cloud-service/**'
-      - '/fr/*.json'
+      - '/fr/**.json'
 
   sitemap-de-1:
     <<: *base-sitemap-1
@@ -532,7 +532,7 @@ indices:
       - '/de/docs/experience-cloud-kcs/**'
       - '/de/docs/experience-manager-learn/**'
       - '/de/docs/experience-manager-cloud-service/**'
-      - '/de/*.json'
+      - '/de/**.json'
 
   sitemap-es-1:
     <<: *base-sitemap-1
@@ -564,7 +564,7 @@ indices:
       - '/es/docs/experience-cloud-kcs/**'
       - '/es/docs/experience-manager-learn/**'
       - '/es/docs/experience-manager-cloud-service/**'
-      - '/es/*.json'
+      - '/es/**.json'
 
   sitemap-it-1:
     <<: *base-sitemap-1
@@ -596,7 +596,7 @@ indices:
       - '/it/docs/experience-cloud-kcs/**'
       - '/it/docs/experience-manager-learn/**'
       - '/it/docs/experience-manager-cloud-service/**'
-      - '/it/*.json'
+      - '/it/**.json'
 
   sitemap-nl-1:
     <<: *base-sitemap-1
@@ -628,7 +628,7 @@ indices:
       - '/nl/docs/experience-cloud-kcs/**'
       - '/nl/docs/experience-manager-learn/**'
       - '/nl/docs/experience-manager-cloud-service/**'
-      - '/nl/*.json'
+      - '/nl/**.json'
 
   sitemap-pt-br-1:
     <<: *base-sitemap-1
@@ -660,7 +660,7 @@ indices:
       - '/pt-br/docs/experience-cloud-kcs/**'
       - '/pt-br/docs/experience-manager-learn/**'
       - '/pt-br/docs/experience-manager-cloud-service/**'
-      - '/pt-br/*.json'
+      - '/pt-br/**.json'
 
   sitemap-ko-1:
     <<: *base-sitemap-1
@@ -692,7 +692,7 @@ indices:
       - '/ko/docs/experience-cloud-kcs/**'
       - '/ko/docs/experience-manager-learn/**'
       - '/ko/docs/experience-manager-cloud-service/**'
-      - '/ko/*.json'
+      - '/ko/**.json'
 
   sitemap-ja-1:
     <<: *base-sitemap-1
@@ -724,7 +724,7 @@ indices:
       - '/ja/docs/experience-cloud-kcs/**'
       - '/ja/docs/experience-manager-learn/**'
       - '/ja/docs/experience-manager-cloud-service/**'
-      - '/ja/*.json'
+      - '/ja/**.json'
 
   sitemap-sv-1:
     <<: *base-sitemap-1
@@ -756,7 +756,7 @@ indices:
       - '/sv/docs/experience-cloud-kcs/**'
       - '/sv/docs/experience-manager-learn/**'
       - '/sv/docs/experience-manager-cloud-service/**'
-      - '/sv/*.json'
+      - '/sv/**.json'
 
   sitemap-zh-hans-1:
     <<: *base-sitemap-1
@@ -788,7 +788,7 @@ indices:
       - '/zh-hans/docs/experience-cloud-kcs/**'
       - '/zh-hans/docs/experience-manager-learn/**'
       - '/zh-hans/docs/experience-manager-cloud-service/**'
-      - '/zh-hans/*.json'
+      - '/zh-hans/**.json'
 
   sitemap-zh-hant-1:
     <<: *base-sitemap-1
@@ -820,7 +820,7 @@ indices:
       - '/zh-hant/docs/experience-cloud-kcs/**'
       - '/zh-hant/docs/experience-manager-learn/**'
       - '/zh-hant/docs/experience-manager-cloud-service/**'
-      - '/zh-hant/*.json'
+      - '/zh-hant/**.json'
 
   playlists-en: &base-playlists
     target: /en/playlists.json

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -461,9 +461,7 @@ indices:
       - '/en/docs/experience-cloud-kcs/**'
       - '/en/docs/experience-manager-learn/**'
       - '/en/docs/experience-manager-cloud-service/**'
-      - '/en/placeholders.json'
-      - '/en/top-products.json'
-      - '/en/fragments.json'
+      - '/en/*.json'
     properties:
       robots:
         select: head > meta[name="robots"]
@@ -502,9 +500,7 @@ indices:
       - '/fr/docs/experience-cloud-kcs/**'
       - '/fr/docs/experience-manager-learn/**'
       - '/fr/docs/experience-manager-cloud-service/**'
-      - '/fr/placeholders.json'
-      - '/fr/top-products.json'
-      - '/fr/fragments.json'
+      - '/fr/*.json'
 
   sitemap-de-1:
     <<: *base-sitemap-1
@@ -536,9 +532,7 @@ indices:
       - '/de/docs/experience-cloud-kcs/**'
       - '/de/docs/experience-manager-learn/**'
       - '/de/docs/experience-manager-cloud-service/**'
-      - '/de/placeholders.json'
-      - '/de/top-products.json'
-      - '/de/fragments.json'
+      - '/de/*.json'
 
   sitemap-es-1:
     <<: *base-sitemap-1
@@ -570,9 +564,7 @@ indices:
       - '/es/docs/experience-cloud-kcs/**'
       - '/es/docs/experience-manager-learn/**'
       - '/es/docs/experience-manager-cloud-service/**'
-      - '/es/placeholders.json'
-      - '/es/top-products.json'
-      - '/es/fragments.json'
+      - '/es/*.json'
 
   sitemap-it-1:
     <<: *base-sitemap-1
@@ -604,9 +596,7 @@ indices:
       - '/it/docs/experience-cloud-kcs/**'
       - '/it/docs/experience-manager-learn/**'
       - '/it/docs/experience-manager-cloud-service/**'
-      - '/it/placeholders.json'
-      - '/it/top-products.json'
-      - '/it/fragments.json'
+      - '/it/*.json'
 
   sitemap-nl-1:
     <<: *base-sitemap-1
@@ -638,9 +628,7 @@ indices:
       - '/nl/docs/experience-cloud-kcs/**'
       - '/nl/docs/experience-manager-learn/**'
       - '/nl/docs/experience-manager-cloud-service/**'
-      - '/nl/placeholders.json'
-      - '/nl/top-products.json'
-      - '/nl/fragments.json'
+      - '/nl/*.json'
 
   sitemap-pt-br-1:
     <<: *base-sitemap-1
@@ -672,9 +660,7 @@ indices:
       - '/pt-br/docs/experience-cloud-kcs/**'
       - '/pt-br/docs/experience-manager-learn/**'
       - '/pt-br/docs/experience-manager-cloud-service/**'
-      - '/pt-br/placeholders.json'
-      - '/pt-br/top-products.json'
-      - '/pt-br/fragments.json'
+      - '/pt-br/*.json'
 
   sitemap-ko-1:
     <<: *base-sitemap-1
@@ -706,9 +692,7 @@ indices:
       - '/ko/docs/experience-cloud-kcs/**'
       - '/ko/docs/experience-manager-learn/**'
       - '/ko/docs/experience-manager-cloud-service/**'
-      - '/ko/placeholders.json'
-      - '/ko/top-products.json'
-      - '/ko/fragments.json'
+      - '/ko/*.json'
 
   sitemap-ja-1:
     <<: *base-sitemap-1
@@ -740,9 +724,7 @@ indices:
       - '/ja/docs/experience-cloud-kcs/**'
       - '/ja/docs/experience-manager-learn/**'
       - '/ja/docs/experience-manager-cloud-service/**'
-      - '/ja/placeholders.json'
-      - '/ja/top-products.json'
-      - '/ja/fragments.json'
+      - '/ja/*.json'
 
   sitemap-sv-1:
     <<: *base-sitemap-1
@@ -774,9 +756,7 @@ indices:
       - '/sv/docs/experience-cloud-kcs/**'
       - '/sv/docs/experience-manager-learn/**'
       - '/sv/docs/experience-manager-cloud-service/**'
-      - '/sv/placeholders.json'
-      - '/sv/top-products.json'
-      - '/sv/fragments.json'
+      - '/sv/*.json'
 
   sitemap-zh-hans-1:
     <<: *base-sitemap-1
@@ -808,9 +788,7 @@ indices:
       - '/zh-hans/docs/experience-cloud-kcs/**'
       - '/zh-hans/docs/experience-manager-learn/**'
       - '/zh-hans/docs/experience-manager-cloud-service/**'
-      - '/zh-hans/placeholders.json'
-      - '/zh-hans/top-products.json'
-      - '/zh-hans/fragments.json'
+      - '/zh-hans/*.json'
 
   sitemap-zh-hant-1:
     <<: *base-sitemap-1
@@ -842,9 +820,7 @@ indices:
       - '/zh-hant/docs/experience-cloud-kcs/**'
       - '/zh-hant/docs/experience-manager-learn/**'
       - '/zh-hant/docs/experience-manager-cloud-service/**'
-      - '/zh-hant/placeholders.json'
-      - '/zh-hant/top-products.json'
-      - '/zh-hant/fragments.json'
+      - '/zh-hant/*.json'
 
   playlists-en: &base-playlists
     target: /en/playlists.json

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -461,7 +461,8 @@ indices:
       - '/en/docs/experience-cloud-kcs/**'
       - '/en/docs/experience-manager-learn/**'
       - '/en/docs/experience-manager-cloud-service/**'
-      - '/en/**.json'
+      - '/*.json'
+      - '/**/*.json'
     properties:
       robots:
         select: head > meta[name="robots"]
@@ -500,7 +501,8 @@ indices:
       - '/fr/docs/experience-cloud-kcs/**'
       - '/fr/docs/experience-manager-learn/**'
       - '/fr/docs/experience-manager-cloud-service/**'
-      - '/fr/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   sitemap-de-1:
     <<: *base-sitemap-1
@@ -532,7 +534,8 @@ indices:
       - '/de/docs/experience-cloud-kcs/**'
       - '/de/docs/experience-manager-learn/**'
       - '/de/docs/experience-manager-cloud-service/**'
-      - '/de/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   sitemap-es-1:
     <<: *base-sitemap-1
@@ -564,7 +567,8 @@ indices:
       - '/es/docs/experience-cloud-kcs/**'
       - '/es/docs/experience-manager-learn/**'
       - '/es/docs/experience-manager-cloud-service/**'
-      - '/es/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   sitemap-it-1:
     <<: *base-sitemap-1
@@ -596,7 +600,8 @@ indices:
       - '/it/docs/experience-cloud-kcs/**'
       - '/it/docs/experience-manager-learn/**'
       - '/it/docs/experience-manager-cloud-service/**'
-      - '/it/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   sitemap-nl-1:
     <<: *base-sitemap-1
@@ -628,7 +633,8 @@ indices:
       - '/nl/docs/experience-cloud-kcs/**'
       - '/nl/docs/experience-manager-learn/**'
       - '/nl/docs/experience-manager-cloud-service/**'
-      - '/nl/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   sitemap-pt-br-1:
     <<: *base-sitemap-1
@@ -660,7 +666,8 @@ indices:
       - '/pt-br/docs/experience-cloud-kcs/**'
       - '/pt-br/docs/experience-manager-learn/**'
       - '/pt-br/docs/experience-manager-cloud-service/**'
-      - '/pt-br/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   sitemap-ko-1:
     <<: *base-sitemap-1
@@ -692,7 +699,8 @@ indices:
       - '/ko/docs/experience-cloud-kcs/**'
       - '/ko/docs/experience-manager-learn/**'
       - '/ko/docs/experience-manager-cloud-service/**'
-      - '/ko/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   sitemap-ja-1:
     <<: *base-sitemap-1
@@ -724,7 +732,8 @@ indices:
       - '/ja/docs/experience-cloud-kcs/**'
       - '/ja/docs/experience-manager-learn/**'
       - '/ja/docs/experience-manager-cloud-service/**'
-      - '/ja/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   sitemap-sv-1:
     <<: *base-sitemap-1
@@ -756,7 +765,8 @@ indices:
       - '/sv/docs/experience-cloud-kcs/**'
       - '/sv/docs/experience-manager-learn/**'
       - '/sv/docs/experience-manager-cloud-service/**'
-      - '/sv/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   sitemap-zh-hans-1:
     <<: *base-sitemap-1
@@ -788,7 +798,8 @@ indices:
       - '/zh-hans/docs/experience-cloud-kcs/**'
       - '/zh-hans/docs/experience-manager-learn/**'
       - '/zh-hans/docs/experience-manager-cloud-service/**'
-      - '/zh-hans/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   sitemap-zh-hant-1:
     <<: *base-sitemap-1
@@ -820,7 +831,8 @@ indices:
       - '/zh-hant/docs/experience-cloud-kcs/**'
       - '/zh-hant/docs/experience-manager-learn/**'
       - '/zh-hant/docs/experience-manager-cloud-service/**'
-      - '/zh-hant/**.json'
+      - '/*.json'
+      - '/**/*.json'
 
   playlists-en: &base-playlists
     target: /en/playlists.json


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: EXLM-2826

> NOTE: `- After: https://exlm-2826--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2826--exlm--adobe-experience-league.aem.page
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2826--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off