### PR TITLE
UGP-9959 Adding separator to "Applies to" items

### DIFF
--- a/blocks/article-metadata-appliesto/article-metadata-appliesto.css
+++ b/blocks/article-metadata-appliesto/article-metadata-appliesto.css
@@ -10,6 +10,11 @@
   font-size: var(--spectrum-font-size-100);
 }
 
+.article-metadata-appliesto li + li:not(:last-child)::after {
+  content: ' |';
+  margin-left: 0.75em;
+}
+
 .article-metadata-appliesto li:first-child {
   font-size: var(--spectrum-font-size-75);
   text-transform: uppercase;
@@ -19,7 +24,7 @@
 }
 
 .article-metadata-appliesto ul > li:not(:first-child) {
-  margin-bottom: 14px;
+  margin-bottom: unset;
   margin-right: 8px;
 }
 

--- a/blocks/article-metadata-createdby/article-metadata-createdby.css
+++ b/blocks/article-metadata-createdby/article-metadata-createdby.css
@@ -22,6 +22,11 @@
   margin-top: 0;
 }
 
+.article-metadata-createdby li:not(:last-child)::after {
+  content: ' |';
+  margin-left: 0.75em;
+}
+
 .article-metadata-createdby ul > li:not(:last-child) {
   margin-bottom: 0;
 }

--- a/blocks/article-metadata-topics/article-metadata-topics.css
+++ b/blocks/article-metadata-topics/article-metadata-topics.css
@@ -10,6 +10,11 @@
   font-size: var(--spectrum-font-size-100);
 }
 
+.article-metadata-topics li + li:not(:last-child)::after {
+  content: ' |';
+  margin-left: 0.75em;
+}
+
 .article-metadata-topics li:first-child {
   font-size: var(--spectrum-font-size-75);
   text-transform: uppercase;
@@ -33,5 +38,4 @@
   cursor: default;
   color: inherit;
   font-size: var(--spectrum-font-size-100);
-  margin-right: 7px;
 }


### PR DESCRIPTION
Jira ID: UGP-9929
<img width="767" alt="Screenshot 2025-04-22 at 11 14 48" src="https://github.com/user-attachments/assets/233ee62c-751c-4735-a843-bfd391c1c237" />


Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page
- After: https://ugp-9959-1--exlm--adobe-experience-league.aem.page

- After: https://UGP-9959-1--exlm--adobe-experience-league.aem.page
- After: https://UGP-9959-1--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://UGP-9959-1--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://UGP-9959-1--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://UGP-9959-1--exlm--adobe-experience-league.aem.page/en/docs/internal-test/test/table-spans?martech=off
- After: https://UGP-9959-1--exlm--adobe-experience-league.aem.page/en/docs/experience-manager-cloud-service/content/forms/adaptive-forms-authoring/authoring-adaptive-forms-core-components/create-an-adaptive-form-on-forms-cs/template-editor-core-components?martech=off
- After: https://UGP-9959-1--exlm--adobe-experience-league.aem.page/en/docs/internal-test/test/bug-fixes/zoomable-images-tables?martech=off
