### PR TITLE
fix: consider only fresh cards to decide to show more btn EXLM-3003

### DIFF
--- a/blocks/recommendation-marquee/recommendation-marquee.js
+++ b/blocks/recommendation-marquee/recommendation-marquee.js
@@ -61,10 +61,10 @@ function ensureDataSaveConfigExists(dataConfiguration, lowercaseOptionType, ctTy
 }
 
 function getSavedCardsCount(dataConfiguration, optionType) {
-  return Object.values(dataConfiguration.savedCardsResponse[optionType] || {}).reduce(
-    (acc, curr) => acc + curr.models.length,
-    0,
-  );
+  return Object.values(dataConfiguration.savedCardsResponse[optionType] || {}).reduce((acc, curr) => {
+    const availableModels = curr.models.filter((model) => !model.markedForReplacement);
+    return acc + availableModels.length;
+  }, 0);
 }
 
 function restoreSavedCardsModelState(dataConfiguration, optionType) {

--- a/blocks/recommended-content/recommended-content.js
+++ b/blocks/recommended-content/recommended-content.js
@@ -102,10 +102,10 @@ function ensureDataSaveConfigExists(dataConfiguration, lowercaseOptionType, ctTy
 }
 
 function getSavedCardsCount(dataConfiguration, optionType) {
-  return Object.values(dataConfiguration.savedCardsResponse[optionType] || {}).reduce(
-    (acc, curr) => acc + curr.models.length,
-    0,
-  );
+  return Object.values(dataConfiguration.savedCardsResponse[optionType] || {}).reduce((acc, curr) => {
+    const availableModels = curr.models.filter((model) => !model.markedForReplacement);
+    return acc + availableModels.length;
+  }, 0);
 }
 
 function restoreSavedCardsModelState(dataConfiguration, optionType) {


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
Please also provide test paths following the template below.

Jira ID: https://jira.corp.adobe.com/browse/EXLM-3003

> NOTE: `- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page` will be automatically replaced with the proper origin (using your branch) to test performance against with AEM Sync Bot.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://EXLM-3003--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off