### PR TITLE
adding maxsize 6 to marquee block

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -1706,6 +1706,7 @@
         "label": "Style",
         "valueType": "string",
         "required": true,
+        "maxSize": 6,
         "options": [
           {
             "name": "Size Variant",


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: https://jira.corp.adobe.com/browse/EXLM-3604

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page/en/test-folder/marquee-text-color
- After: https://EXLM-3604--exlm--adobe-experience-league.aem.page/en/test-folder/marquee-text-color