### PR TITLE
feat: UGP-14953 UGP-15374 Prevent focus from shifting during active BC conversations

### DIFF
--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -211,13 +211,14 @@
 
   /* Room for input row + panel disclaimer (2–3 lines). */
   --bc-input-overlay-height: 220px;
+  --bc-chat-history-clearance: var(--bc-input-overlay-height);
 }
 
 #brand-concierge-mount .chat-history {
   flex: 1 !important;
   overflow-y: auto !important;
   min-height: 0 !important;
-  padding-bottom: var(--bc-input-overlay-height) !important;
+  padding-bottom: var(--bc-chat-history-clearance, var(--bc-input-overlay-height)) !important;
 }
 
 #brand-concierge-mount .message-blocker {
@@ -244,24 +245,37 @@
   position: absolute !important;
   inset: auto 0 0 !important;
   z-index: 10 !important;
-  display: flex !important;
-  flex-direction: column !important;
+  display: grid !important;
+  grid-template-rows: minmax(96px, 1fr) auto auto !important;
+  align-content: end !important;
   align-items: stretch !important;
   background: transparent !important;
 
   /* No bottom padding — disclaimer sits flush with panel bottom (drawer + expanded). */
-  padding: 96px 28px 0 !important;
+  padding: 0 28px !important;
+
+  /* Pass clicks through the gradient fade; keep input + disclaimer interactive. */
+  pointer-events: none !important;
+}
+
+#brand-concierge-mount .input-section > * {
+  pointer-events: auto !important;
 }
 
 #bc-dialog.exl-dialog-expanded #brand-concierge-mount .input-section {
-  padding: 96px max(40px, 15%) 0 !important;
+  padding: 0 max(40px, 15%) !important;
 }
 
 #brand-concierge-mount .input-container {
+  grid-row: 2 !important;
   align-items: center !important;
+  box-sizing: border-box !important;
+  min-height: 52px !important;
+  height: 52px !important;
   max-height: 56px !important;
   overflow: hidden !important;
   background: #fff !important;
+  border-width: 1px !important;
 }
 
 #brand-concierge-mount label.ai-chat-label .bc-input-label-sparkle {
@@ -273,10 +287,13 @@
 
 #brand-concierge-mount .input-container:focus-within {
   outline: none !important;
+  border-width: 1px !important;
   border-color: var(--spectrum-gray-300) !important;
 }
 
 #brand-concierge-mount .chat-input-wrapper {
+  min-height: 40px !important;
+  height: 40px !important;
   max-height: 40px !important;
   overflow: hidden !important;
 }
@@ -416,10 +433,11 @@
 }
 
 /*
- * Expanded-only prompt layouts (wide viewports). Below 769px, expanded uses the same
+ * Expanded-only prompt layouts (wide viewports). Below 768px, expanded uses the same
  * full-width prompt stack as the side drawer (base `.bc-prompt-pill-button` rules).
+ * Following exlm viewport standards 600px, 900px, 1200px will look bad, so we're using 768px.
  */
-@media (min-width: 769px) {
+@media (min-width: 768px) {
   /* Expanded only: full-width prompt area; taller, half-width welcome pill cards (not in the narrow drawer). */
   #bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-suggestions-container {
     max-width: 100% !important;
@@ -487,7 +505,9 @@
   }
 }
 
-/* Expanded on narrow viewports: match side-drawer prompt stack (full-width pills, same gap as base). */
+/* Expanded on narrow viewports: match side-drawer prompt stack (full-width pills, same gap as base). 
+ * Following exlm viewport standards 600px, 900px, 1200px will look bad, so we're using 768px.
+*/
 @media (max-width: 768px) {
   #bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-pills-container:has(> :nth-child(4):last-child) {
     display: flex !important;
@@ -522,6 +542,62 @@
 
 #brand-concierge-mount .submit-button svg path {
   fill: white !important;
+}
+
+#brand-concierge-mount .scroll-to-bottom {
+  width: 36px !important;
+  min-width: 36px !important;
+  max-width: 36px !important;
+  height: 36px !important;
+  min-height: 36px !important;
+  max-height: 36px !important;
+  padding: 0 !important;
+  border-radius: 50% !important;
+  box-sizing: border-box !important;
+  flex-shrink: 0 !important;
+  align-items: center !important;
+  justify-content: center !important;
+}
+
+#brand-concierge-mount .input-section .scroll-to-bottom {
+  position: absolute !important;
+  inset: 48px auto auto 50% !important;
+  transform: translateX(-50%) !important;
+  margin: 0 !important;
+}
+
+#brand-concierge-mount .input-section .bc-panel-disclaimer {
+  grid-row: 3 !important;
+}
+
+#brand-concierge-mount .scroll-to-bottom:not(.bc-scroll-to-bottom-visible) {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+
+#brand-concierge-mount .scroll-to-bottom.bc-scroll-to-bottom-visible {
+  display: flex !important;
+  visibility: visible !important;
+  pointer-events: auto !important;
+  z-index: 8 !important;
+  background-color: #fff !important;
+  border: 1px solid var(--spectrum-gray-300) !important;
+}
+
+/* styles.css sets button:focus { background: link-hover-color } without :focus-visible. */
+#brand-concierge-mount .scroll-to-bottom:focus {
+  background-color: #fff !important;
+  outline: none;
+}
+
+#brand-concierge-mount .scroll-to-bottom:focus-visible {
+  outline: 2px solid var(--non-spectrum-navy-blue);
+  outline-offset: 2px;
+}
+
+#brand-concierge-mount .scroll-to-bottom:hover {
+  background-color: var(--spectrum-gray-100) !important;
 }
 
 #brand-concierge-mount .scroll-to-bottom svg {

--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -426,13 +426,22 @@
   display: none !important;
 }
 
+/* Expanded welcome pills default (all viewports): column stack matching the side-drawer layout. */
+#bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-pills-container:has(> :nth-child(4):last-child) {
+  display: flex !important;
+  flex-flow: column nowrap !important;
+  align-items: stretch !important;
+  justify-content: flex-start !important;
+  gap: 6px !important;
+}
+
 /*
  * Expanded-only prompt layouts (wide viewports).
  * Intentional breakpoint exception: ExL uses 600 / 900 / 1200px, but the
  * expanded drawer is only 80vw wide. At 769–899px the modal is still too narrow for the
  * half-width welcome pill grid; 900px leaves that range with incorrect pill rendering. 769px
- * aligns with when 80vw (~615px) can fit the card layout; below that, use the side-drawer
- * full-width prompt stack (base `.bc-prompt-pill-button` rules).
+ * aligns with when 80vw (~615px) can fit the card layout; below that, the base column stack
+ * above applies.
  */
 @media (min-width: 769px) {
   /* Expanded only: full-width prompt area; taller, half-width welcome pill cards (not in the narrow drawer). */
@@ -504,17 +513,6 @@
     align-items: center !important;
     justify-content: flex-start !important;
     box-sizing: border-box !important;
-  }
-}
-
-/* Expanded on narrow viewports: match side-drawer prompt stack (see breakpoint note above). */
-@media (max-width: 768px) {
-  #bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-pills-container:has(> :nth-child(4):last-child) {
-    display: flex !important;
-    flex-flow: column nowrap !important;
-    align-items: stretch !important;
-    justify-content: flex-start !important;
-    gap: 6px !important;
   }
 }
 

--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -258,10 +258,6 @@
   pointer-events: none !important;
 }
 
-#brand-concierge-mount .input-section > * {
-  pointer-events: auto !important;
-}
-
 #bc-dialog.exl-dialog-expanded #brand-concierge-mount .input-section {
   padding: 0 max(40px, 15%) !important;
 }
@@ -273,9 +269,9 @@
   min-height: 52px !important;
   height: 52px !important;
   max-height: 56px !important;
-  overflow: hidden !important;
+  overflow: visible !important;
   background: #fff !important;
-  border-width: 1px !important;
+  border: 1px solid var(--spectrum-gray-300) !important;
 }
 
 #brand-concierge-mount label.ai-chat-label .bc-input-label-sparkle {
@@ -287,15 +283,14 @@
 
 #brand-concierge-mount .input-container:focus-within {
   outline: none !important;
-  border-width: 1px !important;
-  border-color: var(--spectrum-gray-300) !important;
+  border: 1px solid var(--spectrum-gray-300) !important;
 }
 
 #brand-concierge-mount .chat-input-wrapper {
   min-height: 40px !important;
   height: 40px !important;
   max-height: 40px !important;
-  overflow: hidden !important;
+  overflow: visible !important;
 }
 
 /* stylelint-disable-next-line selector-class-pattern -- BC internal BEM modifier */
@@ -490,6 +485,11 @@
     gap: 8px !important;
     width: auto !important;
     max-width: 100% !important;
+    margin-bottom: 12px !important;
+
+    /* Keep in-chat follow-up suggestions above the bottom gradient fade. */
+    position: relative !important;
+    z-index: 6 !important;
   }
 
   #bc-dialog.exl-dialog-expanded
@@ -612,6 +612,15 @@
 
 #brand-concierge-mount .scroll-to-bottom svg path {
   fill: currentcolor !important;
+}
+
+/* Restore interactivity for specific interactive children of the pointer-events:none overlay. */
+#brand-concierge-mount .input-section .input-container,
+#brand-concierge-mount .input-section .input-container *,
+#brand-concierge-mount .input-section .bc-panel-disclaimer,
+#brand-concierge-mount .input-section .bc-panel-disclaimer a,
+#brand-concierge-mount .input-section .scroll-to-bottom {
+  pointer-events: auto !important;
 }
 
 #brand-concierge-mount .citations-link {

--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -561,6 +561,8 @@
 
 #brand-concierge-mount .input-section .scroll-to-bottom {
   position: absolute !important;
+
+  /* 48 px = button radius (18 px) + visual gap above the input container */
   inset: 48px auto auto 50% !important;
   transform: translateX(-50%) !important;
   margin: 0 !important;

--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -433,11 +433,14 @@
 }
 
 /*
- * Expanded-only prompt layouts (wide viewports). Below 768px, expanded uses the same
- * full-width prompt stack as the side drawer (base `.bc-prompt-pill-button` rules).
- * Following exlm viewport standards 600px, 900px, 1200px will look bad, so we're using 768px.
+ * Expanded-only prompt layouts (wide viewports).
+ * Intentional breakpoint exception: ExL uses 600 / 900 / 1200px, but the
+ * expanded drawer is only 80vw wide. At 769–899px the modal is still too narrow for the
+ * half-width welcome pill grid; 900px leaves that range with incorrect pill rendering. 769px
+ * aligns with when 80vw (~615px) can fit the card layout; below that, use the side-drawer
+ * full-width prompt stack (base `.bc-prompt-pill-button` rules).
  */
-@media (min-width: 768px) {
+@media (min-width: 769px) {
   /* Expanded only: full-width prompt area; taller, half-width welcome pill cards (not in the narrow drawer). */
   #bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-suggestions-container {
     max-width: 100% !important;
@@ -505,9 +508,7 @@
   }
 }
 
-/* Expanded on narrow viewports: match side-drawer prompt stack (full-width pills, same gap as base). 
- * Following exlm viewport standards 600px, 900px, 1200px will look bad, so we're using 768px.
-*/
+/* Expanded on narrow viewports: match side-drawer prompt stack (see breakpoint note above). */
 @media (max-width: 768px) {
   #bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-pills-container:has(> :nth-child(4):last-child) {
     display: flex !important;
@@ -562,7 +563,7 @@
 #brand-concierge-mount .input-section .scroll-to-bottom {
   position: absolute !important;
 
-  /* 48 px = button radius (18 px) + visual gap above the input container */
+  /* 48 px from section top → button bottom lands 12 px above the input row */
   inset: 48px auto auto 50% !important;
   transform: translateX(-50%) !important;
   margin: 0 !important;
@@ -574,7 +575,6 @@
 
 #brand-concierge-mount .scroll-to-bottom:not(.bc-scroll-to-bottom-visible) {
   display: none !important;
-  visibility: hidden !important;
   pointer-events: none !important;
 }
 

--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -283,7 +283,6 @@
 
 #brand-concierge-mount .input-container:focus-within {
   outline: none !important;
-  border: 1px solid var(--spectrum-gray-300) !important;
 }
 
 #brand-concierge-mount .chat-input-wrapper {
@@ -614,7 +613,13 @@
   fill: currentcolor !important;
 }
 
-/* Restore interactivity for specific interactive children of the pointer-events:none overlay. */
+/*
+ * Restore interactivity for interactive children of the pointer-events:none overlay.
+ * MAINTENANCE: If BC adds new interactive elements inside .input-section (voice button,
+ * tooltip trigger, close icon, etc.) they must be added here or clicks will silently
+ * do nothing. A ::before/::after gradient approach would avoid this list, but is not
+ * feasible here because .input-section itself provides the grid layout for the overlay.
+ */
 #brand-concierge-mount .input-section .input-container,
 #brand-concierge-mount .input-section .input-container *,
 #brand-concierge-mount .input-section .bc-panel-disclaimer,

--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -267,7 +267,6 @@
   align-items: center !important;
   box-sizing: border-box !important;
   min-height: 52px !important;
-  height: 52px !important;
   max-height: 56px !important;
   overflow: visible !important;
   background: #fff !important;

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -62,6 +62,7 @@ let scrollPinCleanupTimerId = null;
 let scrollPinRafId = null;
 let scrollPinUserScrollCleanup = null;
 let mountInteractionHandler = null;
+let mountWithHandler = null;
 
 /**
  * Removes persisted BC chat sessions from localStorage (transcript + metadata).
@@ -439,11 +440,11 @@ function onMountInteraction(event) {
 }
 
 function removeQuestionPinHandlers() {
-  const mount = getBrandConciergeMount();
-  if (mountInteractionHandler && mount) {
-    mount.removeEventListener('click', mountInteractionHandler, true);
+  if (mountInteractionHandler && mountWithHandler) {
+    mountWithHandler.removeEventListener('click', mountInteractionHandler, true);
   }
   mountInteractionHandler = null;
+  mountWithHandler = null;
   clearScrollAfterSuggestionSchedule();
 }
 
@@ -452,18 +453,26 @@ function installQuestionPinHandlers(mount) {
   if (!mount) return;
 
   mountInteractionHandler = onMountInteraction;
+  mountWithHandler = mount;
   mount.addEventListener('click', mountInteractionHandler, true);
 }
 
 function rafDebounce(fn) {
   let id = null;
-  return () => {
+  const debounced = () => {
     if (!id)
       id = window.requestAnimationFrame(() => {
         id = null;
         fn();
       });
   };
+  debounced.cancel = () => {
+    if (id) {
+      window.cancelAnimationFrame(id);
+      id = null;
+    }
+  };
+  return debounced;
 }
 
 /**
@@ -478,6 +487,7 @@ function watchScrollToBottomButton(mount) {
   let history = null;
   let historyResizeObserver = null;
   let historyContentObserver = null;
+  let debouncedHistoryUpdate = null;
   let scrollBtnStyleObserver = null;
   let inputAreaResizeObserver = null;
 
@@ -529,7 +539,7 @@ function watchScrollToBottomButton(mount) {
     });
     scrollBtnStyleObserver.observe(scrollBtn, {
       attributes: true,
-      attributeFilter: ['style', 'hidden'],
+      attributeFilter: ['style', 'hidden', 'class'],
     });
   };
 
@@ -544,6 +554,7 @@ function watchScrollToBottomButton(mount) {
     history?.removeEventListener('scroll', debouncedScrollUpdate);
     historyResizeObserver?.disconnect();
     historyContentObserver?.disconnect();
+    debouncedHistoryUpdate?.cancel();
 
     history = nextHistory;
     if (!history) {
@@ -556,7 +567,8 @@ function watchScrollToBottomButton(mount) {
     history.addEventListener('scroll', debouncedScrollUpdate, { passive: true });
     historyResizeObserver = new ResizeObserver(update);
     historyResizeObserver.observe(history);
-    historyContentObserver = new MutationObserver(rafDebounce(update));
+    debouncedHistoryUpdate = rafDebounce(update);
+    historyContentObserver = new MutationObserver(debouncedHistoryUpdate);
     historyContentObserver.observe(history, { childList: true, subtree: true });
     attachScrollButtonObserver();
     attachInputAreaObserver();
@@ -573,8 +585,10 @@ function watchScrollToBottomButton(mount) {
       mountObserver.disconnect();
       window.removeEventListener('resize', update);
       history?.removeEventListener('scroll', debouncedScrollUpdate);
+      debouncedScrollUpdate.cancel();
       historyResizeObserver?.disconnect();
       historyContentObserver?.disconnect();
+      debouncedHistoryUpdate?.cancel();
       scrollBtnStyleObserver?.disconnect();
       inputAreaResizeObserver?.disconnect();
     },

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -305,7 +305,8 @@ function ensureExchangeScrollRoom(mount, history, userMessageEl, userMessageCoun
   const inputSection = mount?.querySelector('.input-section');
   if (!container) return;
 
-  const neededMinHeight = userMessageEl.offsetTop + container.clientHeight - (inputSection?.clientHeight ?? 0);
+  const neededMinHeight =
+    getMessageScrollTopInHistory(history, userMessageEl) + container.clientHeight - (inputSection?.clientHeight ?? 0);
   if (neededMinHeight > currentMin) {
     history.style.setProperty('min-height', `${Math.ceil(neededMinHeight)}px`);
   }
@@ -344,7 +345,6 @@ function startScrollPin(mount) {
 
   const tick = () => {
     if (Date.now() > end) {
-      scrollPinRafId = null;
       stopScrollPin();
       return;
     }

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -23,6 +23,8 @@ const PIN_IGNORE_SELECTOR =
 
 /** How long to hold scroll position after a new question (BC may auto-scroll to bottom). */
 const SCROLL_AFTER_SUGGESTION_PIN_MS = 3500;
+/** Retry cadence (ms) for re-applying scroll position while BC settles its DOM after a query. */
+const SCROLL_PIN_RETRY_DELAYS_MS = [16, 50, 120, 250, 500, 1000, 1800];
 
 const SUGGESTION_CLICK_SELECTOR =
   '.bc-prompt-suggestion-button, .bc-prompt-pill-button, .prompt-suggestions-container button, .widget-options-container button';
@@ -293,7 +295,7 @@ function getMessageScrollTopInHistory(history, messageEl) {
   return messageEl.getBoundingClientRect().top - history.getBoundingClientRect().top + history.scrollTop;
 }
 
-function ensureExchangeScrollRoom(mount, history, userMessageEl, userMessageCount) {
+function ensureExchangeScrollRoom(history, userMessageEl, userMessageCount) {
   const currentMin = parseInt(history.style.minHeight || '0', 10) || 0;
   if (userMessageCount < 2) {
     if (currentMin > 0) history.style.removeProperty('min-height');
@@ -301,12 +303,7 @@ function ensureExchangeScrollRoom(mount, history, userMessageEl, userMessageCoun
   }
   if (!userMessageEl) return;
 
-  const container = history.closest('.brand-concierge-container');
-  const inputSection = mount?.querySelector('.input-section');
-  if (!container) return;
-
-  const neededMinHeight =
-    getMessageScrollTopInHistory(history, userMessageEl) + container.clientHeight - (inputSection?.clientHeight ?? 0);
+  const neededMinHeight = getMessageScrollTopInHistory(history, userMessageEl) + history.clientHeight;
   if (neededMinHeight > currentMin) {
     history.style.setProperty('min-height', `${Math.ceil(neededMinHeight)}px`);
   }
@@ -323,7 +320,7 @@ function resolveExchangeScrollTop(mount) {
   }
 
   const userMessage = userMessages[userMessages.length - 1];
-  ensureExchangeScrollRoom(mount, history, userMessage, userMessages.length);
+  ensureExchangeScrollRoom(history, userMessage, userMessages.length);
 
   const messageMarginTop = parseInt(window.getComputedStyle(userMessage).marginTop, 10) || 0;
 
@@ -377,7 +374,7 @@ function scheduleScrollAfterSuggestion(mount) {
   };
 
   run();
-  [16, 50, 120, 250, 500, 1000, 1800].forEach((delay) => {
+  SCROLL_PIN_RETRY_DELAYS_MS.forEach((delay) => {
     scrollAfterSuggestionTimers.push(window.setTimeout(run, delay));
   });
 
@@ -412,7 +409,7 @@ function getBootstrapOptions() {
 }
 
 function onMountInteraction(event) {
-  const mount = getBrandConciergeMount();
+  const mount = /** @type {Element} */ (event.currentTarget);
   if (!mount?.contains(event.target)) return;
 
   if (event.target.closest('.citations-accordion, .citations-accordion-button, .citations-section')) {

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -404,6 +404,9 @@ function handleBrandConciergeClientEvent(event) {
   const mount = getBrandConciergeMount();
   if (!mount) return;
 
+  // response:started intentionally re-pins: if a new response begins while the user is still
+  // reading a previous answer we want to re-anchor to their most recent question, not leave
+  // them watching the bottom of a growing history panel.
   scheduleScrollAfterSuggestion(mount);
 }
 
@@ -420,7 +423,7 @@ function getBootstrapOptions() {
 
 function onMountInteraction(event) {
   const mount = /** @type {Element} */ (event.currentTarget);
-  if (!mount?.contains(event.target)) return;
+  if (!mount) return;
 
   if (event.target.closest('.citations-accordion, .citations-accordion-button, .citations-section')) {
     clearScrollAfterSuggestionSchedule();

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -252,8 +252,6 @@ function syncScrollToBottomButton(mount) {
   const visible = !inWelcomeState && shouldShowScrollToBottomButton(history);
 
   scrollBtn.classList.toggle('bc-scroll-to-bottom-visible', visible);
-  scrollBtn.toggleAttribute('hidden', !visible);
-  scrollBtn.style.display = visible ? 'flex' : 'none';
 }
 
 function getBrandConciergeMount() {
@@ -311,15 +309,17 @@ function resolveExchangeScrollTop(mount) {
   if (!history) return 0;
 
   const userMessages = history.querySelectorAll('.user-message');
-  if (userMessages.length === 0) return 0;
+  if (userMessages.length === 0) {
+    history.style.removeProperty('min-height');
+    return 0;
+  }
 
   const userMessage = userMessages[userMessages.length - 1];
   if (userMessages.length >= 2) {
     ensureExchangeScrollRoom(mount, history, userMessage, userMessages.length);
   }
 
-  const lastChatMessage = history.querySelector('.chat-message:last-child');
-  const messageMarginTop = lastChatMessage ? parseInt(window.getComputedStyle(lastChatMessage).marginTop, 10) || 0 : 0;
+  const messageMarginTop = parseInt(window.getComputedStyle(userMessage).marginTop, 10) || 0;
 
   const offsetTop = getMessageScrollTopInHistory(history, userMessage);
   return Math.max(0, offsetTop - messageMarginTop);

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -58,6 +58,7 @@ let panelDisclaimerObserver = null;
 let scrollToBottomWatcher = null;
 let scrollAfterSuggestionObserver = null;
 let scrollAfterSuggestionTimers = [];
+let scrollPinCleanupTimerId = null;
 let scrollPinRafId = null;
 let scrollPinUserScrollCleanup = null;
 let mountInteractionHandler = null;
@@ -275,6 +276,10 @@ function clearScrollAfterSuggestionSchedule() {
   scrollAfterSuggestionTimers = [];
   scrollAfterSuggestionObserver?.disconnect();
   scrollAfterSuggestionObserver = null;
+  if (scrollPinCleanupTimerId !== null) {
+    window.clearTimeout(scrollPinCleanupTimerId);
+    scrollPinCleanupTimerId = null;
+  }
   stopScrollPin();
 }
 
@@ -304,6 +309,9 @@ function ensureExchangeScrollRoom(history, userMessageEl, userMessageCount) {
   if (!userMessageEl) return;
 
   const neededMinHeight = getMessageScrollTopInHistory(history, userMessageEl) + history.clientHeight;
+  // Intentional one-way ratchet: min-height only grows to accommodate the latest exchange.
+  // It resets only when userMessageCount < 2 (clear/re-bootstrap). Long sessions accumulate
+  // a large value but BC refreshes the DOM on conversation clear, so it never persists.
   if (neededMinHeight > currentMin) {
     history.style.setProperty('min-height', `${Math.ceil(neededMinHeight)}px`);
   }
@@ -387,9 +395,7 @@ function scheduleScrollAfterSuggestion(mount) {
     run();
   });
   scrollAfterSuggestionObserver.observe(chatHistory, { childList: true, subtree: true });
-  scrollAfterSuggestionTimers.push(
-    window.setTimeout(clearScrollAfterSuggestionSchedule, SCROLL_AFTER_SUGGESTION_PIN_MS + 500),
-  );
+  scrollPinCleanupTimerId = window.setTimeout(clearScrollAfterSuggestionSchedule, SCROLL_AFTER_SUGGESTION_PIN_MS + 500);
 }
 
 function handleBrandConciergeClientEvent(event) {
@@ -450,7 +456,7 @@ function rafDebounce(fn) {
   let id = null;
   return () => {
     if (!id)
-      id = requestAnimationFrame(() => {
+      id = window.requestAnimationFrame(() => {
         id = null;
         fn();
       });

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -12,6 +12,28 @@ const TRIGGER_ID = 'bc-trigger';
 const HEADER_CLEAR_ID = 'bc-header-clear';
 const PANEL_DISCLAIMER_ID = 'bc-panel-disclaimer';
 
+/** Pixels from the bottom of `.chat-history` treated as “at bottom”. */
+const SCROLL_BOTTOM_THRESHOLD = 32;
+/** Space between the last chat message and the message input when scrolled to bottom. */
+const CHAT_HISTORY_BOTTOM_GAP = 16;
+
+/** Mutations inside these regions should not re-run question pinning / scroll alignment. */
+const PIN_IGNORE_SELECTOR =
+  '.citations-accordion, .citations-section, .citations-source-item, .citations-link, .bc-response-footer, .prompt-suggestions-container';
+
+/** How long to hold scroll position after a new question (BC may auto-scroll to bottom). */
+const SCROLL_AFTER_SUGGESTION_PIN_MS = 3500;
+
+const SUGGESTION_CLICK_SELECTOR =
+  '.bc-prompt-suggestion-button, .bc-prompt-pill-button, .prompt-suggestions-container button, .widget-options-container button';
+
+/** BC `onEvent` types (see mt enum in the web client bundle). */
+const BC_EVENT_PROMPT_CLICKED = 'promptSuggestion:clicked';
+const BC_EVENT_QUERY_SUBMITTED = 'query:submitted';
+const BC_EVENT_RESPONSE_STARTED = 'response:started';
+
+const SCROLL_EVENT_TYPES = new Set([BC_EVENT_PROMPT_CLICKED, BC_EVENT_QUERY_SUBMITTED, BC_EVENT_RESPONSE_STARTED]);
+
 /** Brand Concierge web client transcript keys (see ChatTranscriptStorage in bc main.js). */
 const BC_STORAGE_TRANSCRIPT_PREFIX = 'bc_chat_transcript_';
 const BC_STORAGE_METADATA_KEY = 'bc_chat_metadata';
@@ -29,9 +51,13 @@ const error = (...args) => console.error('[BC]', ...args);
 
 let cssLinkEl = null;
 let drawerHandle = null;
-let chatObserver = null;
 let inputLabelIconObserver = null;
 let panelDisclaimerObserver = null;
+let scrollToBottomWatcher = null;
+let scrollAfterSuggestionObserver = null;
+let scrollAfterSuggestionTimers = [];
+let scrollPinRafId = null;
+let mountInteractionHandler = null;
 
 /**
  * Removes persisted BC chat sessions from localStorage (transcript + metadata).
@@ -52,16 +78,6 @@ function clearBrandConciergeTranscriptStorage(options = {}) {
     }
   }
   toRemove.forEach((k) => localStorage.removeItem(k));
-}
-
-function getBootstrapOptions() {
-  const { stickySession = false, ...stylingConfigurations } = brandConciergeConfig;
-  return {
-    instanceName: ALLOY_INSTANCE_NAME,
-    stylingConfigurations,
-    selector: MOUNT_SELECTOR,
-    stickySession,
-  };
 }
 
 /**
@@ -186,17 +202,333 @@ function focusBcChatInputWhenReady(mount) {
   timeoutId = window.setTimeout(cleanup, 8000);
 }
 
-// scroll the container to the bottom each time.
-function watchChatHistory(mount) {
-  const history = mount.querySelector('.chat-history');
-  if (!history) return null;
+function shouldShowScrollToBottomButton(history) {
+  if (!history) return false;
+  const { scrollTop, scrollHeight, clientHeight } = history;
+  if (scrollHeight - clientHeight <= 1) return false;
+  return scrollHeight - scrollTop - clientHeight > SCROLL_BOTTOM_THRESHOLD;
+}
 
-  const observer = new MutationObserver(() => {
-    history.scrollTo({ top: history.scrollHeight, behavior: 'smooth' });
+function scrollChatHistoryToBottom(mount) {
+  const history = mount?.querySelector('.chat-history');
+  if (!history) return;
+  history.scrollTo({ top: history.scrollHeight, behavior: 'smooth' });
+}
+
+/** Places the scroll button above the input and sets chat-history bottom padding (excludes gradient fade). */
+function updateInputOverlayLayout(mount) {
+  const history = mount?.querySelector('.chat-history');
+  const inputSection = mount?.querySelector('.input-section');
+  const inputContainer = mount?.querySelector('.input-container');
+  if (!history || !inputSection || !inputContainer) return;
+
+  const sectionRect = inputSection.getBoundingClientRect();
+  const inputRect = inputContainer.getBoundingClientRect();
+
+  const clearance = Math.ceil(sectionRect.bottom - inputRect.top + CHAT_HISTORY_BOTTOM_GAP);
+  history.style.setProperty('--bc-chat-history-clearance', `${clearance}px`);
+
+  const scrollBtn = mount.querySelector('.scroll-to-bottom');
+  if (!scrollBtn) return;
+
+  if (scrollBtn.parentElement !== inputSection) {
+    inputSection.prepend(scrollBtn);
+  }
+
+  scrollBtn.style.bottom = '';
+  scrollBtn.style.left = '';
+  scrollBtn.style.right = '';
+  scrollBtn.style.position = '';
+}
+
+function syncScrollToBottomButton(mount) {
+  updateInputOverlayLayout(mount);
+
+  const history = mount?.querySelector('.chat-history');
+  const scrollBtn = mount?.querySelector('.scroll-to-bottom');
+  if (!history || !scrollBtn) return;
+
+  const inWelcomeState = mount.querySelector('.brand-concierge-container.initial-state');
+  const visible = !inWelcomeState && shouldShowScrollToBottomButton(history);
+
+  scrollBtn.classList.toggle('bc-scroll-to-bottom-visible', visible);
+  scrollBtn.toggleAttribute('hidden', !visible);
+  scrollBtn.style.display = visible ? 'flex' : 'none';
+}
+
+function getBrandConciergeMount() {
+  return document.getElementById('brand-concierge-mount') || document.querySelector(MOUNT_SELECTOR);
+}
+
+function stopScrollPin() {
+  if (scrollPinRafId) {
+    window.cancelAnimationFrame(scrollPinRafId);
+    scrollPinRafId = null;
+  }
+}
+
+function clearScrollAfterSuggestionSchedule() {
+  scrollAfterSuggestionTimers.forEach((id) => window.clearTimeout(id));
+  scrollAfterSuggestionTimers = [];
+  scrollAfterSuggestionObserver?.disconnect();
+  scrollAfterSuggestionObserver = null;
+  stopScrollPin();
+}
+
+function isInsidePinIgnoredRegion(node) {
+  return node instanceof Element && !!node.closest(PIN_IGNORE_SELECTOR);
+}
+
+function mutationShouldTriggerExchangePin(mutation) {
+  if (mutation.type !== 'childList') return false;
+  if (isInsidePinIgnoredRegion(mutation.target)) return false;
+  if ([...mutation.addedNodes, ...mutation.removedNodes].some((node) => isInsidePinIgnoredRegion(node))) {
+    return false;
+  }
+  return true;
+}
+
+function getMessageScrollTopInHistory(history, messageEl) {
+  return messageEl.getBoundingClientRect().top - history.getBoundingClientRect().top + history.scrollTop;
+}
+
+function ensureExchangeScrollRoom(mount, history, userMessageEl, userMessageCount) {
+  if (userMessageCount < 2 || !userMessageEl) return;
+
+  const container = history.closest('.brand-concierge-container');
+  const inputSection = mount?.querySelector('.input-section');
+  if (!container) return;
+
+  const neededMinHeight = userMessageEl.offsetTop + container.clientHeight - (inputSection?.clientHeight ?? 0);
+  const currentMin = parseInt(history.style.minHeight || '0', 10) || 0;
+  if (neededMinHeight > currentMin) {
+    history.style.setProperty('min-height', `${Math.ceil(neededMinHeight)}px`);
+  }
+}
+
+function resolveExchangeScrollTop(mount) {
+  const history = mount?.querySelector('.chat-history');
+  if (!history) return 0;
+
+  const userMessages = history.querySelectorAll('.user-message');
+  if (userMessages.length === 0) return 0;
+
+  const userMessage = userMessages[userMessages.length - 1];
+  if (userMessages.length >= 2) {
+    ensureExchangeScrollRoom(mount, history, userMessage, userMessages.length);
+  }
+
+  const lastChatMessage = history.querySelector('.chat-message:last-child');
+  const messageMarginTop = lastChatMessage ? parseInt(window.getComputedStyle(lastChatMessage).marginTop, 10) || 0 : 0;
+
+  const offsetTop = getMessageScrollTopInHistory(history, userMessage);
+  return Math.max(0, offsetTop - messageMarginTop);
+}
+
+function startScrollPin(mount) {
+  stopScrollPin();
+  const history = mount?.querySelector('.chat-history');
+  if (!history) return;
+
+  const end = Date.now() + SCROLL_AFTER_SUGGESTION_PIN_MS;
+  const tick = () => {
+    if (Date.now() > end) {
+      scrollPinRafId = null;
+      return;
+    }
+    history.scrollTop = resolveExchangeScrollTop(mount);
+    scrollPinRafId = window.requestAnimationFrame(tick);
+  };
+  tick();
+}
+
+function applyExchangeScrollTop(mount) {
+  const history = mount?.querySelector('.chat-history');
+  if (!history) return;
+
+  const targetTop = resolveExchangeScrollTop(mount);
+  if (targetTop === 0 && history.querySelectorAll('.user-message').length === 0) return;
+
+  history.scrollTop = targetTop;
+}
+
+function scheduleScrollAfterSuggestion(mount) {
+  const chatHistory = mount?.querySelector('.chat-history');
+  if (!chatHistory) return;
+
+  clearScrollAfterSuggestionSchedule();
+  startScrollPin(mount);
+
+  const run = () => {
+    applyExchangeScrollTop(mount);
+    syncScrollToBottomButton(mount);
+  };
+
+  run();
+  [16, 50, 120, 250, 500, 1000, 1800].forEach((delay) => {
+    scrollAfterSuggestionTimers.push(window.setTimeout(run, delay));
   });
 
-  observer.observe(history, { childList: true });
-  return observer;
+  scrollAfterSuggestionObserver = new MutationObserver((mutations) => {
+    if (!mutations.some(mutationShouldTriggerExchangePin)) return;
+    run();
+  });
+  scrollAfterSuggestionObserver.observe(chatHistory, { childList: true, subtree: true });
+  scrollAfterSuggestionTimers.push(
+    window.setTimeout(clearScrollAfterSuggestionSchedule, SCROLL_AFTER_SUGGESTION_PIN_MS + 500),
+  );
+}
+
+function handleBrandConciergeClientEvent(event) {
+  if (!event?.eventType || !SCROLL_EVENT_TYPES.has(event.eventType)) return;
+
+  const mount = getBrandConciergeMount();
+  if (!mount) return;
+
+  scheduleScrollAfterSuggestion(mount);
+}
+
+function getBootstrapOptions() {
+  const { stickySession = false, ...stylingConfigurations } = brandConciergeConfig;
+  return {
+    instanceName: ALLOY_INSTANCE_NAME,
+    stylingConfigurations,
+    selector: MOUNT_SELECTOR,
+    stickySession,
+    onEvent: handleBrandConciergeClientEvent,
+  };
+}
+
+function onMountInteraction(event) {
+  const mount = getBrandConciergeMount();
+  if (!mount?.contains(event.target)) return;
+
+  if (event.target.closest('.citations-accordion, .citations-accordion-button, .citations-section')) {
+    clearScrollAfterSuggestionSchedule();
+    return;
+  }
+
+  if (event.target.closest(SUGGESTION_CLICK_SELECTOR)) {
+    scheduleScrollAfterSuggestion(mount);
+  }
+}
+
+function removeQuestionPinHandlers() {
+  const mount = getBrandConciergeMount();
+  if (mountInteractionHandler && mount) {
+    mount.removeEventListener('click', mountInteractionHandler, true);
+  }
+  mountInteractionHandler = null;
+  clearScrollAfterSuggestionSchedule();
+}
+
+function installQuestionPinHandlers(mount) {
+  removeQuestionPinHandlers();
+  if (!mount) return;
+
+  mountInteractionHandler = onMountInteraction;
+  mount.addEventListener('click', mountInteractionHandler, true);
+}
+
+/**
+ * Shows BC’s scroll-to-bottom control only when `.chat-history` overflows and the
+ * user is not already at the bottom; re-evaluates on scroll, resize, and content changes.
+ */
+function watchScrollToBottomButton(mount) {
+  scrollToBottomWatcher?.cleanup();
+  scrollToBottomWatcher = null;
+  if (!mount) return;
+
+  let history = null;
+  let historyResizeObserver = null;
+  let historyContentObserver = null;
+  let scrollBtnStyleObserver = null;
+  let inputAreaResizeObserver = null;
+
+  const update = () => syncScrollToBottomButton(mount);
+
+  const attachInputAreaObserver = () => {
+    inputAreaResizeObserver?.disconnect();
+    const inputSection = mount.querySelector('.input-section');
+    if (!inputSection) return;
+    inputAreaResizeObserver = new ResizeObserver(update);
+    inputAreaResizeObserver.observe(inputSection);
+  };
+
+  const attachScrollButtonObserver = () => {
+    scrollBtnStyleObserver?.disconnect();
+    const scrollBtn = mount.querySelector('.scroll-to-bottom');
+    if (!scrollBtn) return;
+
+    if (!scrollBtn.dataset.exlScrollBound) {
+      scrollBtn.dataset.exlScrollBound = 'true';
+      scrollBtn.addEventListener('click', () => {
+        clearScrollAfterSuggestionSchedule();
+        scrollChatHistoryToBottom(mount);
+        scrollBtn.blur();
+        update();
+      });
+    }
+
+    scrollBtnStyleObserver = new MutationObserver(() => {
+      const inWelcomeState = mount.querySelector('.brand-concierge-container.initial-state');
+      const shouldShow = !inWelcomeState && history && shouldShowScrollToBottomButton(history);
+      if (shouldShow && !scrollBtn.classList.contains('bc-scroll-to-bottom-visible')) {
+        update();
+      }
+    });
+    scrollBtnStyleObserver.observe(scrollBtn, {
+      attributes: true,
+      attributeFilter: ['class', 'style', 'hidden'],
+    });
+  };
+
+  const attachHistory = () => {
+    const nextHistory = mount.querySelector('.chat-history');
+    if (nextHistory === history) {
+      if (!scrollBtnStyleObserver) attachScrollButtonObserver();
+      if (!inputAreaResizeObserver) attachInputAreaObserver();
+      return;
+    }
+
+    history?.removeEventListener('scroll', update);
+    historyResizeObserver?.disconnect();
+    historyContentObserver?.disconnect();
+
+    history = nextHistory;
+    if (!history) {
+      attachScrollButtonObserver();
+      attachInputAreaObserver();
+      update();
+      return;
+    }
+
+    history.addEventListener('scroll', update, { passive: true });
+    historyResizeObserver = new ResizeObserver(update);
+    historyResizeObserver.observe(history);
+    historyContentObserver = new MutationObserver(update);
+    historyContentObserver.observe(history, { childList: true, subtree: true });
+    attachScrollButtonObserver();
+    attachInputAreaObserver();
+    update();
+  };
+
+  const mountObserver = new MutationObserver(attachHistory);
+  mountObserver.observe(mount, { childList: true, subtree: true });
+  window.addEventListener('resize', update, { passive: true });
+  attachHistory();
+
+  scrollToBottomWatcher = {
+    cleanup: () => {
+      mountObserver.disconnect();
+      window.removeEventListener('resize', update);
+      history?.removeEventListener('scroll', update);
+      historyResizeObserver?.disconnect();
+      historyContentObserver?.disconnect();
+      scrollBtnStyleObserver?.disconnect();
+      inputAreaResizeObserver?.disconnect();
+    },
+  };
 }
 
 /**
@@ -230,9 +562,10 @@ async function clearBrandConciergeConversation() {
     await concierge.bootstrap(getBootstrapOptions());
   }
 
-  const bcMount = document.getElementById('brand-concierge-mount');
-  chatObserver?.disconnect();
-  chatObserver = watchChatHistory(bcMount);
+  const bcMount = getBrandConciergeMount();
+  scrollToBottomWatcher?.cleanup();
+  watchScrollToBottomButton(bcMount);
+  installQuestionPinHandlers(bcMount);
   patchBcSparkleIcons(bcMount);
   panelDisclaimerObserver?.disconnect();
   panelDisclaimerObserver = null;
@@ -354,8 +687,9 @@ function injectAlloyStub() {
 
 /** Call on SPA navigation to prevent the UI persisting across page transitions. */
 export function destroyBrandConcierge() {
-  chatObserver?.disconnect();
-  chatObserver = null;
+  scrollToBottomWatcher?.cleanup();
+  scrollToBottomWatcher = null;
+  removeQuestionPinHandlers();
   inputLabelIconObserver?.disconnect();
   inputLabelIconObserver = null;
   panelDisclaimerObserver?.disconnect();
@@ -384,8 +718,9 @@ export async function initBrandConcierge() {
     log('[BC] Web Client loaded — calling bootstrap');
     bootstrapWebClient();
     log('[BC] bootstrapWebClient called');
-    const bcMount = document.getElementById('brand-concierge-mount');
-    chatObserver = watchChatHistory(bcMount);
+    const bcMount = getBrandConciergeMount();
+    watchScrollToBottomButton(bcMount);
+    installQuestionPinHandlers(bcMount);
     patchBcSparkleIcons(bcMount);
     watchPanelDisclaimer(bcMount);
 

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -487,7 +487,10 @@ function watchScrollToBottomButton(mount) {
     const scrollBtn = mount.querySelector('.scroll-to-bottom');
     if (!history || !scrollBtn) return;
     const inWelcomeState = mount.querySelector('.brand-concierge-container.initial-state');
-    scrollBtn.classList.toggle('bc-scroll-to-bottom-visible', !inWelcomeState && shouldShowScrollToBottomButton(history));
+    scrollBtn.classList.toggle(
+      'bc-scroll-to-bottom-visible',
+      !inWelcomeState && shouldShowScrollToBottomButton(history),
+    );
   };
   const debouncedScrollUpdate = rafDebounce(scrollUpdate);
 

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -552,6 +552,7 @@ function watchScrollToBottomButton(mount) {
     }
 
     history?.removeEventListener('scroll', debouncedScrollUpdate);
+    debouncedScrollUpdate.cancel();
     historyResizeObserver?.disconnect();
     historyContentObserver?.disconnect();
     debouncedHistoryUpdate?.cancel();

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -362,11 +362,7 @@ function startScrollPin(mount) {
 function applyExchangeScrollTop(mount) {
   const history = mount?.querySelector('.chat-history');
   if (!history) return;
-
-  const targetTop = resolveExchangeScrollTop(mount);
-  if (targetTop === 0 && history.querySelectorAll('.user-message').length === 0) return;
-
-  history.scrollTop = targetTop;
+  history.scrollTop = resolveExchangeScrollTop(mount);
 }
 
 function scheduleScrollAfterSuggestion(mount) {

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -328,6 +328,14 @@ function resolveExchangeScrollTop(mount) {
   return Math.max(0, offsetTop - messageMarginTop);
 }
 
+/*
+ * NOTE: The rAF loop in startScrollPin is intentional and cannot be replaced by the mutation
+ * observer + retry timeouts alone. BC's streaming renderer resets scrollTop to the bottom on
+ * every content chunk it appends — effectively on every frame. Without a matching rAF loop
+ * our position is overwritten between mutation callbacks, and the question-pin never sticks.
+ * The forced-layout cost (~2 getBoundingClientRect calls per frame × 3.5 s) is accepted as
+ * the minimum overhead required to hold scroll position against BC's own auto-scroll.
+ */
 function startScrollPin(mount) {
   stopScrollPin();
   const history = mount?.querySelector('.chat-history');
@@ -502,7 +510,7 @@ function watchScrollToBottomButton(mount) {
     });
     scrollBtnStyleObserver.observe(scrollBtn, {
       attributes: true,
-      attributeFilter: ['class', 'style', 'hidden'],
+      attributeFilter: ['style', 'hidden'],
     });
   };
 

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -57,6 +57,7 @@ let scrollToBottomWatcher = null;
 let scrollAfterSuggestionObserver = null;
 let scrollAfterSuggestionTimers = [];
 let scrollPinRafId = null;
+let scrollPinUserScrollCleanup = null;
 let mountInteractionHandler = null;
 
 /**
@@ -263,6 +264,8 @@ function stopScrollPin() {
     window.cancelAnimationFrame(scrollPinRafId);
     scrollPinRafId = null;
   }
+  scrollPinUserScrollCleanup?.();
+  scrollPinUserScrollCleanup = null;
 }
 
 function clearScrollAfterSuggestionSchedule() {
@@ -291,14 +294,18 @@ function getMessageScrollTopInHistory(history, messageEl) {
 }
 
 function ensureExchangeScrollRoom(mount, history, userMessageEl, userMessageCount) {
-  if (userMessageCount < 2 || !userMessageEl) return;
+  const currentMin = parseInt(history.style.minHeight || '0', 10) || 0;
+  if (userMessageCount < 2) {
+    if (currentMin > 0) history.style.removeProperty('min-height');
+    return;
+  }
+  if (!userMessageEl) return;
 
   const container = history.closest('.brand-concierge-container');
   const inputSection = mount?.querySelector('.input-section');
   if (!container) return;
 
   const neededMinHeight = userMessageEl.offsetTop + container.clientHeight - (inputSection?.clientHeight ?? 0);
-  const currentMin = parseInt(history.style.minHeight || '0', 10) || 0;
   if (neededMinHeight > currentMin) {
     history.style.setProperty('min-height', `${Math.ceil(neededMinHeight)}px`);
   }
@@ -315,9 +322,7 @@ function resolveExchangeScrollTop(mount) {
   }
 
   const userMessage = userMessages[userMessages.length - 1];
-  if (userMessages.length >= 2) {
-    ensureExchangeScrollRoom(mount, history, userMessage, userMessages.length);
-  }
+  ensureExchangeScrollRoom(mount, history, userMessage, userMessages.length);
 
   const messageMarginTop = parseInt(window.getComputedStyle(userMessage).marginTop, 10) || 0;
 
@@ -331,9 +336,16 @@ function startScrollPin(mount) {
   if (!history) return;
 
   const end = Date.now() + SCROLL_AFTER_SUGGESTION_PIN_MS;
+  const onUserScroll = (e) => {
+    if (e.isTrusted) stopScrollPin();
+  };
+  history.addEventListener('scroll', onUserScroll, true);
+  scrollPinUserScrollCleanup = () => history.removeEventListener('scroll', onUserScroll, true);
+
   const tick = () => {
     if (Date.now() > end) {
       scrollPinRafId = null;
+      stopScrollPin();
       return;
     }
     history.scrollTop = resolveExchangeScrollTop(mount);
@@ -409,6 +421,9 @@ function onMountInteraction(event) {
   }
 
   if (event.target.closest(SUGGESTION_CLICK_SELECTOR)) {
+    // BC_EVENT_PROMPT_CLICKED also triggers scheduleScrollAfterSuggestion for suggestion
+    // clicks, but SUGGESTION_CLICK_SELECTOR covers widget-options buttons and any click
+    // paths that do not fire a BC onEvent (e.g. keyboard-activated clicks on some builds).
     scheduleScrollAfterSuggestion(mount);
   }
 }
@@ -428,6 +443,17 @@ function installQuestionPinHandlers(mount) {
 
   mountInteractionHandler = onMountInteraction;
   mount.addEventListener('click', mountInteractionHandler, true);
+}
+
+function rafDebounce(fn) {
+  let id = null;
+  return () => {
+    if (!id)
+      id = requestAnimationFrame(() => {
+        id = null;
+        fn();
+      });
+  };
 }
 
 /**
@@ -506,7 +532,7 @@ function watchScrollToBottomButton(mount) {
     history.addEventListener('scroll', update, { passive: true });
     historyResizeObserver = new ResizeObserver(update);
     historyResizeObserver.observe(history);
-    historyContentObserver = new MutationObserver(update);
+    historyContentObserver = new MutationObserver(rafDebounce(update));
     historyContentObserver.observe(history, { childList: true, subtree: true });
     attachScrollButtonObserver();
     attachInputAreaObserver();

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -341,7 +341,7 @@ function resolveExchangeScrollTop(mount) {
  * observer + retry timeouts alone. BC's streaming renderer resets scrollTop to the bottom on
  * every content chunk it appends — effectively on every frame. Without a matching rAF loop
  * our position is overwritten between mutation callbacks, and the question-pin never sticks.
- * The forced-layout cost (~2 getBoundingClientRect calls per frame × 3.5 s) is accepted as
+ * The forced-layout cost (~3 layout reads per frame × 3.5 s) is accepted as
  * the minimum overhead required to hold scroll position against BC's own auto-scroll.
  */
 function startScrollPin(mount) {
@@ -480,6 +480,17 @@ function watchScrollToBottomButton(mount) {
 
   const update = () => syncScrollToBottomButton(mount);
 
+  // Scroll-only update: .input-section and .input-container are position:absolute bottom:0
+  // and don't move during scroll, so skip the getBoundingClientRect calls in
+  // updateInputOverlayLayout — only the button visibility needs re-evaluating.
+  const scrollUpdate = () => {
+    const scrollBtn = mount.querySelector('.scroll-to-bottom');
+    if (!history || !scrollBtn) return;
+    const inWelcomeState = mount.querySelector('.brand-concierge-container.initial-state');
+    scrollBtn.classList.toggle('bc-scroll-to-bottom-visible', !inWelcomeState && shouldShowScrollToBottomButton(history));
+  };
+  const debouncedScrollUpdate = rafDebounce(scrollUpdate);
+
   const attachInputAreaObserver = () => {
     inputAreaResizeObserver?.disconnect();
     const inputSection = mount.querySelector('.input-section');
@@ -524,7 +535,7 @@ function watchScrollToBottomButton(mount) {
       return;
     }
 
-    history?.removeEventListener('scroll', update);
+    history?.removeEventListener('scroll', debouncedScrollUpdate);
     historyResizeObserver?.disconnect();
     historyContentObserver?.disconnect();
 
@@ -536,7 +547,7 @@ function watchScrollToBottomButton(mount) {
       return;
     }
 
-    history.addEventListener('scroll', update, { passive: true });
+    history.addEventListener('scroll', debouncedScrollUpdate, { passive: true });
     historyResizeObserver = new ResizeObserver(update);
     historyResizeObserver.observe(history);
     historyContentObserver = new MutationObserver(rafDebounce(update));
@@ -555,7 +566,7 @@ function watchScrollToBottomButton(mount) {
     cleanup: () => {
       mountObserver.disconnect();
       window.removeEventListener('resize', update);
-      history?.removeEventListener('scroll', update);
+      history?.removeEventListener('scroll', debouncedScrollUpdate);
       historyResizeObserver?.disconnect();
       historyContentObserver?.disconnect();
       scrollBtnStyleObserver?.disconnect();

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -21,16 +21,6 @@ if (window.location.search?.indexOf('martech=off') === -1) {
   sendCoveoPageViewEvent();
 }
 
-async function isAdobeEmployee() {
-  if (!window.adobeIMS?.isSignedInUser()) return false;
-  try {
-    const profile = await window.adobeIMS.getProfile();
-    return profile?.email?.toLowerCase().endsWith('@adobe.com') === true;
-  } catch {
-    return false;
-  }
-}
-
 /** Paths like /en/support, /fr/premium (communities use a separate origin). */
 function isBrandConciergeExcludedPath() {
   const { pathname } = window.location;
@@ -49,7 +39,6 @@ async function loadBrandConcierge() {
   const { bcAuthRequired } = getConfig();
   if (bcAuthRequired) {
     await loadIms();
-    if (!(await isAdobeEmployee())) return;
   }
 
   const { default: initBrandConcierge } = await import('./brand-concierge/brand-concierge.js');

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -39,6 +39,7 @@ async function loadBrandConcierge() {
   const { bcAuthRequired } = getConfig();
   if (bcAuthRequired) {
     await loadIms();
+    if (!window.adobeIMS?.isSignedInUser()) return;
   }
 
   const { default: initBrandConcierge } = await import('./brand-concierge/brand-concierge.js');

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -31,7 +31,7 @@ function isBrandConciergeExcludedPath() {
  * Loads Brand Concierge on eligible page types.
  * Guards:
  *   - hidden on Support and Premium Learning routes
- *   - bcAuthRequired → when true, user must be signed in AND be an @adobe.com employee
+ *   - bcAuthRequired → when true, user must be signed in 
  */
 async function loadBrandConcierge() {
   if (isBrandConciergeExcludedPath()) return;

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -31,7 +31,7 @@ function isBrandConciergeExcludedPath() {
  * Loads Brand Concierge on eligible page types.
  * Guards:
  *   - hidden on Support and Premium Learning routes
- *   - bcAuthRequired → when true, user must be signed in 
+ *   - bcAuthRequired → when true, user must be signed in
  */
 async function loadBrandConcierge() {
   if (isBrandConciergeExcludedPath()) return;

--- a/scripts/dialog/dialog.css
+++ b/scripts/dialog/dialog.css
@@ -67,8 +67,7 @@ dialog[data-type] {
 }
 
 .exl-dialog-header-expand,
-.exl-dialog-header-close,
-.exl-dialog-header-clear {
+.exl-dialog-header-close {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/scripts/dialog/dialog.css
+++ b/scripts/dialog/dialog.css
@@ -99,6 +99,8 @@ dialog[data-type] {
   font-weight: 600;
   line-height: 1;
   color: var(--spectrum-gray-800);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
 }
 
 .exl-dialog-header-clear:hover {

--- a/scripts/dialog/dialog.css
+++ b/scripts/dialog/dialog.css
@@ -86,6 +86,9 @@ dialog[data-type] {
 
 /* Text control (e.g. Clear) — secondary outline button, distinct from icon-only controls */
 .exl-dialog-header-clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: auto;
   min-width: auto;
   height: 30px;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -917,7 +917,7 @@ export function getConfig() {
     bcOrgId: 'E4722728699EC56A0A495CA2@AdobeOrg',
     bcAlloySdkUrl: 'https://cdn1.adoberesources.net/alloy/2.31.1/alloy.min.js',
 
-    // Using temporary URL for Brand Concierge web client until the code is deployed on the actual URL.
+    // TODO: Delete this line and uncomment the line below when the code is deployed on the actual URL.
     bcWebClientUrl: 'https://d3mey6isb8np59.cloudfront.net/experience-league-prod/main.js',
     // bcWebClientUrl:
     // 'https://experience.adobe.net/solutions/experience-platform-brand-concierge-web-agent/static-assets/main.js',

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -916,8 +916,11 @@ export function getConfig() {
     bcDatastreamId: '87ae6de9-a49c-4734-a88a-17ec707ded09',
     bcOrgId: 'E4722728699EC56A0A495CA2@AdobeOrg',
     bcAlloySdkUrl: 'https://cdn1.adoberesources.net/alloy/2.31.1/alloy.min.js',
-    bcWebClientUrl:
-      'https://experience.adobe.net/solutions/experience-platform-brand-concierge-web-agent/static-assets/main.js',
+
+    // Using temporary URL for Brand Concierge web client until the code is deployed on the actual URL.
+    bcWebClientUrl: 'https://d3mey6isb8np59.cloudfront.net/experience-league-prod/main.js',
+    // bcWebClientUrl:
+    // 'https://experience.adobe.net/solutions/experience-platform-brand-concierge-web-agent/static-assets/main.js',
     bcEdgeDomain: 'edge.adobedc.net',
     bcAuthRequired: true,
   };


### PR DESCRIPTION
## Summary
- prevent active Brand Concierge conversations from auto-scrolling users away from their selected question context
- add/position a scroll-to-bottom control above the input so users can intentionally jump to the latest response
- stabilize Brand Concierge overlay/input layout behavior and align dialog header clear-button styling with the new interaction model
- Every logged-in users should be able to access Exl BC not just user with @adobe.com. We will use Adobe Target to open up BC for 25% of users + Adobe employees in first phase.
- Replaced BC production CDN with temporary CDN to include the latest BC bug fixes that are not yet available on Production environment.

## Test plan
- [x] Open Brand Concierge and click a prompt suggestion; verify the selected question remains in view while the response renders
- [x] Confirm the scroll-to-bottom button appears above the input during active conversation and jumps to latest message when clicked
- [x] Verify the input/search bar position does not shift during typing, selecting prompts, or clearing the conversation

Jira ID: [UGP-14953](https://jira.corp.adobe.com/browse/UGP-14953) [UGP-15374](https://jira.corp.adobe.com/browse/UGP-15374)

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://UGP-14953--exlm--adobe-experience-league.aem.live
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://UGP-14953--exlm--adobe-experience-league.aem.live/en/search?martech=off