### PR TITLE
EXLM 3111 - Fix Marquee full width Issue

### DIFF
--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -442,7 +442,16 @@ div.marquee-wrapper {
 }
 
 @media (min-width: 1280px) {
-  .marquee .marquee-text {
-    padding-left: calc(56px - ((100vw - 1280px) / 2));
+  .marquee.large.straight .marquee-content-container {
+    max-width: unset;
+  }
+
+  .marquee.large.straight .marquee-foreground {
+    max-width: calc(var(--default-max-width) / 2);
+    margin-left: auto;
+  }
+
+  .marquee.large.straight .marquee-text {
+    padding-left: calc(56px - ((100vw - var(--default-max-width)) / 2));
   }
 }

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -332,7 +332,7 @@ div.marquee-wrapper {
     height: 100%;
     left: 100%;
     top: 0;
-    width: 1000px;
+    width: 4000px;
   }
 
   .marquee.no-subject {
@@ -438,5 +438,11 @@ div.marquee-wrapper {
     border-radius: 4px;
     background-color: var(--background-color);
     box-sizing: border-box;
+  }
+}
+
+@media (min-width: 1280px) {
+  .marquee .marquee-text {
+    padding-left: calc(56px - ((100vw - 1280px) / 2));
   }
 }

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -332,7 +332,7 @@ div.marquee-wrapper {
     height: 100%;
     left: 100%;
     top: 0;
-    width: 4000px;
+    width: 100%;
   }
 
   .marquee.no-subject {

--- a/blocks/marquee/marquee.css
+++ b/blocks/marquee/marquee.css
@@ -442,16 +442,16 @@ div.marquee-wrapper {
 }
 
 @media (min-width: 1280px) {
-  .marquee.large.straight .marquee-content-container {
+  .marquee.straight .marquee-content-container {
     max-width: unset;
   }
 
-  .marquee.large.straight .marquee-foreground {
+  .marquee.straight .marquee-foreground {
     max-width: calc(var(--default-max-width) / 2);
     margin-left: auto;
   }
 
-  .marquee.large.straight .marquee-text {
+  .marquee .marquee-text {
     padding-left: calc(56px - ((100vw - var(--default-max-width)) / 2));
   }
 }


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: https://jira.corp.adobe.com/browse/EXLM-3111 

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-3111--exlm--adobe-experience-league.aem.page
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-3111--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off