### PR TITLE
fix: retain previous H-tag elements while updating the copy from target EXLM-2888

### DIFF
--- a/blocks/recently-reviewed/recently-reviewed.js
+++ b/blocks/recently-reviewed/recently-reviewed.js
@@ -168,8 +168,15 @@ function createSeeMoreButton(block, contentDiv, addNewRowOfCards, cardData) {
  * @returns {void}
  */
 export function updateCopyFromTarget(data, heading, subheading, taglineCta, taglineText) {
-  if (data?.meta?.heading && heading) heading.innerHTML = data.meta.heading;
-  else heading?.remove();
+  if (data?.meta?.heading && heading) {
+    if (heading.firstElementChild) {
+      heading.firstElementChild.innerHTML = data.meta.heading;
+    } else {
+      heading.innerHTML = data.meta.heading;
+    }
+  } else {
+    heading?.remove();
+  }
   if (data?.meta?.subheading && subheading) subheading.innerHTML = data.meta.subheading;
   else subheading?.remove();
   if (

--- a/blocks/recommendation-marquee/recommendation-marquee.js
+++ b/blocks/recommendation-marquee/recommendation-marquee.js
@@ -137,8 +137,15 @@ function generateLoadingShimmer(shimmerSizes = [[100, 30]]) {
  */
 export function updateCopyFromTarget(data, heading, subheading, taglineCta, taglineText) {
   if (isFeatureEnabled('recMarqueeTargetHeading')) {
-    if (data?.meta?.heading && heading) heading.innerHTML = data.meta.heading;
-    else heading?.remove();
+    if (data?.meta?.heading && heading) {
+      if (heading.firstElementChild && !heading.firstElementChild.className.includes('loading-shimmer')) {
+        heading.firstElementChild.innerHTML = data.meta.heading;
+      } else {
+        heading.innerHTML = data.meta.heading;
+      }
+    } else {
+      heading?.remove();
+    }
     if (data?.meta?.subheading && subheading) subheading.innerHTML = data.meta.subheading;
     else subheading?.remove();
   } else {
@@ -290,6 +297,7 @@ export default async function decorate(block) {
   }
 
   const [headingElement, descriptionElement, ...contentTypesEl] = restOfEl.reverse();
+  const headingElementNode = htmlToElement(headingElement.innerHTML);
   const recommendedContentShimmer = `
   <div class="recommendation-marquee-header">${generateLoadingShimmer([[50, 14]])}</div>
   <div class="recommendation-marquee-description">${generateLoadingShimmer([[50, 10]])}</div>
@@ -488,8 +496,12 @@ export default async function decorate(block) {
       } else {
         defaultOptionsKey.push(ALL_ADOBE_OPTIONS_KEY);
       }
-
-      if (!(targetSupport && targetCriteriaScopeId)) {
+      const coveoFlowDetection = !(targetSupport && targetCriteriaScopeId);
+      if (headingElementNode) {
+        headerContainer.innerHTML = '';
+        headerContainer.appendChild(headingElementNode);
+      }
+      if (coveoFlowDetection) {
         headerContainer.innerHTML = headingElement.innerHTML;
         descriptionContainer.innerHTML = descriptionElement.innerHTML;
         setCoveoCountAsBlockAttribute();

--- a/blocks/recommended-content/recommended-content.js
+++ b/blocks/recommended-content/recommended-content.js
@@ -203,8 +203,15 @@ function resizeObserverHandler(callback, block) {
  * @returns {void}
  */
 export function updateCopyFromTarget(data, heading, subheading, taglineCta, taglineText) {
-  if (data?.meta?.heading && heading) heading.innerHTML = data.meta.heading;
-  else heading?.remove();
+  if (data?.meta?.heading && heading) {
+    if (heading.firstElementChild && !heading.firstElementChild.className.includes('loading-shimmer')) {
+      heading.firstElementChild.innerHTML = data.meta.heading;
+    } else {
+      heading.innerHTML = data.meta.heading;
+    }
+  } else {
+    heading?.remove();
+  }
   if (data?.meta?.subheading && subheading) subheading.innerHTML = data.meta.subheading;
   else subheading?.remove();
   if (
@@ -333,6 +340,7 @@ export default async function decorate(block) {
   block.innerHTML = '';
 
   filterSectionElement.classList.add('recommended-content-filter-heading');
+  const headingElementNode = htmlToElement(headingElement.innerHTML);
   const blockHeader = createTag('div', { class: 'recommended-content-block-header' });
   blockHeader.innerHTML = generateLoadingShimmer([[80, 30]]);
   block.insertAdjacentHTML('afterbegin', recommendedContentShimmer);
@@ -543,8 +551,12 @@ export default async function decorate(block) {
       } else {
         defaultOptionsKey.push(ALL_ADOBE_OPTIONS_KEY);
       }
-
-      if (!(targetSupport && targetCriteriaScopeId)) {
+      const coveoFlowDetection = !(targetSupport && targetCriteriaScopeId);
+      if (headingElementNode) {
+        headerContainer.innerHTML = '';
+        headerContainer.appendChild(headingElementNode);
+      }
+      if (coveoFlowDetection) {
         headerContainer.innerHTML = headingElement.innerHTML;
         descriptionContainer.innerHTML = descriptionElement.innerHTML;
         setCoveoCountAsBlockAttribute();


### PR DESCRIPTION
…

Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-2888

> NOTE: `- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://EXLM-2888--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off