### PR TITLE
EXLM-4852: Add componentClick tracking for Premium Learning cards (do NOT merge)

### DIFF
--- a/scripts/browse-card/browse-cards-premium-learning.js
+++ b/scripts/browse-card/browse-cards-premium-learning.js
@@ -2,6 +2,7 @@
 import { loadCSS, decorateIcons } from '../lib-franklin.js';
 import { fetchLanguagePlaceholders } from '../scripts.js';
 import UserActions from '../user-actions/user-actions.js';
+import { pushBrowseCardClickEvent } from '../analytics/lib-analytics.js';
 
 /**
  * @fileoverview premium-learning specific browse card implementation
@@ -50,6 +51,36 @@ function getBookmarkId(id, viewLink) {
   } catch {
     return '';
   }
+}
+
+/**
+ * Returns the card header and position for analytics payloads.
+ * @param {HTMLElement} card - The card element.
+ * @param {HTMLElement} element - The card wrapper element in the list.
+ * @returns {{cardHeader: string, cardPosition: string}}
+ */
+function getCardHeaderAndPosition(card, element) {
+  let cardHeader = '';
+  const currentBlock = card.closest('.block');
+  const headerEl = currentBlock?.querySelector(
+    '.browse-cards-block-title, .rec-block-header, .inprogress-courses-header-wrapper',
+  );
+
+  if (headerEl) {
+    const cloned = headerEl.cloneNode(true);
+    cloned.querySelectorAll('[data-cs-mask]').forEach((maskedElement) => maskedElement.remove());
+    cardHeader = cloned.innerText.trim();
+  }
+
+  cardHeader = cardHeader || currentBlock?.getAttribute('data-block-name')?.trim() || '';
+
+  let cardPosition = '';
+  if (element?.parentElement?.children) {
+    const siblings = Array.from(element.parentElement.children);
+    cardPosition = String(siblings.indexOf(element) + 1);
+  }
+
+  return { cardHeader, cardPosition };
 }
 
 /**
@@ -271,7 +302,11 @@ export async function buildPLCard(element, model) {
     cardContainer.addEventListener('click', (e) => {
       if (e.target?.closest('.user-actions')) {
         e.preventDefault();
+        return;
       }
+
+      const { cardHeader, cardPosition } = getCardHeaderAndPosition(card, element);
+      pushBrowseCardClickEvent('browseCardClicked', model, cardHeader, cardPosition);
     });
 
     cardContainer.appendChild(card);


### PR DESCRIPTION
## Summary
- route Premium Learning card clicks through existing browse card analytics to emit `componentClick`
- add shared header/position extraction in the Premium Learning card builder for consistent payload fields
- preserve current behavior by excluding bookmark/copy user-action clicks from card click tracking

## Test plan
- [x] Run `npx eslint scripts/browse-card/browse-cards-premium-learning.js`
- [ ] Verify in browser that clicking Premium Learning cards emits `componentClick` in `window.adobeDataLayer`
- [ ] Verify bookmark/copy interactions do not emit `browseCardClicked`

Test URLs:
- Before: https://main--exlm--adobe-experience-league.aem.page/
- After: https://exlm-4852-main--exlm--adobe-experience-league.aem.page/

Made with [Cursor](https://cursor.com)