### PR TITLE
EXLM-3059 -  browser cards - always show 4 cards - base the column number on the container width

### DIFF
--- a/blocks/featured-cards/featured-cards.css
+++ b/blocks/featured-cards/featured-cards.css
@@ -34,8 +34,6 @@
 }
 
 .featured-cards .browse-cards-block-content {
-  display: grid;
-  grid-template-columns: 1fr;
   gap: 32px;
   min-height: 284px;
   margin-bottom: 24px;
@@ -47,7 +45,6 @@
 
 .featured-cards .browse-cards-block-content > div {
   min-height: 284px;
-  flex: 0 0 320px;
 }
 
 .featured-cards .browse-card-dropdown {
@@ -76,16 +73,8 @@
     padding-bottom: 30px;
   }
 
-  .featured-cards .browse-cards-block-content {
-    grid-template-columns: 1fr 1fr;
-  }
-
   .featured-cards .browse-cards-block-view {
     text-align: center;
-  }
-
-  .featured-cards .featured-cards .browse-cards-block-content > div {
-    flex: 0 0 286px;
   }
 
   .featured-cards .browse-cards-block-header .browse-card-description-text {
@@ -107,8 +96,6 @@
   }
 
   .featured-cards .browse-cards-block-content {
-    display: flex;
-    gap: 32px;
     text-align: center;
     margin-bottom: 84px;
   }
@@ -128,10 +115,6 @@
 
   .featured-cards .browse-card {
     text-align: left;
-  }
-
-  .featured-cards .browse-cards-block-content > div {
-    flex: 0 0 295px;
   }
 
   .featured-cards .custom-filter-dropdown {

--- a/blocks/featured-cards/featured-cards.js
+++ b/blocks/featured-cards/featured-cards.js
@@ -129,6 +129,7 @@ export default async function decorate(block) {
   const noOfResults = 16;
 
   block.innerHTML = '';
+  block.classList.add('browse-cards-block');
   const headerDiv = htmlToElement(`
     <div class="browse-cards-block-header">
       <div class="browse-cards-block-title">

--- a/blocks/recently-reviewed/recently-reviewed.css
+++ b/blocks/recently-reviewed/recently-reviewed.css
@@ -34,7 +34,6 @@
 }
 
 .recently-reviewed .browse-cards-block-content .card-wrapper {
-  min-height: 400px;
   max-width: 552px;
 }
 
@@ -83,6 +82,14 @@
 
 .recently-reviewed-see-more-btn {
   display: none;
+}
+
+.recently-reviewed.block .hide-see-more-row {
+  display: none;
+}
+
+.recently-reviewed.block .show-see-more-row {
+  display: grid;
 }
 
 @media (min-width: 1024px) {

--- a/blocks/recently-reviewed/recently-reviewed.css
+++ b/blocks/recently-reviewed/recently-reviewed.css
@@ -34,8 +34,7 @@
 }
 
 .recently-reviewed .browse-cards-block-content .card-wrapper {
-  flex: 1;
-  min-width: 264px;
+  min-height: 400px;
   max-width: 552px;
 }
 
@@ -46,7 +45,6 @@
 
 .recently-reviewed .browse-cards-block-content > .browse-card-no-results {
   margin-top: 0;
-  flex: 1;
   display: block;
 }
 
@@ -87,21 +85,8 @@
   display: none;
 }
 
-@media (min-width: 600px) {
-  .recently-reviewed.block .browse-cards-block-content .card-wrapper {
-    min-width: 286px;
-  }
-}
-
-@media (min-width: 900px) {
-  .recently-reviewed.block .browse-cards-block-content .card-wrapper {
-    min-width: 256px;
-  }
-}
-
 @media (min-width: 1024px) {
   .recently-reviewed.block .browse-cards-block-content {
-    overflow: hidden;
     margin-top: 24px;
   }
 

--- a/blocks/recently-reviewed/recently-reviewed.css
+++ b/blocks/recently-reviewed/recently-reviewed.css
@@ -88,10 +88,6 @@
   display: none;
 }
 
-.recently-reviewed.block .show-see-more-row {
-  display: grid;
-}
-
 @media (min-width: 1024px) {
   .recently-reviewed.block .browse-cards-block-content {
     margin-top: 24px;

--- a/blocks/recently-reviewed/recently-reviewed.css
+++ b/blocks/recently-reviewed/recently-reviewed.css
@@ -84,7 +84,7 @@
   display: none;
 }
 
-.recently-reviewed.block .hide-see-more-row {
+.recently-reviewed.block .browse-cards-block-content.hide-see-more-row {
   display: none;
 }
 

--- a/blocks/recently-reviewed/recently-reviewed.js
+++ b/blocks/recently-reviewed/recently-reviewed.js
@@ -50,7 +50,8 @@ function createSeeMoreButton(block, contentDiv, addNewRowOfCards, cardData) {
             div.classList.add('fade-out');
             div.classList.remove('fade-in');
             const handleTransitionEnd = () => {
-              div.style.display = 'none';
+              div.classList.add('hide-see-more-row');
+              div.classList.remove('show-see-more-row');
               div.removeEventListener('animationend', handleTransitionEnd);
             };
             div.addEventListener('animationend', handleTransitionEnd);
@@ -65,11 +66,11 @@ function createSeeMoreButton(block, contentDiv, addNewRowOfCards, cardData) {
 
       function showNewRow() {
         contentDivs.forEach((div, index) => {
-          div.style.display = 'grid';
+          div.classList.add('show-see-more-row');
+          div.classList.remove('hide-see-more-row');
           if (index > newRow - 1) {
-            div.style.display = 'none';
-            div.classList.remove('fade-in');
-            div.classList.add('fade-out');
+            div.classList.remove('fade-in', 'show-see-more-row');
+            div.classList.add('fade-out', 'hide-see-more-row');
           } else {
             div.classList.add('fade-in');
             div.classList.remove('fade-out');

--- a/blocks/recently-reviewed/recently-reviewed.js
+++ b/blocks/recently-reviewed/recently-reviewed.js
@@ -51,7 +51,6 @@ function createSeeMoreButton(block, contentDiv, addNewRowOfCards, cardData) {
             div.classList.remove('fade-in');
             const handleTransitionEnd = () => {
               div.classList.add('hide-see-more-row');
-              div.classList.remove('show-see-more-row');
               div.removeEventListener('animationend', handleTransitionEnd);
             };
             div.addEventListener('animationend', handleTransitionEnd);
@@ -66,10 +65,9 @@ function createSeeMoreButton(block, contentDiv, addNewRowOfCards, cardData) {
 
       function showNewRow() {
         contentDivs.forEach((div, index) => {
-          div.classList.add('show-see-more-row');
           div.classList.remove('hide-see-more-row');
           if (index > newRow - 1) {
-            div.classList.remove('fade-in', 'show-see-more-row');
+            div.classList.remove('fade-in');
             div.classList.add('fade-out', 'hide-see-more-row');
           } else {
             div.classList.add('fade-in');

--- a/blocks/recently-reviewed/recently-reviewed.js
+++ b/blocks/recently-reviewed/recently-reviewed.js
@@ -21,69 +21,11 @@ const targetEventEmitter = getEmitter('loadTargetBlocks');
 const UEAuthorMode = window.hlx.aemRoot || window.location.href.includes('.html');
 let displayBlock = false;
 
-let DEFAULT_NUM_CARDS = 4;
-let resizeObserved;
-let cardsWidth;
-let cardsGap;
+const DEFAULT_NUM_CARDS = 4;
 const seeMoreConfig = {
   minWidth: 1024,
   noOfRows: 2,
 };
-
-/**
- * Debounces a function call to limit its execution rate.
- * @param {number} ms - The debounce delay in milliseconds.
- * @param {Function} fn - The function to debounce.
- * @returns {Function} - The debounced function.
- */
-// eslint-disable-next-line class-methods-use-this
-function debounce(func, delay) {
-  let timeoutId;
-
-  return function debounced(...args) {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-    timeoutId = setTimeout(() => {
-      func.apply(this, args);
-    }, delay);
-  };
-}
-
-function resizeObserverHandler(callback, block) {
-  const debouncedCallback = debounce(callback, 500);
-  const wrapperResizeObserver = new ResizeObserver(debouncedCallback);
-  wrapperResizeObserver.observe(block);
-}
-
-function calculateNumberOfCardsToRender(container) {
-  if (window.innerWidth < seeMoreConfig.minWidth) {
-    DEFAULT_NUM_CARDS = 4;
-  } else {
-    let cardsContainer = container.querySelector('.card-wrapper');
-    if (!cardsContainer) cardsContainer = container.querySelector('.browse-card-shimmer-wrapper');
-    let containerWidth = container.offsetWidth;
-
-    if (!containerWidth) {
-      const section = container.closest('.section');
-      if (section) {
-        const originalDisplay = section.style.display;
-        section.style.display = 'block';
-        section.style.visibility = 'hidden';
-        containerWidth = container.offsetWidth;
-        section.style.display = originalDisplay;
-        section.style.visibility = 'visible';
-      }
-    }
-
-    if (!cardsWidth) cardsWidth = cardsContainer?.offsetWidth || 256;
-    if (!cardsGap) cardsGap = parseInt(getComputedStyle(cardsContainer).gap, 10) || 24;
-    const visibleItems = Math.floor((containerWidth + cardsGap) / (cardsWidth + cardsGap));
-    if (visibleItems) {
-      DEFAULT_NUM_CARDS = visibleItems;
-    }
-  }
-}
 
 function createSeeMoreButton(block, contentDiv, addNewRowOfCards, cardData) {
   if (!block.querySelector('.recently-reviewed-see-more-btn')) {
@@ -123,7 +65,7 @@ function createSeeMoreButton(block, contentDiv, addNewRowOfCards, cardData) {
 
       function showNewRow() {
         contentDivs.forEach((div, index) => {
-          div.style.display = 'flex';
+          div.style.display = 'grid';
           if (index > newRow - 1) {
             div.style.display = 'none';
             div.classList.remove('fade-in');
@@ -219,6 +161,7 @@ export default async function decorate(block) {
   defaultAdobeTargetClient.checkTargetSupport().then((targetSupport) => {
     let headingElement;
     let descriptionElement;
+    block.classList.add('browse-cards-block');
     if (!block.dataset.targetScope) {
       [headingElement, descriptionElement] = [...block.children].map((row) => row.firstElementChild);
     } else {
@@ -242,7 +185,6 @@ export default async function decorate(block) {
     }
 
     let isTooltipListenerAdded = false;
-    resizeObserved = false;
 
     function addNewRowOfCards(cardData, args = { clear: false }) {
       let contentDivs = block.querySelectorAll('.browse-cards-block-content');
@@ -288,28 +230,6 @@ export default async function decorate(block) {
       }
     }
 
-    function calculateNumberOfCardsOnResize(cardData) {
-      if (!resizeObserved) {
-        let previousWidth = block.offsetWidth;
-        resizeObserverHandler((entries) => {
-          if (resizeObserved) {
-            entries.forEach((entry) => {
-              const { width } = entry.contentRect;
-              if (!previousWidth) previousWidth = block.offsetWidth;
-              if (Math.abs(entry.contentRect.width - previousWidth) > 1) {
-                // Calculate no. of cards that fits
-                calculateNumberOfCardsToRender(block);
-                addNewRowOfCards(cardData, { clear: true });
-                // Render the new set of cards
-                previousWidth = width;
-              }
-            });
-          }
-          resizeObserved = true;
-        }, block);
-      }
-    }
-
     function renderCards() {
       defaultAdobeTargetClient.getTargetData(block.dataset.targetScope).then(async (resp) => {
         updateCopyFromTarget(resp, headingElement, descriptionElement);
@@ -319,9 +239,7 @@ export default async function decorate(block) {
           appendNavAndContent();
           buildCardsShimmer.addShimmer(block);
           const cardData = await BrowseCardsTargetDataAdapter.mapResultsToCardsData(resp.data);
-          calculateNumberOfCardsToRender(block);
           addNewRowOfCards(cardData, { clear: true }); // eslint-disable-next-line no-new
-          calculateNumberOfCardsOnResize(cardData);
           setTargetDataAsBlockAttribute(block, resp);
         } else {
           const contentDiv = document.createElement('div');

--- a/blocks/recommendation-marquee/recommendation-marquee.css
+++ b/blocks/recommendation-marquee/recommendation-marquee.css
@@ -108,6 +108,7 @@
 }
 
 .recommendation-marquee.block .browse-cards-block-content .card-wrapper .browse-card {
+  min-height: auto;
   border-radius: 16px;
   box-shadow: var(--box-shadow-2);
 }

--- a/blocks/recommendation-marquee/recommendation-marquee.css
+++ b/blocks/recommendation-marquee/recommendation-marquee.css
@@ -84,6 +84,7 @@
 }
 
 .recommendation-marquee.block .browse-card-shimmer {
+  grid-template-columns: 1fr;
   min-width: 100%;
   max-height: 404px;
   overflow: hidden;
@@ -91,6 +92,7 @@
 }
 
 .recommendation-marquee.block .browse-cards-block-content {
+  display: flex;
   margin-top: 0;
   margin-bottom: 0;
   padding-bottom: 4px;

--- a/blocks/recommended-content/recommended-content.css
+++ b/blocks/recommended-content/recommended-content.css
@@ -117,7 +117,6 @@ body.profile
 }
 
 .recommended-content.block .browse-cards-block-content .card-wrapper {
-  min-height: 400px;
   max-width: 552px;
 }
 
@@ -221,6 +220,14 @@ body.profile
 
 .recommended-content-see-more-btn {
   display: none;
+}
+
+.recommended-content.block .hide-see-more-row {
+  display: none;
+}
+
+.recommended-content.block .show-see-more-row {
+  display: grid;
 }
 
 @media (min-width: 420px) {

--- a/blocks/recommended-content/recommended-content.css
+++ b/blocks/recommended-content/recommended-content.css
@@ -222,7 +222,7 @@ body.profile
   display: none;
 }
 
-.recommended-content.block .hide-see-more-row {
+.recommended-content.block .browse-cards-block-content.hide-see-more-row {
   display: none;
 }
 

--- a/blocks/recommended-content/recommended-content.css
+++ b/blocks/recommended-content/recommended-content.css
@@ -102,6 +102,7 @@ body.profile
 }
 
 .recommended-content.block .browse-card-shimmer {
+  grid-template-columns: 1fr;
   min-width: 100%;
   max-height: 404px;
   overflow: hidden;
@@ -113,12 +114,10 @@ body.profile
   margin-bottom: 0;
   padding-bottom: 4px;
   gap: 24px;
-  display: flex;
 }
 
 .recommended-content.block .browse-cards-block-content .card-wrapper {
-  flex: 1;
-  min-width: 264px;
+  min-height: 400px;
   max-width: 552px;
 }
 
@@ -235,10 +234,6 @@ body.profile
     display: flex;
   }
 
-  .recommended-content.block .browse-cards-block-content .card-wrapper {
-    min-width: 286px;
-  }
-
   .recommended-content-result-text {
     display: flex;
     align-items: flex-start;
@@ -255,10 +250,6 @@ body.profile
 }
 
 @media (min-width: 900px) {
-  .recommended-content.block .browse-cards-block-content .card-wrapper {
-    min-width: 256px;
-  }
-
   .recommended-content-result-text {
     gap: 148px;
   }
@@ -270,7 +261,6 @@ body.profile
 
 @media (min-width: 1024px) {
   .recommended-content.block .browse-cards-block-content {
-    overflow: hidden;
     margin-top: 24px;
   }
 

--- a/blocks/recommended-content/recommended-content.css
+++ b/blocks/recommended-content/recommended-content.css
@@ -226,10 +226,6 @@ body.profile
   display: none;
 }
 
-.recommended-content.block .show-see-more-row {
-  display: grid;
-}
-
 @media (min-width: 420px) {
   .recommended-content.block .custom-filter-dropdown {
     min-width: 360px;

--- a/blocks/recommended-content/recommended-content.js
+++ b/blocks/recommended-content/recommended-content.js
@@ -966,7 +966,6 @@ export default async function decorate(block) {
             }
             const cardsCount = contentDiv.querySelectorAll('.browse-card').length;
             if (cardsCount !== 0) {
-              contentDiv.querySelectorAll(':scope > *:not(:has(.browse-card)').forEach((card) => card?.remove()); // Remove empty cards
               createSeeMoreButton(block, contentDiv, fetchDataAndRenderBlock);
               if (!isTooltipListenerAdded) {
                 hideTooltipOnScroll(contentDiv);

--- a/blocks/recommended-content/recommended-content.js
+++ b/blocks/recommended-content/recommended-content.js
@@ -27,10 +27,7 @@ try {
 
 const REMOVE_DUPLICATES_BY_EXCLUSION = false;
 const ALL_ADOBE_OPTIONS_KEY = placeholders?.allAdobeProducts || 'All Adobe Products';
-let DEFAULT_NUM_CARDS = 4;
-let resizeObserved;
-let cardsWidth;
-let cardsGap;
+const DEFAULT_NUM_CARDS = 4;
 const seeMoreConfig = {
   minWidth: 1024,
   noOfRows: 2,
@@ -57,39 +54,6 @@ function generateLoadingShimmer(shimmerSizes = [[100, 30]]) {
         `<div class="loading-shimmer" style="--placeholder-width: ${width}%; --placeholder-height: ${height}px"></div>`,
     )
     .join('');
-}
-
-function calculateNumberOfCardsToRender(container) {
-  if (window.innerWidth < seeMoreConfig.minWidth) {
-    DEFAULT_NUM_CARDS = 4;
-  } else {
-    const cardsContainer = container.querySelector('.card-wrapper');
-    let containerWidth = container.offsetWidth;
-
-    if (!containerWidth) {
-      const section = container.closest('.section');
-      if (section) {
-        const originalDisplay = section.style.display;
-        section.style.display = 'block';
-        section.style.visibility = 'hidden';
-        containerWidth = container.offsetWidth;
-        section.style.display = originalDisplay;
-        section.style.visibility = 'visible';
-      }
-    }
-    const DEFAULT_CARD_WIDTH = 256;
-    const DEFAULT_CARD_GAP = 24;
-    if (!cardsWidth) cardsWidth = cardsContainer?.offsetWidth || DEFAULT_CARD_WIDTH;
-    if (!cardsGap) {
-      cardsGap = cardsContainer
-        ? parseInt(getComputedStyle(cardsContainer).gap, 10) || DEFAULT_CARD_GAP
-        : DEFAULT_CARD_GAP;
-    }
-    const visibleItems = Math.floor((containerWidth + cardsGap) / (cardsWidth + cardsGap));
-    if (visibleItems) {
-      DEFAULT_NUM_CARDS = visibleItems;
-    }
-  }
 }
 
 function ensureDataSaveConfigExists(dataConfiguration, lowercaseOptionType, ctType) {
@@ -176,7 +140,7 @@ function createSeeMoreButton(block, contentDiv, fetchDataAndRenderBlock) {
 
       function showNewRow() {
         contentDivs.forEach((div, index) => {
-          div.style.display = 'flex';
+          div.style.display = 'grid';
 
           if (index > newRow - 1) {
             div.style.display = 'none';
@@ -216,32 +180,6 @@ function createSeeMoreButton(block, contentDiv, fetchDataAndRenderBlock) {
       }
     });
   }
-}
-
-/**
- * Debounces a function call to limit its execution rate.
- * @param {number} ms - The debounce delay in milliseconds.
- * @param {Function} fn - The function to debounce.
- * @returns {Function} - The debounced function.
- */
-// eslint-disable-next-line class-methods-use-this
-function debounce(func, delay) {
-  let timeoutId;
-
-  return function debounced(...args) {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-    timeoutId = setTimeout(() => {
-      func.apply(this, args);
-    }, delay);
-  };
-}
-
-function resizeObserverHandler(callback, block) {
-  const debouncedCallback = debounce(callback, 500);
-  const wrapperResizeObserver = new ResizeObserver(debouncedCallback);
-  wrapperResizeObserver.observe(block);
 }
 
 /**
@@ -363,7 +301,7 @@ export default async function decorate(block) {
 `;
   // Clearing the block's content and adding CSS class
   block.innerHTML = '';
-
+  block.classList.add('browse-cards-block');
   filterSectionElement.classList.add('recommended-content-filter-heading');
   const headingElementNode = htmlToElement(headingElement.innerHTML);
   const blockHeader = createTag('div', { class: 'recommended-content-block-header' });
@@ -391,7 +329,6 @@ export default async function decorate(block) {
     `);
   const tempContentSection = tempWrapper.querySelector('.recommended-content-block-section');
   block.appendChild(tempWrapper);
-  calculateNumberOfCardsToRender(block);
   countNumberAsArray(DEFAULT_NUM_CARDS).forEach(() => {
     const { shimmer: shimmerInstance, wrapper } = renderCardPlaceholders(tempWrapper);
     shimmerInstance.addShimmer(wrapper);
@@ -406,29 +343,6 @@ export default async function decorate(block) {
     savedCardsResponse: {},
   };
   let isTooltipListenerAdded = false;
-  resizeObserved = false;
-
-  function calculateNumberOfCardsOnResize(fetchDataAndRenderBlock) {
-    if (!resizeObserved) {
-      let previousWidth = block.offsetWidth;
-      resizeObserverHandler((entries) => {
-        if (resizeObserved) {
-          entries.forEach((entry) => {
-            const { width } = entry.contentRect;
-            if (Math.abs(entry.contentRect.width - previousWidth) > 1) {
-              const optionType = block.querySelector('.browse-cards-block-content').dataset.selected;
-              // Calculate no. of cards that fits
-              calculateNumberOfCardsToRender(block);
-              // Render the new set of cards
-              fetchDataAndRenderBlock(optionType, { renderCards: true, createRow: true, clearAllRows: true });
-              previousWidth = width;
-            }
-          });
-        }
-        resizeObserved = true;
-      }, block);
-    }
-  }
 
   const getCardsData = (payload) =>
     new Promise((resolve) => {
@@ -616,8 +530,6 @@ export default async function decorate(block) {
         setCoveoAnalyticsAttribute(block);
         block.style.display = 'block';
       }
-
-      calculateNumberOfCardsToRender(block);
 
       const sortByContent = sortEl?.innerText?.trim();
 
@@ -1054,7 +966,7 @@ export default async function decorate(block) {
             }
             const cardsCount = contentDiv.querySelectorAll('.browse-card').length;
             if (cardsCount !== 0) {
-              calculateNumberOfCardsOnResize(fetchDataAndRenderBlock);
+              contentDiv.querySelectorAll(':scope > *:not(:has(.browse-card)').forEach((card) => card?.remove()); // Remove empty cards
               createSeeMoreButton(block, contentDiv, fetchDataAndRenderBlock);
               if (!isTooltipListenerAdded) {
                 hideTooltipOnScroll(contentDiv);

--- a/blocks/recommended-content/recommended-content.js
+++ b/blocks/recommended-content/recommended-content.js
@@ -125,7 +125,8 @@ function createSeeMoreButton(block, contentDiv, fetchDataAndRenderBlock) {
             div.classList.add('fade-out');
             div.classList.remove('fade-in');
             const handleTransitionEnd = () => {
-              div.style.display = 'none';
+              div.classList.add('hide-see-more-row');
+              div.classList.remove('show-see-more-row');
               div.removeEventListener('animationend', handleTransitionEnd);
             };
             div.addEventListener('animationend', handleTransitionEnd);
@@ -140,12 +141,12 @@ function createSeeMoreButton(block, contentDiv, fetchDataAndRenderBlock) {
 
       function showNewRow() {
         contentDivs.forEach((div, index) => {
-          div.style.display = 'grid';
+          div.classList.add('show-see-more-row');
+          div.classList.remove('hide-see-more-row');
 
           if (index > newRow - 1) {
-            div.style.display = 'none';
-            div.classList.remove('fade-in');
-            div.classList.add('fade-out');
+            div.classList.remove('fade-in', 'show-see-more-row');
+            div.classList.add('fade-out', 'hide-see-more-row');
           } else {
             div.classList.add('fade-in');
             div.classList.remove('fade-out');

--- a/blocks/recommended-content/recommended-content.js
+++ b/blocks/recommended-content/recommended-content.js
@@ -126,7 +126,6 @@ function createSeeMoreButton(block, contentDiv, fetchDataAndRenderBlock) {
             div.classList.remove('fade-in');
             const handleTransitionEnd = () => {
               div.classList.add('hide-see-more-row');
-              div.classList.remove('show-see-more-row');
               div.removeEventListener('animationend', handleTransitionEnd);
             };
             div.addEventListener('animationend', handleTransitionEnd);
@@ -141,11 +140,10 @@ function createSeeMoreButton(block, contentDiv, fetchDataAndRenderBlock) {
 
       function showNewRow() {
         contentDivs.forEach((div, index) => {
-          div.classList.add('show-see-more-row');
           div.classList.remove('hide-see-more-row');
 
           if (index > newRow - 1) {
-            div.classList.remove('fade-in', 'show-see-more-row');
+            div.classList.remove('fade-in');
             div.classList.add('fade-out', 'hide-see-more-row');
           } else {
             div.classList.add('fade-in');

--- a/blocks/tabbed-cards/tabbed-cards.css
+++ b/blocks/tabbed-cards/tabbed-cards.css
@@ -47,7 +47,7 @@
   line-height: 23.4px;
 }
 
-.tabbed-cards .hide-tab {
+.tabbed-cards .browse-cards-block-content.hide-tab {
   display: none;
 }
 

--- a/blocks/tabbed-cards/tabbed-cards.css
+++ b/blocks/tabbed-cards/tabbed-cards.css
@@ -47,6 +47,14 @@
   line-height: 23.4px;
 }
 
+.tabbed-cards .show-tab {
+  display: grid;
+}
+
+.tabbed-cards .hide-tab {
+  display: none;
+}
+
 @media (max-width: 1024px) {
   .tabbed-cards-label {
     border-bottom: 0 none;

--- a/blocks/tabbed-cards/tabbed-cards.css
+++ b/blocks/tabbed-cards/tabbed-cards.css
@@ -47,10 +47,6 @@
   line-height: 23.4px;
 }
 
-.tabbed-cards .show-tab {
-  display: grid;
-}
-
 .tabbed-cards .hide-tab {
   display: none;
 }

--- a/blocks/tabbed-cards/tabbed-cards.js
+++ b/blocks/tabbed-cards/tabbed-cards.js
@@ -110,20 +110,21 @@ export default async function decorate(block) {
           }
           // Append content div to shimmer card parent and decorate icons
           block.appendChild(contentDiv);
-          contentDiv.style.display = 'grid';
+          contentDiv.classList.remove('hide-tab');
+          contentDiv.classList.add('show-tab');
           /* Hide Tooltip while scrolling the cards layout */
           hideTooltipOnScroll(contentDiv);
         } else {
           buildCardsShimmer.removeShimmer();
           buildNoResultsContent(block, true);
-          contentDiv.style.display = 'none';
+          contentDiv.classList.add('hide-tab');
         }
       })
       .catch((err) => {
         // Hide shimmer placeholders on error
         buildCardsShimmer.removeShimmer();
         buildNoResultsContent(block, true);
-        contentDiv.style.display = 'none';
+        contentDiv.classList.add('hide-tab');
         /* eslint-disable-next-line no-console */
         console.error(err);
       });
@@ -159,7 +160,7 @@ export default async function decorate(block) {
         tabLabel.classList.add('active');
         if (tabbedContent) {
           tabbedContent.innerHTML = '';
-          tabbedContent.style.display = 'none';
+          contentDiv.classList.add('hide-tab');
         }
 
         // Clear No Results Content if avaliabel

--- a/blocks/tabbed-cards/tabbed-cards.js
+++ b/blocks/tabbed-cards/tabbed-cards.js
@@ -111,7 +111,6 @@ export default async function decorate(block) {
           // Append content div to shimmer card parent and decorate icons
           block.appendChild(contentDiv);
           contentDiv.classList.remove('hide-tab');
-          contentDiv.classList.add('show-tab');
           /* Hide Tooltip while scrolling the cards layout */
           hideTooltipOnScroll(contentDiv);
         } else {

--- a/blocks/tabbed-cards/tabbed-cards.js
+++ b/blocks/tabbed-cards/tabbed-cards.js
@@ -110,7 +110,7 @@ export default async function decorate(block) {
           }
           // Append content div to shimmer card parent and decorate icons
           block.appendChild(contentDiv);
-          contentDiv.style.display = 'flex';
+          contentDiv.style.display = 'grid';
           /* Hide Tooltip while scrolling the cards layout */
           hideTooltipOnScroll(contentDiv);
         } else {

--- a/scripts/browse-card/browse-card-shimmer.css
+++ b/scripts/browse-card/browse-card-shimmer.css
@@ -7,15 +7,26 @@
 .browse-card-shimmer {
   position: relative;
   height: 100%;
-  display: flex;
-  flex-wrap: nowrap;
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 16px;
   transition: all 0.5s ease-in-out;
-  overflow: auto hidden;
   min-height: 400px;
   margin: 0;
   z-index: 1;
   margin-top: 16px;
+}
+
+@container browse-cards-block (min-width: 600px) {
+  .browse-card-shimmer {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@container browse-cards-block (min-width: 1024px) {
+  .browse-card-shimmer {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 
 .browse-card-shimmer-text-wrapper {
@@ -52,9 +63,6 @@
 }
 
 .featured-cards .browse-card-shimmer {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 32px;
   margin-top: 24px;
 }
 
@@ -63,7 +71,6 @@
   height: 100%;
   border-radius: 4px;
   overflow: hidden;
-  flex: 0 0 264px;
   border: 1px solid var(--spectrum-gray-200);
 }
 
@@ -75,21 +82,12 @@
 @media only screen and (min-width: 600px) {
   .browse-card-shimmer {
     gap: 25px;
-    overflow: auto hidden;
     margin-top: 16px;
   }
 
-  .featured-cards .browse-card-shimmer,
   .browse-filters-wrapper .browse-card-shimmer {
     grid-template-columns: 1fr 1fr;
-  }
-
-  .browse-filters-wrapper .browse-card-shimmer {
     margin-top: 0;
-  }
-
-  .browse-card-shimmer-wrapper {
-    flex: 0 0 286px;
   }
 }
 
@@ -97,19 +95,6 @@
   .browse-card-shimmer {
     gap: 32px;
     margin-top: 24px;
-  }
-
-  .browse-card-shimmer-wrapper {
-    flex: 0 0 256px;
-  }
-
-  .featured-cards .browse-card-shimmer {
-    display: flex;
-    gap: 32px;
-  }
-
-  .featured-cards .browse-card-shimmer-wrapper {
-    flex: 0 0 295px;
   }
 
   .browse-filters-wrapper .browse-card-shimmer {

--- a/scripts/browse-card/browse-card-shimmer.css
+++ b/scripts/browse-card/browse-card-shimmer.css
@@ -25,7 +25,7 @@
 
 @container browse-cards-block (min-width: 1024px) {
   .browse-card-shimmer {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 }
 

--- a/scripts/browse-card/browse-card.css
+++ b/scripts/browse-card/browse-card.css
@@ -32,6 +32,7 @@
   height: 100%;
   border-radius: 16px;
   word-break: break-word;
+  min-height: 400px;
 }
 
 .browse-card:hover {

--- a/scripts/browse-card/browse-cards-block.css
+++ b/scripts/browse-card/browse-cards-block.css
@@ -108,7 +108,7 @@
 
 @container browse-cards-block (min-width: 1024px) {
   .browse-cards-block-content {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 }
 

--- a/scripts/browse-card/browse-cards-block.css
+++ b/scripts/browse-card/browse-cards-block.css
@@ -8,6 +8,9 @@
 .browse-cards-block {
   min-height: 532px;
   position: relative;
+  display: block;
+  container-type: inline-size;
+  container-name: browse-cards-block;
 }
 
 .browse-cards-block-title {
@@ -87,19 +90,26 @@
 }
 
 .browse-cards-block-content {
+  display: grid;
+  grid-template-columns: 1fr;
   margin-top: 16px;
-  display: flex;
-  flex-wrap: nowrap;
   gap: 16px;
   margin-bottom: 40px;
   transition: all 0.5s ease-in-out;
-  overflow: auto hidden;
   padding-bottom: 2px;
   min-height: 400px;
 }
 
-.browse-cards-block-content > div {
-  flex: 0 0 264px;
+@container browse-cards-block (min-width: 600px) {
+  .browse-cards-block-content {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@container browse-cards-block (min-width: 1024px) {
+  .browse-cards-block-content {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 
 .browse-cards-block-content > div:first-child .browse-card .user-actions .action-tooltip {
@@ -118,7 +128,6 @@
 
   .browse-cards-block-content {
     gap: 25px;
-    overflow: auto hidden;
     margin-bottom: 56px;
     margin-top: 16px;
   }


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.
EXLM-3059 

This PR uses [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) to address an issue with card widths on browse pages. It ensure a specific number of clolumns in card grid is used based on the _container width_ NOT the _view port width_



https://github.com/user-attachments/assets/ccebde23-0760-4172-b2dd-dc77e39028ef



<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://EXLM-3059-v2--exlm--adobe-experience-league.aem.page
- After: https://EXLM-3059-v2--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://EXLM-3059-v2--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://EXLM-3059-v2--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off