### PR TITLE
EXLM-3641 Default filter/(s) set if user uses search from various pag…

### DIFF
--- a/scripts/search/search.js
+++ b/scripts/search/search.js
@@ -31,7 +31,7 @@ if (!contentType) {
 export const redirectToSearchPage = (searchUrl, searchInput, filters = '') => {
   const isLegacySearch = searchUrl.includes('.html');
   let targetUrlWithLanguage = isLegacySearch ? `${searchUrl}?lang=${languageCode}` : searchUrl;
-  const filterValue = filters && filters.toLowerCase() === 'all' ? '' : filters;
+  const filterValue = filters?.toLowerCase() === 'all' ? '' : filters;
   if (searchInput) {
     const trimmedSearchInput = encodeURIComponent(searchInput.trim());
     targetUrlWithLanguage += `#q=${trimmedSearchInput}`;


### PR DESCRIPTION
…e types

Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page

- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/docs?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/docs/analytics?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/playlists?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/docs/home-tutorials?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/docs/analytics-learn/tutorials/overview?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/perspectives?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/certification-home?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/browse?martech=off
- After: https://exlm-3641-v2--exlm--adobe-experience-league.aem.page/en/browse/analytics?martech=off