### PR TITLE
EXLM-3641 Default filter/(s) set if user uses search from various page types

### DIFF
--- a/scripts/search/search.js
+++ b/scripts/search/search.js
@@ -1,17 +1,37 @@
 import { getMetadata } from '../lib-franklin.js';
-import { htmlToElement, loadIms, getLanguageCode } from '../scripts.js';
+import { htmlToElement, loadIms, getLanguageCode, getPathDetails } from '../scripts.js';
 import SearchDelegate from './search-delegate.js';
 
 // Get language code from URL
 const languageCode = await getLanguageCode();
 // Get solution from metadata
 const solution = getMetadata('solution')?.split(',')[0].trim();
+// Get content type from metadata
+let contentType = getMetadata('type')?.trim();
+
+if (!contentType) {
+  // Fallback logic to determine contentType from URL
+  const url = window.location.pathname;
+  const { lang } = getPathDetails();
+  if (url === `/${lang}/playlists`) {
+    contentType = 'Playlist';
+  } else if (url === `/${lang}/perspectives`) {
+    contentType = 'Perspective';
+  } else if (url === `/${lang}/events`) {
+    contentType = 'Event';
+  } else if (url.includes(`/${lang}/certification`)) {
+    contentType = 'Certification';
+  } else {
+    contentType = '';
+  }
+}
 
 // Redirects to the search page based on the provided search input and filters
 export const redirectToSearchPage = (searchUrl, searchInput, filters = '') => {
   const isLegacySearch = searchUrl.includes('.html');
   let targetUrlWithLanguage = isLegacySearch ? `${searchUrl}?lang=${languageCode}` : searchUrl;
-  const filterValue = filters && filters.toLowerCase() === 'all' ? '' : filters;
+  // Use contentType as filter if available, otherwise use provided filters
+  const filterValue = contentType || (filters && filters.toLowerCase() === 'all' ? '' : filters);
   if (searchInput) {
     const trimmedSearchInput = encodeURIComponent(searchInput.trim());
     targetUrlWithLanguage += `#q=${trimmedSearchInput}`;
@@ -83,6 +103,11 @@ export default class Search {
     this.savedDefaultSuggestions = null;
     this.setupAutoCompleteEvents();
     this.callbackFn = this.showSearchSuggestions ? this.fetchInitialSuggestions : null;
+
+    // Set initial filter based on meta "type" / page URL
+    if (contentType) {
+      this.setSelectedSearchOption(contentType);
+    }
   }
 
   setupAutoCompleteEvents() {

--- a/scripts/search/search.js
+++ b/scripts/search/search.js
@@ -11,18 +11,19 @@ let contentType = getMetadata('type')?.trim();
 
 if (!contentType) {
   // Fallback logic to determine contentType from URL
-  const url = window.location.pathname;
   const { lang } = getPathDetails();
-  if (url === `/${lang}/playlists`) {
-    contentType = 'Playlist';
-  } else if (url === `/${lang}/perspectives`) {
-    contentType = 'Perspective';
-  } else if (url === `/${lang}/events`) {
-    contentType = 'Event';
-  } else if (url.includes(`/${lang}/certification`)) {
+  const url = window.location.pathname;
+
+  const contentTypeMap = {
+    [`/${lang}/playlists`]: 'Playlist',
+    [`/${lang}/perspectives`]: 'Perspective',
+    [`/${lang}/events`]: 'Event',
+  };
+
+  contentType = contentTypeMap[url] || '';
+
+  if (url.includes(`/${lang}/certification-home`)) {
     contentType = 'Certification';
-  } else {
-    contentType = '';
   }
 }
 


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-3641

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-3641--exlm--adobe-experience-league.aem.live?martech=off
- After: https://exlm-3641--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-3641--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://exlm-3641--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://exlm-3641--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-3641--exlm--adobe-experience-league.aem.live/en/docs/home-tutorials?martech=off
- After: https://exlm-3641--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://exlm-3641--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-3641--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://exlm-3641--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-3641--exlm--adobe-experience-league.aem.live/en/events?martech=off