### PR TITLE
EXLM-3098 Move to top option added in profile rail

### DIFF
--- a/blocks/profile-rail/profile-rail.js
+++ b/blocks/profile-rail/profile-rail.js
@@ -149,6 +149,13 @@ export default async function ProfileRail(block) {
     newUl.classList.toggle('hidden', !hasHeadings);
     if (!hasHeadings) return;
 
+    const moveToTopLi = document.createElement('li');
+    const moveToTopLink = document.createElement('a');
+    moveToTopLink.textContent = `${placeholders?.moveToTop || 'Move to top'}`;
+    moveToTopLink.href = '#';
+    moveToTopLi.appendChild(moveToTopLink);
+    newUl.prepend(moveToTopLi);
+
     headings.forEach((h) => {
       const sectionId = formatId(h.textContent.trim());
       if (!h.id) {
@@ -171,8 +178,12 @@ export default async function ProfileRail(block) {
         activeLink = link;
         isAnchorScroll = true;
         const targetId = link.getAttribute('href').substring(1);
-        const targetElement = document.getElementById(targetId);
-        targetElement?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        if (targetId === '') {
+          document.body.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        } else {
+          const targetElement = document.getElementById(targetId);
+          targetElement?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
         setTimeout(() => {
           isAnchorScroll = false;
         }, 1000);
@@ -226,6 +237,13 @@ export default async function ProfileRail(block) {
       if (mostVisibleSection) {
         const activeSection = navLinks.find((link) => link.getAttribute('href') === `#${mostVisibleSection}`);
         activeSection?.classList.add('active');
+      }
+
+      const anyActiveLink = navLinks.some((link) => link.classList.contains('active'));
+      if (!anyActiveLink) {
+        moveToTopLink.classList.add('active');
+      } else {
+        moveToTopLink.classList.remove('active');
       }
     }
 


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: https://jira.corp.adobe.com/browse/EXLM-3098

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://feat-exlm-3098--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off