### PR TITLE
EXLM-3125 Remove header options from notification banner RTE

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -929,6 +929,7 @@
                 "template": {
                   "name": "Notification Banner",
                   "model": "notification-banner",
+                  "filter": "notification-banner",
                   "bannerId": "banner-1",
                   "title": "Notification Banner Title",
                   "description": "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt"

--- a/component-filters.json
+++ b/component-filters.json
@@ -307,7 +307,7 @@
     "id": "notification-banner",
     "components": [],
     "rte": {
-      "format": ["bold", "italic"],
+      "format": ["bold", "italic", "underline"],
       "alignment": [],
       "indentation": [],
       "sr_script": ["superscript", "subscript"],

--- a/component-filters.json
+++ b/component-filters.json
@@ -311,7 +311,7 @@
       "alignment": [],
       "indentation": [],
       "sr_script": ["superscript", "subscript"],
-      "list": ["bullist", "numlist"],
+      "list": [],
       "insert": ["link"],
       "advanced": [],
       "extensions": [],

--- a/component-filters.json
+++ b/component-filters.json
@@ -304,6 +304,22 @@
     }
   },
   {
+    "id": "notification-banner",
+    "components": [],
+    "rte": {
+      "format": ["bold", "italic"],
+      "alignment": [],
+      "indentation": [],
+      "sr_script": ["superscript", "subscript"],
+      "list": ["bullist", "numlist"],
+      "insert": ["link"],
+      "advanced": [],
+      "extensions": [],
+      "editor": ["removeformat"],
+      "blocks": []
+    }
+  },
+  {
     "id": "cards",
     "components": ["card"]
   },


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-3125 

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-3125--exlm--adobe-experience-league.aem.live?martech=off
- After: https://exlm-3125--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://exlm-3125--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://exlm-3125--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off

https://author-p122525-e1200861.adobeaemcloud.com/ui#/@amc/aem/universal-editor/canvas/author-p122525-e1200861.adobeaemcloud.com/content/exlm/global/en/test-folder/fragments/notification-banner.html?ref=exlm-3125