### PR TITLE
Fix Browse rail sub page issue

### DIFF
--- a/blocks/browse-rail/browse-rail-utils.js
+++ b/blocks/browse-rail/browse-rail-utils.js
@@ -1,7 +1,6 @@
 import { getLink } from '../../scripts/scripts.js';
 // Utility function to filter sub-pages under a given path
-export const filterSubPages = (data, basePath) =>
-  data.filter((page) => page.path.startsWith(`${basePath}/`) && page.path !== basePath);
+export const filterSubPages = (data, basePath) => data.filter((page) => page.path.startsWith(`${basePath}/`));
 
 // Utility function to build a multi-map from the filtered sub-pages
 export function convertToMultiMap(jsonData, page) {

--- a/blocks/browse-rail/browse-rail-utils.js
+++ b/blocks/browse-rail/browse-rail-utils.js
@@ -1,7 +1,7 @@
 import { getLink } from '../../scripts/scripts.js';
 // Utility function to filter sub-pages under a given path
 export const filterSubPages = (data, basePath) =>
-  data.filter((page) => page.path.startsWith(basePath) && page.path !== basePath);
+  data.filter((page) => page.path.startsWith(`${basePath}/`) && page.path !== basePath);
 
 // Utility function to build a multi-map from the filtered sub-pages
 export function convertToMultiMap(jsonData, page) {

--- a/blocks/browse-rail/browse-rail.js
+++ b/blocks/browse-rail/browse-rail.js
@@ -37,7 +37,7 @@ function setLinkVisibility(block, linkClass, show) {
 function hasDirectLeafNodes(jsonData, currentPage) {
   const directLeafNodes = jsonData.filter(
     (item) =>
-      item.path.startsWith(currentPage) &&
+      item.path.startsWith(`${currentPage}/`) &&
       item.path !== currentPage &&
       !item.path.substring(currentPage.length + 1).includes('/'),
   );

--- a/blocks/browse-rail/browse-rail.js
+++ b/blocks/browse-rail/browse-rail.js
@@ -35,13 +35,10 @@ function setLinkVisibility(block, linkClass, show) {
 
 // Function to check if current page has sub-pages
 function hasDirectLeafNodes(jsonData, currentPage) {
+  const prefix = `${currentPage}/`;
   const directLeafNodes = jsonData.filter(
-    (item) =>
-      item.path.startsWith(`${currentPage}/`) &&
-      item.path !== currentPage &&
-      !item.path.substring(currentPage.length + 1).includes('/'),
+    (item) => item.path.startsWith(prefix) && !item.path.slice(prefix.length).includes('/'),
   );
-
   return directLeafNodes.length > 0;
 }
 


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://browse-rail--exlm--adobe-experience-league.aem.page/en/browse/experience-manager?martech=off
- After: https://browse-rail--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://browse-rail--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off
- After: https://browse-rail--exlm--adobe-experience-league.aem.page/en/browse/journey-optimizer?martech=off
- After: https://browse-rail--exlm--adobe-experience-league.aem.page/en/browse/journey-optimizer-b2b-edition?martech=off