### PR TITLE
Remove cta for premium-learning-active-cohort

### DIFF
--- a/blocks/premium-learning-active-content/premium-learning-active-content.js
+++ b/blocks/premium-learning-active-content/premium-learning-active-content.js
@@ -1,5 +1,4 @@
 import { createTag, fetchLanguagePlaceholders, getConfig } from '../../scripts/scripts.js';
-import decorateCustomButtons from '../../scripts/utils/button-utils.js';
 import {
   fetchUserEnrollments,
   fetchNextEnrollmentPage,

--- a/blocks/premium-learning-active-content/premium-learning-active-content.js
+++ b/blocks/premium-learning-active-content/premium-learning-active-content.js
@@ -243,14 +243,13 @@ function initCarousel(container) {
 export default async function decorate(block) {
   const placeholders = await fetchLanguagePlaceholders().catch(() => ({}));
   const config = getConfig();
-  const [headingElement, descriptionElement, ctaElement] = [...block.children];
+  const [headingElement, descriptionElement] = [...block.children];
 
   block.innerHTML = '';
 
   const description = descriptionElement?.innerHTML
     ? `<div class="premium-learning-active-content-header-description">${descriptionElement.innerHTML}</div>`
     : '';
-  const cta = ctaElement?.innerHTML ? decorateCustomButtons(ctaElement) : '';
 
   const headerDiv = createTag('div', { class: 'premium-learning-active-content-header' });
   headerDiv.innerHTML = `
@@ -258,9 +257,6 @@ export default async function decorate(block) {
       <div class="premium-learning-active-content-header-text">
         ${headingElement?.innerHTML || ''}
         ${description}
-      </div>
-      <div class="premium-learning-active-content-cta">
-        ${cta}
       </div>
     </div>
   `;

--- a/component-models.json
+++ b/component-models.json
@@ -10807,40 +10807,6 @@
         "value": "",
         "label": "Long Description",
         "description": "Sets the description of Premium learning browse cards block."
-      },
-      {
-        "component": "select",
-        "name": "cta1_Type",
-        "value": "primary",
-        "label": "First CTA Type",
-        "description": "'Primary' will render a filled blue CTA, 'Secondary' will render a white CTA with a black border and black text",
-        "valueType": "string",
-        "options": [
-          {
-            "name": "Primary",
-            "value": "primary"
-          },
-          {
-            "name": "Secondary",
-            "value": "secondary"
-          }
-        ]
-      },
-      {
-        "component": "text",
-        "valueType": "string",
-        "name": "cta1_linkText",
-        "value": "",
-        "label": "First CTA Text",
-        "description": "Text to be shown inside button."
-      },
-      {
-        "component": "text",
-        "valueType": "string",
-        "name": "cta1_link",
-        "value": "",
-        "label": "First CTA Link",
-        "description": "What link to open when clicking the button."
       }
     ]
   }


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://4924-exlm--exlm--adobe-experience-league.aem.live
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://4924-exlm--exlm--adobe-experience-league.aem.live/en/search?martech=off