### PR TITLE
fix: send facets to v2 call even when having features EXLM-3003

### DIFF
--- a/blocks/recommendation-marquee/recommendation-marquee.js
+++ b/blocks/recommendation-marquee/recommendation-marquee.js
@@ -360,6 +360,9 @@ export default async function decorate(block) {
 
   const getCardsData = (payload) =>
     new Promise((resolve) => {
+      if (payload.feature?.length) {
+        payload.feature = null;
+      }
       BrowseCardsDelegate.fetchCardData(payload)
         .then((data) => {
           const [ct] = payload.contentType || [''];

--- a/blocks/recommended-content/recommended-content.js
+++ b/blocks/recommended-content/recommended-content.js
@@ -425,6 +425,9 @@ export default async function decorate(block) {
 
   const getCardsData = (payload) =>
     new Promise((resolve) => {
+      if (payload.feature?.length) {
+        payload.feature = null;
+      }
       BrowseCardsDelegate.fetchCardData(payload)
         .then((data) => {
           const [ct] = payload.contentType || [''];
@@ -959,9 +962,11 @@ export default async function decorate(block) {
               contentDiv,
             };
             return new Promise((resolve) => {
-              const savedCardModels = dataConfiguration.savedCardsResponse[lowercaseOptionType]?.[
-                payloadContentType
-              ]?.models?.filter((model) => model.markedForReplacement !== true);
+              const savedCardModels = seeMoreConfig.prefetchCards
+                ? false
+                : dataConfiguration.savedCardsResponse[lowercaseOptionType]?.[payloadContentType]?.models?.filter(
+                    (model) => model.markedForReplacement !== true,
+                  );
               let promise;
               if (Array.isArray(savedCardModels)) {
                 promise = Promise.resolve({


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-3003

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://EXLM-3003-1--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off