### PR TITLE
EXLM-2868 CSS changes for no thumbnail img

### DIFF
--- a/blocks/recommendation-marquee/recommendation-marquee.css
+++ b/blocks/recommendation-marquee/recommendation-marquee.css
@@ -368,7 +368,6 @@
     float: left;
     max-height: 100%;
     border-radius: 16px 0 0 16px;
-    background-color: transparent !important;
   }
 
   .recommendation-marquee.block

--- a/blocks/recommendation-marquee/recommendation-marquee.css
+++ b/blocks/recommendation-marquee/recommendation-marquee.css
@@ -423,6 +423,7 @@
     float: left;
     max-height: 100%;
     border-radius: 16px 0 0 16px;
+    background-color: transparent !important;
   }
 
   .recommendation-marquee.block
@@ -468,7 +469,10 @@
     min-height: auto;
   }
 
-  .recommendation-marquee.block .browse-cards-block-content .card-wrapper .browse-card.no-thumbnail-bg {
+  .recommendation-marquee.block
+    .browse-cards-block-content.recommendation-marquee-wrap
+    .card-wrapper:first-child
+    .browse-card:not(.thumbnail-loaded) {
     background-image: url('../../images/rec-marquee-no-thumbnail-bg.svg');
     background-position: center;
   }

--- a/blocks/recommendation-marquee/recommendation-marquee.js
+++ b/blocks/recommendation-marquee/recommendation-marquee.js
@@ -612,13 +612,6 @@ export default async function decorate(block) {
             });
           }
         }
-        if (!data[0].thumbnail) {
-          const firstCardWrapper = block.querySelector('.card-wrapper');
-          const browseCard = firstCardWrapper.querySelector('.browse-card');
-          const browseCardFigure = firstCardWrapper.querySelector('.browse-card-figure');
-          browseCard?.classList.add('no-thumbnail-bg');
-          if (browseCardFigure) browseCardFigure.style.backgroundColor = 'transparent';
-        }
         return data;
       }
 


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-2868

> NOTE: `- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://feat-exlm-2868-fix--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off