### PR TITLE
Active enrollments fix

### DIFF
--- a/scripts/data-service/premium-learning-data-service.js
+++ b/scripts/data-service/premium-learning-data-service.js
@@ -800,6 +800,37 @@ export async function fetchBoardPosts(boardId, config) {
 }
 
 /**
+ * Checks if user has any active (non-completed) enrollments by paginating through all pages
+ * @param {Object} config - Config object (from getConfig())
+ * @returns {Promise<boolean>} True if user has active enrollments, false otherwise
+ */
+export async function hasActiveEnrollments(config) {
+  try {
+    let result = await fetchUserEnrollments(config, 'learningProgram', 10, null, 'Active');
+
+    while (result) {
+      const nonCompleted = (result.data || []).filter((enrollment) => enrollment.attributes?.state !== 'COMPLETED');
+
+      if (nonCompleted.length > 0) {
+        return true; // Found at least one active enrollment
+      }
+
+      const nextUrl = result.links?.next;
+      if (!nextUrl) break;
+
+      // eslint-disable-next-line no-await-in-loop
+      result = await fetchNextEnrollmentPage(nextUrl);
+    }
+
+    return false; // No active enrollments found after checking all pages
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error checking active enrollments:', error);
+    return false;
+  }
+}
+
+/**
  * Fetches user badges from Adobe Learning Manager API
  * Returns badges earned by the user, sorted by date achieved
  * @param {string} userId - User ID

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1780,23 +1780,18 @@ async function loadPage() {
               // TODO: Guard this fetch behind a check that the PL blocks are actually present
               // in the DOM before firing — avoids an unnecessary API call on profile pages
               // that have no PL content blocks.
-              const { fetchUserEnrollments } = await import('./data-service/premium-learning-data-service.js');
+              const { hasActiveEnrollments } = await import('./data-service/premium-learning-data-service.js');
               const config = getConfig();
-              const enrollmentData = await fetchUserEnrollments(config, 'learningProgram', 10);
-              // Filter out completed enrollments
-              const activeEnrollments = enrollmentData?.data?.filter(
-                (enrollment) => enrollment.attributes?.state !== 'COMPLETED',
-              );
-              const hasEnrollments = activeEnrollments?.length > 0;
+              const hasEnrollments = await hasActiveEnrollments(config);
 
               const activeContentBlock = document.querySelector('.premium-learning-active-content');
               const suggestedContentBlock = document.querySelector('.premium-learning-suggested-content');
 
               if (hasEnrollments) {
-                // User has enrollments - remove suggested content block wrapper
+                // User has active enrollments - remove suggested content block wrapper
                 suggestedContentBlock?.parentElement?.remove();
               } else {
-                // User has no enrollments - remove active content block wrapper
+                // User has no active enrollments - remove active content block wrapper
                 activeContentBlock?.parentElement?.remove();
               }
             }
@@ -1834,12 +1829,6 @@ async function loadPage() {
   // Initialize Premium Learning auth — fully non-blocking, does not delay loadPage().
   if (isFeatureEnabled('isPremiumLearningEnabled')) {
     if (isUEMode) {
-      // getConfig() must be called before the import resolves. In non-UE mode this is
-      // guaranteed by isUserSignedIn() → loadIms() → getConfig(). In UE mode there is
-      // no such gate, so a cached module import can resolve before loadLazy() ever calls
-      // getConfig(), leaving window.exlm.config undefined and causing exchangePLToken to
-      // silently no-op. Calling it here is synchronous and idempotent — no effect on non-UE.
-      getConfig();
       // UE Author Mode: fetch PL token anonymously via ?auth=false (no IMS required).
       import('./utils/premium-learning-utils.js')
         .then(({ initPLAuthAnonymous }) => initPLAuthAnonymous())

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1829,6 +1829,12 @@ async function loadPage() {
   // Initialize Premium Learning auth — fully non-blocking, does not delay loadPage().
   if (isFeatureEnabled('isPremiumLearningEnabled')) {
     if (isUEMode) {
+      // getConfig() must be called before the import resolves. In non-UE mode this is
+      // guaranteed by isUserSignedIn() → loadIms() → getConfig(). In UE mode there is
+      // no such gate, so a cached module import can resolve before loadLazy() ever calls
+      // getConfig(), leaving window.exlm.config undefined and causing exchangePLToken to
+      // silently no-op. Calling it here is synchronous and idempotent — no effect on non-UE.
+      getConfig();
       // UE Author Mode: fetch PL token anonymously via ?auth=false (no IMS required).
       import('./utils/premium-learning-utils.js')
         .then(({ initPLAuthAnonymous }) => initPLAuthAnonymous())


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://5121-exlm--exlm--adobe-experience-league.aem.live
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://5121-exlm--exlm--adobe-experience-league.aem.live/en/search?martech=off