### PR TITLE
IMS to always remove token from URL

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -871,6 +871,7 @@ export async function loadIms() {
         scope:
           'AdobeID,additional_info.company,additional_info.ownerOrg,avatar,openid,read_organizations,read_pc,session,account_cluster.read,pps.read',
         autoValidateToken: true,
+        alwaysRemoveTokenFromUrl: true,
         locale: locales.get(document.querySelector('html').lang) || locales.get('en'),
         ...ims,
         onReady: () => {


### PR DESCRIPTION
potential fix for UGP-13417
adding this property will let IMS ALWAYS cleanup token fragment in the URL regardless or the token origin.

see: https://git.corp.adobe.com/pages/IMS/imslib2.js/classes/adobe-id_AdobeIdData.AdobeIdData.html#alwaysremovetokenfromurl