### PR TITLE
EXLM-2944 Profile Rail - whitespace issue

### DIFF
--- a/blocks/profile-rail/profile-rail.css
+++ b/blocks/profile-rail/profile-rail.css
@@ -111,11 +111,16 @@
 
   .profile-rail .profile-rail-links li {
     margin: 8px 0;
+    display: flex;
+
+    /** To remove the visual rendering of inline non-breaking space (`&nbsp;`) characters that appear between child elements */
+    font-size: 0;
   }
 
   .profile-rail .profile-rail-links li > a {
     display: flex;
     padding: 5px 12px;
+    flex: 1;
   }
 
   .profile-rail .profile-rail-links li > a.active {

--- a/blocks/profile-rail/profile-rail.js
+++ b/blocks/profile-rail/profile-rail.js
@@ -52,8 +52,6 @@ export default async function ProfileRail(block) {
   });
 
   block.querySelectorAll('.profile-rail-links > li').forEach((navLink) => {
-    // Remove &nbsp; characters between <li> and <a> elements
-    navLink.innerHTML = navLink.innerHTML.replace(/&nbsp;/g, '');
     // In case of no awards for the profile
     if (!awards && !UEAuthorMode) {
       // remove the Awards link from left rail

--- a/blocks/profile-rail/profile-rail.js
+++ b/blocks/profile-rail/profile-rail.js
@@ -52,6 +52,8 @@ export default async function ProfileRail(block) {
   });
 
   block.querySelectorAll('.profile-rail-links > li').forEach((navLink) => {
+    // Remove &nbsp; characters between <li> and <a> elements
+    navLink.innerHTML = navLink.innerHTML.replace(/&nbsp;/g, '');
     // In case of no awards for the profile
     if (!awards && !UEAuthorMode) {
       // remove the Awards link from left rail


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: EXLM-2944

> NOTE: `- After: https://exlm-2944--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2944--exlm--adobe-experience-league.aem.page
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2944--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off