### PR TITLE
feature/UGP-9959 Fix spacing order on blocks

### DIFF
--- a/blocks/article-metadata-appliesto/article-metadata-appliesto.css
+++ b/blocks/article-metadata-appliesto/article-metadata-appliesto.css
@@ -35,9 +35,3 @@
   font-size: var(--spectrum-font-size-100);
   margin-right: 7px;
 }
-
-.article-metadata-container .article-metadata-appliesto-wrapper {
-  border-bottom: 1px solid var(--non-spectrurm-whisper-gray);
-  padding-bottom: 38px;
-  margin-bottom: 32px;
-}

--- a/blocks/article-metadata-createdby/article-metadata-createdby.css
+++ b/blocks/article-metadata-createdby/article-metadata-createdby.css
@@ -53,5 +53,7 @@
 }
 
 .article-metadata-container .article-metadata-createdby-wrapper {
-  margin-bottom: 5px;
+  border-bottom: 1px solid var(--non-spectrurm-whisper-gray);
+  padding-bottom: 38px;
+  margin-bottom: 32px;
 }


### PR DESCRIPTION
Jira ID: UGP-9959 Show version(s) as 'Applies to' in ExL pages

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page
- After: https://feature-ugp-9959--exlm--adobe-experience-league.aem.page

- After: https://feature-UGP-9959--exlm--adobe-experience-league.aem.page
- After: https://feature-UGP-9959--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://feature-UGP-9959--exlm--adobe-experience-league.aem.page/en/docs/experience-manager-cloud-service/content/forms/adaptive-forms-authoring/authoring-adaptive-forms-core-components/create-an-adaptive-form-on-forms-cs/template-editor-core-components?martech=off
- After: https://feature-UGP-9959--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://feature-UGP-9959--exlm--adobe-experience-league.aem.page/en/docs/internal-test/test/table-spans?martech=off
- After: https://feature-UGP-9959--exlm--adobe-experience-league.aem.page/en/docs/internal-test/test/bug-fixes/zoomable-images-tables?martech=off

