### PR TITLE
feat: remove exclusion of duplicates EXLM-3003

### DIFF
--- a/blocks/recommendation-marquee/recommendation-marquee.js
+++ b/blocks/recommendation-marquee/recommendation-marquee.js
@@ -20,6 +20,7 @@ import { setTargetDataAsBlockAttribute, setCoveoAnalyticsAttribute } from '../..
 const targetEventEmitter = getEmitter('loadTargetBlocks');
 const UEAuthorMode = window.hlx.aemRoot || window.location.href.includes('.html');
 const DEFAULT_NUM_CARDS = 5;
+const REMOVE_DUPLICATES_BY_EXCLUSION = false;
 let seeMoreFlag = false;
 const seeMoreConfig = {
   minWidth: 1024,
@@ -829,7 +830,10 @@ export default async function decorate(block) {
           role: role?.length ? role : profileRoles,
           sortCriteria,
           noOfResults: numberOfResults,
-          aq: !showDefaultOptions && cardIdsToExclude.length ? prepareExclusionQuery(cardIdsToExclude) : undefined,
+          aq:
+            !showDefaultOptions && cardIdsToExclude.length && REMOVE_DUPLICATES_BY_EXCLUSION
+              ? prepareExclusionQuery(cardIdsToExclude)
+              : undefined,
           context: showDefaultOptions ? {} : { interests: [interest], experience: [expLevel], role: profileRoles },
         };
 

--- a/blocks/recommended-content/recommended-content.js
+++ b/blocks/recommended-content/recommended-content.js
@@ -25,6 +25,7 @@ try {
   console.error('Error fetching placeholders:', err);
 }
 
+const REMOVE_DUPLICATES_BY_EXCLUSION = false;
 const ALL_ADOBE_OPTIONS_KEY = placeholders?.allAdobeProducts || 'All Adobe Products';
 let DEFAULT_NUM_CARDS = 4;
 let resizeObserved;
@@ -876,7 +877,10 @@ export default async function decorate(block) {
           role: role?.length ? role : profileRoles,
           sortCriteria,
           noOfResults: numberOfResults,
-          aq: !showDefaultOptions && cardIdsToExclude.length ? prepareExclusionQuery(cardIdsToExclude) : undefined,
+          aq:
+            !showDefaultOptions && cardIdsToExclude.length && REMOVE_DUPLICATES_BY_EXCLUSION
+              ? prepareExclusionQuery(cardIdsToExclude)
+              : undefined,
           context: showDefaultOptions ? {} : { interests: [interest], experience: [expLevel], role: profileRoles },
         };
 


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-3003

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://EXLM-3003-2--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off