### PR TITLE
fix: correct recommendation marquee card ordering as per the new authoring order EXLM-2941

### DIFF
--- a/blocks/recommendation-marquee/recommendation-marquee.js
+++ b/blocks/recommendation-marquee/recommendation-marquee.js
@@ -636,7 +636,7 @@ export default async function decorate(block) {
         if (btn) {
           btn.classList.remove('hide');
         }
-        let contentTypes = contentTypesEl?.map((contentTypeEL) => contentTypeEL?.innerText?.trim()).reverse() || [];
+        let contentTypes = contentTypesEl?.map((contentTypeEL) => contentTypeEL?.innerText?.trim()) || [];
         contentTypes = contentTypes.slice(0, DEFAULT_NUM_CARDS);
         const contentTypeIsEmpty = contentTypes?.length === 0;
         let noOfRows = parseInt(block.dataset.browseCardRows, 10);


### PR DESCRIPTION


Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-2941

> NOTE: `- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://EXLM-2941--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off