### PR TITLE
Append PHP Target blocks before Profile Rail section

### DIFF
--- a/scripts/adobe-target/adobe-target.js
+++ b/scripts/adobe-target/adobe-target.js
@@ -306,7 +306,12 @@ class AdobeTargetClient {
     } else {
       const containerSection = document.createElement('div');
       containerSection.classList.add('section', 'profile-section');
-      main.appendChild(containerSection);
+      const profileRailSection = main.querySelector('.profile-rail-section');
+      if (profileRailSection) {
+        main.insertBefore(containerSection, profileRailSection);
+      } else {
+        main.appendChild(containerSection);
+      }
       decorateSections(main);
       containerSection.appendChild(blockEl);
     }


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID:

> NOTE: `- After: https://php-css-fix--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live?martech=off

- After: https://php-css-fix--exlm--adobe-experience-league.aem.live?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/docs/home-tutorials?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://php-css-fix--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off