### PR TITLE
EXLM 2982 - Fix thumbnail load in browse cards

### DIFF
--- a/blocks/browse-filters/browse-filters.css
+++ b/blocks/browse-filters/browse-filters.css
@@ -135,7 +135,7 @@
   overflow-y: auto;
   background-color: var(--non-spectrum-grey-100);
   min-width: 160px;
-  z-index: 2;
+  z-index: 10;
   width: 100%;
   box-sizing: border-box;
   padding: 12px;

--- a/scripts/browse-card/browse-card.css
+++ b/scripts/browse-card/browse-card.css
@@ -259,9 +259,15 @@
   border-bottom: 1px solid var(--spectrum-gray-200);
   object-fit: cover;
   z-index: 9;
+  opacity: 0;
   transition:
     height 0.2s,
-    width 0.2s;
+    width 0.2s,
+    opacity 0.2s;
+}
+
+.browse-card .browse-card-figure > img.img-loaded {
+  opacity: 1;
 }
 
 .browse-card .browse-card-contributor-info img {

--- a/scripts/browse-card/browse-card.js
+++ b/scripts/browse-card/browse-card.js
@@ -348,6 +348,10 @@ export async function buildCard(container, element, model) {
     const laptopKeyboard = document.createElement('div');
     laptopContainer.append(laptopScreen, laptopKeyboard);
 
+    cardFigure.classList.add('img-custom-height');
+    card.classList.add('thumbnail-loaded');
+    cardFigure.appendChild(laptopContainer);
+
     const img = document.createElement('img');
     img.src = thumbnail;
     img.loading = 'lazy';
@@ -356,14 +360,14 @@ export async function buildCard(container, element, model) {
     img.height = 153;
     cardFigure.appendChild(img);
     img.addEventListener('error', () => {
+      cardFigure.classList.remove('img-custom-height');
+      card.classList.remove('thumbnail-loaded');
+      card.classList.add('thumbnail-not-loaded');
       img.style.display = 'none';
       laptopContainer.style.display = 'none';
-      card.classList.add('thumbnail-not-loaded');
     });
     img.addEventListener('load', () => {
-      cardFigure.classList.add('img-custom-height');
-      card.classList.add('thumbnail-loaded');
-      cardFigure.appendChild(laptopContainer);
+      img.classList.add('img-loaded');
       if (
         VIDEO_THUMBNAIL_FORMAT.test(thumbnail) ||
         type === CONTENT_TYPES.PLAYLIST.MAPPING_KEY ||

--- a/scripts/browse-card/browse-card.js
+++ b/scripts/browse-card/browse-card.js
@@ -366,6 +366,11 @@ export async function buildCard(container, element, model) {
       img.style.display = 'none';
       laptopContainer.style.display = 'none';
     });
+
+    if(img.complete) {
+      img.classList.add('img-loaded');
+    }
+    
     img.addEventListener('load', () => {
       img.classList.add('img-loaded');
       if (

--- a/scripts/browse-card/browse-card.js
+++ b/scripts/browse-card/browse-card.js
@@ -367,10 +367,10 @@ export async function buildCard(container, element, model) {
       laptopContainer.style.display = 'none';
     });
 
-    if(img.complete) {
+    if (img.complete) {
       img.classList.add('img-loaded');
     }
-    
+
     img.addEventListener('load', () => {
       img.classList.add('img-loaded');
       if (


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-2982

> NOTE: `- After: https://exlm-2982--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-2982--exlm--adobe-experience-league.aem.page
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-2982--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off