### PR TITLE
EXLM 3141 - Fetch fragment based on Language

### DIFF
--- a/blocks/notification-banner/notification-banner.js
+++ b/blocks/notification-banner/notification-banner.js
@@ -38,11 +38,11 @@ function decorateBanner({ block, bannerId, headingElem, descriptionElem, ctaElem
   block.innerHTML = `
     <div>
       <div class='notification-banner-content'>
-        ${headingElem.textContent ? `<h3>${headingElem.innerHTML}</h3>` : ''}
-        ${descriptionElem.textContent ? `<p>${descriptionElem.innerHTML}</p>` : ''}
+        ${headingElem?.textContent.trim() ? `<h3>${headingElem.innerHTML}</h3>` : ''}
+        ${descriptionElem?.textContent.trim() ? `<p>${descriptionElem.innerHTML}</p>` : ''}
         </div>
         <div class="notification-banner-actions">
-          ${ctaElem.textContent ? `<div class='notification-banner-cta'>${ctaElem?.innerHTML}</div>` : ''}
+          ${ctaElem?.textContent.trim() ? `<div class='notification-banner-cta'>${ctaElem?.innerHTML}</div>` : ''}
           ${dismissable ? dismissButton : ''}
         </div>
       </div>

--- a/blocks/notification-banner/notification-banner.js
+++ b/blocks/notification-banner/notification-banner.js
@@ -27,8 +27,8 @@ const bannerStore = {
 function decorateBanner({ block, bannerId, headingElem, descriptionElem, ctaElem, dismissable }) {
   block.textContent = '';
 
-  const cta = ctaElem.querySelector('a');
-  cta.classList.add('button', 'secondary', 'custom', 'text-white');
+  const cta = ctaElem?.querySelector('a');
+  cta?.classList.add('button', 'secondary', 'custom', 'text-white');
 
   const dismissButton = `
   <div class='notification-banner-close'>
@@ -38,11 +38,11 @@ function decorateBanner({ block, bannerId, headingElem, descriptionElem, ctaElem
   block.innerHTML = `
     <div>
       <div class='notification-banner-content'>
-          <h3>${headingElem.innerHTML}</h3>
-          <p>${descriptionElem.innerHTML}</p>
+        ${headingElem.textContent ? `<h3>${headingElem.innerHTML}</h3>` : ''}
+        ${descriptionElem.textContent ? `<p>${descriptionElem.innerHTML}</p>` : ''}
         </div>
         <div class="notification-banner-actions">
-          <div class='notification-banner-cta'>${ctaElem.innerHTML}</div>
+          ${ctaElem.textContent ? `<div class='notification-banner-cta'>${ctaElem?.innerHTML}</div>` : ''}
           ${dismissable ? dismissButton : ''}
         </div>
       </div>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -522,15 +522,22 @@ export function getLink(edsPath) {
 
 /** @param {HTMLMapElement} main */
 async function buildPreMain(main) {
+  const { lang } = getPathDetails();
   const fragmentUrl = getMetadata('fragment');
+
   const fragmentPath = fragmentUrl ? new URL(fragmentUrl, window.location).pathname : '';
+  let fragmentLangUrl;
+  if (fragmentPath.startsWith('/en/')) {
+    fragmentLangUrl = fragmentPath.replace('/en/', `/${lang}/`);
+  }
+
   const currentPath = window.location.pathname?.replace('.html', '');
   if (currentPath.endsWith(fragmentPath)) {
     return; // do not load fragment if it is the same as the current page
   }
   if (fragmentUrl) {
     const preMain = htmlToElement(
-      `<aside><div><div class="fragment"><a href="${fragmentUrl}"></a></div></div></aside>`,
+      `<aside><div><div class="fragment"><a href="${fragmentLangUrl ?? fragmentUrl}"></a></div></div></aside>`,
     );
     // add fragment as first section in preMain
     main.before(preMain);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -529,7 +529,7 @@ async function buildPreMain(main) {
 
   const fragmentLangUrl = fragmentUrl.startsWith('/en/') ? fragmentUrl.replace('/en/', `/${lang}/`) : fragmentUrl;
   const fragmentPath = new URL(fragmentLangUrl, window.location).pathname;
-  
+
   const currentPath = window.location.pathname?.replace('.html', '');
   if (currentPath.endsWith(fragmentPath)) {
     return; // do not load fragment if it is the same as the current page

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -526,10 +526,8 @@ async function buildPreMain(main) {
   const fragmentUrl = getMetadata('fragment');
 
   const fragmentPath = fragmentUrl ? new URL(fragmentUrl, window.location).pathname : '';
-  let fragmentLangUrl;
-  if (fragmentPath.startsWith('/en/')) {
-    fragmentLangUrl = fragmentPath.replace('/en/', `/${lang}/`);
-  }
+  if (!fragmentUrl) return;
+  const fragmentLangUrl = fragmentUrl.startsWith('/en/') ? fragmentUrl.replace('/en/', `/${lang}/`) : fragmentUrl;
 
   const currentPath = window.location.pathname?.replace('.html', '');
   if (currentPath.endsWith(fragmentPath)) {
@@ -537,7 +535,7 @@ async function buildPreMain(main) {
   }
   if (fragmentUrl) {
     const preMain = htmlToElement(
-      `<aside><div><div class="fragment"><a href="${fragmentLangUrl ?? fragmentUrl}"></a></div></div></aside>`,
+      `<aside><div><div class="fragment"><a href="${fragmentLangUrl}"></a></div></div></aside>`,
     );
     // add fragment as first section in preMain
     main.before(preMain);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -525,14 +525,16 @@ async function buildPreMain(main) {
   const { lang } = getPathDetails();
   const fragmentUrl = getMetadata('fragment');
 
-  const fragmentPath = fragmentUrl ? new URL(fragmentUrl, window.location).pathname : '';
   if (!fragmentUrl) return;
-  const fragmentLangUrl = fragmentUrl.startsWith('/en/') ? fragmentUrl.replace('/en/', `/${lang}/`) : fragmentUrl;
 
+  const fragmentLangUrl = fragmentUrl.startsWith('/en/') ? fragmentUrl.replace('/en/', `/${lang}/`) : fragmentUrl;
+  const fragmentPath = new URL(fragmentLangUrl, window.location).pathname;
+  
   const currentPath = window.location.pathname?.replace('.html', '');
   if (currentPath.endsWith(fragmentPath)) {
     return; // do not load fragment if it is the same as the current page
   }
+
   if (fragmentUrl) {
     const preMain = htmlToElement(
       `<aside><div><div class="fragment"><a href="${fragmentLangUrl}"></a></div></div></aside>`,


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: https://jira.corp.adobe.com/browse/EXLM-3141 

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-3141--exlm--adobe-experience-league.aem.page
- After: https://exlm-3141--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-3141--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-3141--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-3141--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-3141--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-3141--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-3141--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-3141--exlm--adobe-experience-league.aem.page/en/browse?martech=off
