### PR TITLE
fix: exclude header elements from tabs component EXLM-3797

### DIFF
--- a/blocks/mini-toc/mini-toc.js
+++ b/blocks/mini-toc/mini-toc.js
@@ -56,7 +56,8 @@ function headerExclusions(header) {
     header.id.length > 0 &&
     !header.classList.contains('no-mtoc') &&
     !header.closest('details') &&
-    !header.closest('sp-tabs')
+    !header.closest('sp-tabs') &&
+    !header.closest('.tab-content')
   );
 }
 


### PR DESCRIPTION
Jira ID: EXLM-3797

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page/en/docs/experience-manager-cloud-service/content/assets/overview
- After: https://EXLM-3797-toc--exlm--adobe-experience-league.aem.live/en/docs/experience-manager-cloud-service/content/assets/overview