### PR TITLE
Enforcing agents to run code-review skill before commit. 

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,14 @@
 
 npm run check:branch-name
 npx lint-staged
+
+# Soft reminder: encourage running the EDS `code-review` skill (or a manual self-review)
+# before committing. This NEVER blocks the commit; lint-staged above is the hard gate.
+# To silence per-commit, set EXLM_SKIP_REVIEW_REMINDER=1 in your shell env.
+if [ -z "$EXLM_SKIP_REVIEW_REMINDER" ] && [ -t 2 ]; then
+  printf '\n\033[33m[reminder]\033[0m Run the \033[1m`code-review`\033[0m skill on your staged changes before committing.\n' >&2
+  printf '  -> Humans (Cursor / Claude Code / Copilot Chat): type \033[1m/code-review\033[0m in the AI panel.\n' >&2
+  printf '  -> AI agents reading this: invoke the \033[1m`code-review`\033[0m skill in self-review mode on the\n' >&2
+  printf '     staged diff and resolve any blocking findings BEFORE retrying `git commit`.\n' >&2
+  printf '  -> Skip this reminder once: EXLM_SKIP_REVIEW_REMINDER=1 git commit ...\n\n' >&2
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,17 @@ Progressive loading follows the same **eager / lazy / delayed** model as standar
 - If you change **`paths.yaml`**, update **`paths.json`** to match (or vice versa)—`validate-paths.js` enforces parity.
 - For previews, use `curl` against the local dev server or published preview URLs; see [Keeping it 100](https://www.aem.live/developer/keeping-it-100) for performance expectations.
 
+### Self-review before commit
+
+Before running `git add` / `git commit`, **run the `code-review` skill on your staged changes**. This applies to everyone — AI agents and humans driving an AI assistant.
+
+- **How to run it**: in Cursor / Claude Code / Copilot Chat, type `/code-review` in the AI panel. The skill operates in **self-review mode** on uncommitted changes in the working directory and checks lint compliance, EDS patterns, performance, accessibility, secrets, CSS scoping, and `eslint-disable` justifications.
+- **Prerequisite**: the skill ships with this repo via `skills-lock.json` — run `npx skills experimental_install` once after cloning to install it.
+- **AI agents (Cursor, Claude Code, Copilot, etc.)**: do not run `git commit` without first invoking `/code-review` on the staged diff and resolving any blocking findings.
+- **Manual fallback** (no AI tool available): review `git diff --staged` for the common issues called out under _Code style_ — debug `console.*`, unscoped CSS selectors, `!important` without justification, hardcoded config, secrets, CSS-in-JS, and changes to `scripts/lib-franklin.js`.
+
+This is a **soft** convention — the husky `pre-commit` hook only prints a reminder and never blocks. Hard enforcement remains `lint-staged` + `npm run quality` in CI.
+
 ## Pull requests
 
 - Include the **Jira issue** and **test URLs** as described in [.github/pull_request_template.md](.github/pull_request_template.md). Prefix paths with `$` so the branch preview base URL can be injected (see [.github/workflows/update-pr-description.yaml](.github/workflows/update-pr-description.yaml)).


### PR DESCRIPTION
… a little reminder

Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-4979--exlm--adobe-experience-league.aem.live
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://exlm-4979--exlm--adobe-experience-league.aem.live/en/search?martech=off