### PR TITLE
EXLM 3328 - Fix Search URL query parameter format

### DIFF
--- a/scripts/search/search.js
+++ b/scripts/search/search.js
@@ -21,12 +21,12 @@ export const redirectToSearchPage = (searchInput, filters = '') => {
     targetUrlWithLanguage += '#sort=relevancy';
   }
   if (filterValue) {
-    const filterValueEncoded = encodeURIComponent(`[${filterValue}]`);
-    targetUrlWithLanguage += `&f:@el_contenttype=${filterValueEncoded}`;
+    const filterValueEncoded = encodeURIComponent(filterValue);
+    targetUrlWithLanguage += `&f-@el_contenttype=${filterValueEncoded}`;
   }
   if (solution) {
-    const solutionEncoded = encodeURIComponent(`[${solution}]`);
-    targetUrlWithLanguage += `&f:el_product=${solutionEncoded}`;
+    const solutionEncoded = encodeURIComponent(solution);
+    targetUrlWithLanguage += `&f-el_product=${solutionEncoded}`;
   }
 
   window.location.href = targetUrlWithLanguage;


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: https://jira.corp.adobe.com/browse/EXLM-3328 

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-3328-query--exlm--adobe-experience-league.aem.page
- After: https://exlm-3328-query--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-3328-query--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-3328-query--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-3328-query--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-3328-query--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off