### PR TITLE
Bugfix/UGP-13000  Caution badges rendering as gray instead of yellow

### DIFF
--- a/styles/theme/docs.css
+++ b/styles/theme/docs.css
@@ -321,8 +321,11 @@
   background-color: var(--spectrum-red-900);
 }
 
-.docs .badge.neutral,
-.docs .badge.caution,
 .docs .badge.yellow {
+  background-color: var(--spectrum-yellow-500);
+}
+
+.docs .badge.neutral,
+.docs .badge.caution {
   background-color: var(--spectrum-gray-600);
 }


### PR DESCRIPTION
Jira ID: UGP-13000 - Caution badges rendering as gray instead of yellow

<img width="749" alt="Screenshot 2025-04-23 at 11 01 31" src="https://github.com/user-attachments/assets/bb9a93de-d425-4b53-890b-6b5cdf8ac00c" />


Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page
- After: https://bugfix-ugp-1300--exlm--adobe-experience-league.aem.page

- After: https://Bugfix-UGP-1300--exlm--adobe-experience-league.aem.page
- After: https://Bugfix-UGP-1300--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://Bugfix-UGP-1300--exlm--adobe-experience-league.aem.page/en/docs/internal-test/test/feature-testing/badge?martech=off
- After: https://Bugfix-UGP-1300--exlm--adobe-experience-league.aem.page/en/docs/experience-manager-cloud-service/content/implementing/developing/universal-editor/page-editor-universal-editor?martech=off