### PR TITLE
fix: send correct urlParams to coveo atomic search to honour filters

### DIFF
--- a/scripts/search/search.js
+++ b/scripts/search/search.js
@@ -22,7 +22,7 @@ export const redirectToSearchPage = (searchUrl, searchInput, filters = '') => {
     const filterValueEncoded = encodeURIComponent(filterValue);
     targetUrlWithLanguage += isLegacySearch
       ? `&f:@el_contenttype=[${filterValueEncoded}]`
-      : `&f-@el_contenttype=${filterValueEncoded}`;
+      : `&f-el_contenttype=${filterValueEncoded}`;
   }
   if (solution) {
     const solutionEncoded = encodeURIComponent(solution);


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page/en/search

- After: https://atomic-search-filters--exlm--adobe-experience-league.aem.page/en/search