### PR TITLE
Fix placeholder bug in Events Search block

### DIFF
--- a/blocks/events-search/events-search.js
+++ b/blocks/events-search/events-search.js
@@ -23,6 +23,9 @@ const FACET_CONTROLLER_MAP = {
   el_contenttype: 'headlessTypeFacet',
 };
 const INITIAL_VISIBLE_FILTER_OPTIONS = 5;
+/** Literal token authors enter in placeholders.json for dynamic counts. */
+// eslint-disable-next-line no-template-curly-in-string -- not a JS template; matches placeholders.json text
+const PLACEHOLDER_COUNT_TOKEN = '${count}';
 const RESULTS_SCROLL_ADJUSTMENT_OFFSET = -12;
 const viewSwitcherInstances = new WeakMap();
 /** AbortController + MutationObserver teardown for Coveo document listeners (re-decorate or DOM removal). */
@@ -204,10 +207,11 @@ function bindSortDropdownToggle(block) {
 
 function getShowMoreLabel(count, placeholders) {
   const template = placeholders.eventSearchShowMoreLabel;
-  if (template?.includes('{}')) {
-    return template.replace('{}', String(count));
+  if (!template) {
+    return `Show ${count} more`;
   }
-  return template || `Show ${count} more`;
+  const s = String(count);
+  return String(template).replaceAll(PLACEHOLDER_COUNT_TOKEN, s).replaceAll('{}', s).replaceAll('{count}', s);
 }
 
 function getShowLessLabel(placeholders) {
@@ -381,12 +385,16 @@ function renderEventsSearchPageNumbers(block, placeholders) {
   }
   if (paginationTextEl) {
     if (pgCount > 1) {
-      paginationTextEl.textContent = placeholders?.eventSearchPagesLabel
-        ? placeholders.eventSearchPagesLabel.replace('{}', pgCount)
+      const label = placeholders?.eventSearchPagesLabel;
+      const pg = String(pgCount);
+      paginationTextEl.textContent = label
+        ? String(label).replaceAll(PLACEHOLDER_COUNT_TOKEN, pg).replaceAll('{}', pg).replaceAll('{count}', pg)
         : `of ${pgCount} pages`;
     } else {
-      paginationTextEl.textContent = placeholders?.eventSearchPageLabel
-        ? placeholders.eventSearchPageLabel.replace('{}', pgCount)
+      const label = placeholders?.eventSearchPageLabel;
+      const pg = String(pgCount);
+      paginationTextEl.textContent = label
+        ? String(label).replaceAll(PLACEHOLDER_COUNT_TOKEN, pg).replaceAll('{}', pg).replaceAll('{count}', pg)
         : `of ${pgCount} page`;
     }
   }

--- a/blocks/events-search/events-search.js
+++ b/blocks/events-search/events-search.js
@@ -27,6 +27,13 @@ const INITIAL_VISIBLE_FILTER_OPTIONS = 5;
 // eslint-disable-next-line no-template-curly-in-string -- not a JS template; matches placeholders.json text
 const PLACEHOLDER_COUNT_TOKEN = '${count}';
 const RESULTS_SCROLL_ADJUSTMENT_OFFSET = -12;
+
+/** Fills count slots in CMS strings: `${count}`, `{}`, `{count}` (see PLACEHOLDER_COUNT_TOKEN). */
+function fillPlaceholderCount(template, value) {
+  const s = String(value);
+  return String(template).replaceAll(PLACEHOLDER_COUNT_TOKEN, s).replaceAll('{}', s).replaceAll('{count}', s);
+}
+
 const viewSwitcherInstances = new WeakMap();
 /** AbortController + MutationObserver teardown for Coveo document listeners (re-decorate or DOM removal). */
 const eventsSearchLoadingUiCleanups = new WeakMap();
@@ -210,8 +217,7 @@ function getShowMoreLabel(count, placeholders) {
   if (!template) {
     return `Show ${count} more`;
   }
-  const s = String(count);
-  return String(template).replaceAll(PLACEHOLDER_COUNT_TOKEN, s).replaceAll('{}', s).replaceAll('{count}', s);
+  return fillPlaceholderCount(template, count);
 }
 
 function getShowLessLabel(placeholders) {
@@ -384,18 +390,13 @@ function renderEventsSearchPageNumbers(block, placeholders) {
     inputText.value = String(currentPageNumber);
   }
   if (paginationTextEl) {
+    const pg = String(pgCount);
     if (pgCount > 1) {
       const label = placeholders?.eventSearchPagesLabel;
-      const pg = String(pgCount);
-      paginationTextEl.textContent = label
-        ? String(label).replaceAll(PLACEHOLDER_COUNT_TOKEN, pg).replaceAll('{}', pg).replaceAll('{count}', pg)
-        : `of ${pgCount} pages`;
+      paginationTextEl.textContent = label ? fillPlaceholderCount(label, pg) : `of ${pgCount} pages`;
     } else {
       const label = placeholders?.eventSearchPageLabel;
-      const pg = String(pgCount);
-      paginationTextEl.textContent = label
-        ? String(label).replaceAll(PLACEHOLDER_COUNT_TOKEN, pg).replaceAll('{}', pg).replaceAll('{count}', pg)
-        : `of ${pgCount} page`;
+      paginationTextEl.textContent = label ? fillPlaceholderCount(label, pg) : `of ${pgCount} page`;
     }
   }
 


### PR DESCRIPTION
Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-4898-bug--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://exlm-4898-bug--exlm--adobe-experience-league.aem.live/en/test-folder/events-search?martech=off