### PR TITLE
use container queries for slides because it will be used in docs content (not full width)

### DIFF
--- a/blocks/slides/slides.css
+++ b/blocks/slides/slides.css
@@ -258,7 +258,7 @@
   object-position: center;
 }
 
-@media screen and (min-width: 600px) {
+@container (min-width: 600px) {
   .slides .visual-wrapper {
     height: 300px;
     max-height: 100%;
@@ -269,14 +269,14 @@
   }
 }
 
-@media screen and (min-width: 900px) {
+@container (min-width: 900px) {
   .slides .visual-wrapper {
     height: 400px;
     max-height: 100%;
   }
 }
 
-@media screen and (min-width: 1200px) {
+@container (min-width: 1200px) {
   .slides .visual-wrapper {
     height: 600px;
     max-height: 100%;


### PR DESCRIPTION
... otherwise the callouts do not lineup.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page


- After: https://slides-container--exlm--adobe-experience-league.aem.page/en/slides/components-console-slides?martech=off