### PR TITLE
Move load blocks to lazy phase for premain

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -543,7 +543,6 @@ async function buildPreMain(main) {
     main.before(preMain);
     decorateSections(preMain);
     decorateBlocks(preMain);
-    loadBlocks(preMain);
   }
 }
 
@@ -871,8 +870,10 @@ async function loadThemes() {
  */
 async function loadLazy(doc) {
   const main = doc.querySelector('main');
+  const preMain = doc.body.querySelector(':scope > aside');
   loadIms(); // start it early, asyncronously
   await loadThemes();
+  if (preMain) await loadBlocks(preMain);
   await loadBlocks(main);
 
   const { hash } = window.location;


### PR DESCRIPTION
... to ensure that themes are loaded first, then all blocks, including the ones in premain

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://premain-order--exlm--adobe-experience-league.aem.page
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://premain-order--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off