### PR TITLE
EXLM-3132 Awards block date locale fix

### DIFF
--- a/blocks/awards/awards.js
+++ b/blocks/awards/awards.js
@@ -1,6 +1,6 @@
 import { defaultProfileClient, isSignedInUser } from '../../scripts/auth/profile.js';
 import { decorateIcons } from '../../scripts/lib-franklin.js';
-import { fetchLanguagePlaceholders } from '../../scripts/scripts.js';
+import { fetchLanguagePlaceholders, getPathDetails } from '../../scripts/scripts.js';
 import Pagination from '../../scripts/pagination/pagination.js';
 
 const UEAuthorMode = window.hlx.aemRoot || window.location.href.includes('.html');
@@ -36,22 +36,22 @@ export default async function decorate(block) {
       `;
   }
 
-  function formatTimestampToMonthYear(timestamp) {
+  function formatTimestampToMonthYear(timestamp, locale) {
     const date = new Date(timestamp);
     const options = { year: 'numeric', month: 'short' };
-    const formattedMonth = date.toLocaleDateString(undefined, options).slice(0, 3).toUpperCase();
-    const year = date.getFullYear();
-    return `${formattedMonth} ${year}`;
+    const formattedDate = date.toLocaleDateString(locale, options).toUpperCase();
+    return formattedDate;
   }
 
   if (isSignedIn) {
+    const { lang } = getPathDetails();
     const profileData = await defaultProfileClient.getMergedProfile();
     const skills = profileData?.skills;
     const awardedSkills = skills.filter((skill) => skill.award === true);
     const awardDetails = awardedSkills
       .map((skill) => ({
         originalTimestamp: skill.timestamp,
-        formattedTimestamp: formatTimestampToMonthYear(skill.timestamp),
+        formattedTimestamp: formatTimestampToMonthYear(skill.timestamp, lang),
         title: skill.name,
         description: skill.description,
       }))


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: https://jira.corp.adobe.com/browse/EXLM-3132

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://feat-exlm-3132--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off