### PR TITLE
EXLM-2934 Point stage env Coveo search to Prod coveo search

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -666,10 +666,11 @@ export function getConfig() {
     profileUrl: `${cdnOrigin}/api/profile?lang=${lang}`,
     JWTTokenUrl: `${cdnOrigin}/api/token?lang=${lang}`,
     coveoTokenUrl: `${cdnOrigin}/api/coveo-token?lang=${lang}`,
-    coveoSearchResultsUrl: isProd
-      ? 'https://platform.cloud.coveo.com/rest/search/v2'
-      : 'https://adobesystemsincorporatednonprod1.org.coveo.com/rest/search/v2',
-    coveoOrganizationId: isProd ? 'adobev2prod9e382h1q' : 'adobesystemsincorporatednonprod1',
+    coveoSearchResultsUrl:
+      isProd || isStage
+        ? 'https://platform.cloud.coveo.com/rest/search/v2'
+        : 'https://adobesystemsincorporatednonprod1.org.coveo.com/rest/search/v2',
+    coveoOrganizationId: isProd || isStage ? 'adobev2prod9e382h1q' : 'adobesystemsincorporatednonprod1',
     coveoToken: 'xxcfe1b6e9-3628-49b5-948d-ed50d3fa6c99',
     liveEventsUrl: `${prodAssetsCdnOrigin}/thumb/upcoming-events.json`,
     adlsUrl: 'https://learning.adobe.com/courses.result.json',


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: EXLM-2934

> NOTE: `- After: https://exlm-2934--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2934--exlm--adobe-experience-league.aem.page
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2934--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off