### PR TITLE
Add messages and notifications urls for community

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -31,6 +31,8 @@ import Profile from './load-profile.js';
  *  @property {boolean} active
  *  @property {boolean} hasMessages
  *  @property {boolean} hasNotifications
+ *  @property {string} notificationsUrl
+ *  @property {string} messagesUrl
  */
 
 /**
@@ -567,15 +569,17 @@ async function decorateCommunityBlock(header, decoratorOptions) {
   communityActionsWrapper.style.display = 'none';
   const messagesMarked = decoratorOptions?.community?.hasMessages ? 'community-action-is-marked' : '';
   const notificationsMarked = decoratorOptions?.community?.hasNotifications ? 'community-action-is-marked' : '';
+  const notificationsUrl = decoratorOptions?.community?.notificationsUrl;
+  const messagesUrl = decoratorOptions?.community?.messagesUrl;
   // note: data-community-action is used by community code when this header is used community.
   communityActionsWrapper.innerHTML = `  
     <div class="community-action ${notificationsMarked}" data-community-action="notifications">
-        <a href="/t5/notificationfeed/page" data-id="notifications" title="notifications">
+        <a href="${notificationsUrl}" data-id="notifications" title="notifications">
           <span class="icon icon-bell"></span>
         </a>
     </div>
     <div class="community-action ${messagesMarked}" data-community-action="messages">   
-        <a href="/t5/notes/privatenotespage" data-id="messages" title="messages">
+        <a href="${messagesUrl}" data-id="messages" title="messages">
           <span class ="icon icon-emailOutline"></span>
         </a> 
     <div>
@@ -806,6 +810,8 @@ class ExlHeader extends HTMLElement {
     options.onSignIn = options.onSignIn || doSignIn;
     options.profilePicture = options.profilePicture || profilePicture;
     options.community = options.community ?? { active: false };
+    options.community.notificationsUrl = options.community.notificationsUrl || '/t5/notificationfeed/page';
+    options.community.messagesUrl = options.community.messagesUrl || '/t5/notes/privatenotespage';
     options.khorosProfileUrl = options.khorosProfileUrl || khorosProfileUrl;
     options.lang = options.lang || getPathDetails().lang || 'en';
     options.navLinkOrigin = options.navLinkOrigin || window.location.origin;


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID:

> NOTE: `- After: https://UGP-12583--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://UGP-12583--exlm--adobe-experience-league.aem.page
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://UGP-12583--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off