### PR TITLE
fix: update atomic search query summary string contents EXLM-4052

### DIFF
--- a/blocks/atomic-search/atomic-search.js
+++ b/blocks/atomic-search/atomic-search.js
@@ -109,7 +109,7 @@ export default function decorate(block) {
       atomicSortDropdownHandler(block.querySelector('atomic-sort-dropdown'));
       atomicFacetManagerHandler(block.querySelector('atomic-facet-manager'));
       atomicNotificationHandler(block.querySelector('atomic-notifications'));
-      atomicQuerySummaryHandler(block.querySelector('atomic-query-summary'), placeholders);
+      atomicQuerySummaryHandler(block, placeholders);
       atomicBreadBoxHandler(block.querySelector('atomic-breadbox'));
       atomicPagerHandler(block.querySelector('atomic-pager'));
       atomicResultPageHandler(block.querySelector('atomic-results-per-page'));


### PR DESCRIPTION
Jira ID: EXLM-4052

Need to ensure the below placeholder keys are registered for all language paths:
atomic-search-resultText ~ "Search Results for:"
atomic-search-no-query-result-text ~ "Search Results"
atomic-search-of-label ~ "of" // This field is new. We cannot use the existing "playlist-of-label" as its value is different for ko lang

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.page/en/search
- After: https://EXLM-4052--exlm--adobe-experience-league.aem.live/en/search