### PR TITLE
fix: Code block rendering in UE mode exlm-3281

### DIFF
--- a/blocks/code/code.js
+++ b/blocks/code/code.js
@@ -1,3 +1,5 @@
+import { htmlToElement } from '../../scripts/scripts.js';
+
 function getDataLineValue(arr) {
   let dataLineValue = '';
   arr.forEach((className) => {
@@ -11,7 +13,21 @@ export default function decorate(block) {
   const [preElement, lineNumberingEl, lineHighlightingEl] = htmlElementData;
 
   const preTagAttributes = {};
-  block.innerHTML = preElement.outerHTML;
+  let preTagElement = preElement.childElementCount === 1 ? preElement.firstElementChild : preElement;
+  if (preTagElement.tagName !== 'PRE') {
+    const newPre = htmlToElement(`<pre>${preTagElement.innerHTML}</pre>`);
+    preElement.innerHTML = '';
+    preElement.appendChild(newPre);
+    preTagElement = newPre;
+  }
+
+  if (!preTagElement.querySelector('code')) {
+    const codeEl = htmlToElement(`<code>${preTagElement.innerHTML}</code>`);
+    preTagElement.innerHTML = '';
+    preTagElement.appendChild(codeEl);
+  }
+  preTagElement.innerHTML = preTagElement.innerHTML.replace(/<br>/g, '\n');
+  block.innerHTML = preTagElement.outerHTML;
   const dataLine = [];
   const pre = block.querySelector('pre');
 
@@ -54,4 +70,13 @@ export default function decorate(block) {
       pre.setAttribute(key, value);
     }
   });
+
+  const UEAuthorMode = window.hlx.aemRoot || window.location.href.includes('.html');
+  if (UEAuthorMode && window.Prism) {
+    // This block is to re-highlight the code block once UE changes the block content.
+    setTimeout(() => {
+      // Wait until the newly updated block is added to DOM and ready for Prism to highlight.
+      window.Prism.highlightAllUnder(block, true);
+    }, 250);
+  }
 }


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-3281

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-3281--exlm--adobe-experience-league.aem.page
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-3281--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off