### PR TITLE
UGP-13018 Update to the feedback program redirect

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1211,7 +1211,10 @@ export function getLastDocsSection() {
 
 /** handles a set of 1-1 redirects */
 function handleRedirects() {
-  const redirects = ['/#feedback:/home#feedback'].map((p) => p.split(':').map((s) => new URL(s, window.location.href)));
+  const { lang } = getPathDetails();
+  const redirects = [`/#feedback:/${lang}/feedback-program`].map((p) =>
+    p.split(':').map((s) => new URL(s, window.location.href)),
+  );
   const redirect = redirects.find(([from]) => window.location.href === from.href);
   if (redirect) window.location.href = redirect[1].href;
 }


### PR DESCRIPTION
Jira ID: UGP-13018

In the legacy header, update the new feedback program page link to https://experienceleague.adobe.com/en/feedback-program

Javascript redirection update from /#feedback to /en/feedback-program

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page
- After: https://bugfix-ugp-13018--exlm--adobe-experience-league.aem.page

- After: https://Bugfix-UGP-13018--exlm--adobe-experience-league.aem.page
- After: https://Bugfix-UGP-13018--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://Bugfix-UGP-13018--exlm--adobe-experience-league.aem.page/#feedback
