### PR TITLE
EXLM 2895 - show laptop only when img is loaded

### DIFF
--- a/scripts/browse-card/browse-card.js
+++ b/scripts/browse-card/browse-card.js
@@ -348,8 +348,6 @@ export async function buildCard(container, element, model) {
     const laptopKeyboard = document.createElement('div');
     laptopContainer.append(laptopScreen, laptopKeyboard);
 
-    cardFigure.appendChild(laptopContainer);
-
     const img = document.createElement('img');
     img.src = thumbnail;
     img.loading = 'lazy';
@@ -365,6 +363,7 @@ export async function buildCard(container, element, model) {
     img.addEventListener('load', () => {
       cardFigure.classList.add('img-custom-height');
       card.classList.add('thumbnail-loaded');
+      cardFigure.appendChild(laptopContainer);
       if (
         VIDEO_THUMBNAIL_FORMAT.test(thumbnail) ||
         type === CONTENT_TYPES.PLAYLIST.MAPPING_KEY ||


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-2895 

> NOTE: `- After: https://exlm-2895--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2895--exlm--adobe-experience-league.aem.page
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2895--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off