### PR TITLE
fix: UGP-15376: Fix keyboard scroll not working in BC panel

### DIFF
--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -676,7 +676,7 @@ function installKeyboardScrollHandler(dialog, mount) {
 
     const isPageKey = e.key === 'PageUp' || e.key === 'PageDown';
     const scrollAmount = isPageKey ? history.clientHeight * 0.85 : 60;
-    const direction = (e.key === 'ArrowUp' || e.key === 'PageUp') ? -1 : 1;
+    const direction = e.key === 'ArrowUp' || e.key === 'PageUp' ? -1 : 1;
 
     history.scrollBy({ top: direction * scrollAmount, behavior: isPageKey ? 'smooth' : 'auto' });
   };

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -640,11 +640,6 @@ async function clearBrandConciergeConversation() {
   focusBcChatInputWhenReady(bcMount);
 }
 
-/**
- * Intercepts keyboard scroll keys on the dialog so they scroll `.chat-history` instead of
- * the page behind. PageUp/PageDown are intercepted unconditionally; ArrowUp/ArrowDown are
- * intercepted only when focus is outside a text input (where they move the cursor).
- */
 function removeKeyboardScrollHandler() {
   if (keyboardScrollHandler && keyboardScrollDialog) {
     keyboardScrollDialog.removeEventListener('keydown', keyboardScrollHandler, true);
@@ -662,7 +657,10 @@ function installKeyboardScrollHandler(dialog, mount) {
     const activeEl = document.activeElement;
     if (
       (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
-      (activeEl?.tagName === 'TEXTAREA' || activeEl?.tagName === 'INPUT' || activeEl?.isContentEditable)
+      (activeEl?.tagName === 'TEXTAREA' ||
+        activeEl?.tagName === 'INPUT' ||
+        activeEl?.tagName === 'SELECT' ||
+        activeEl?.isContentEditable)
     )
       return;
 

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -648,6 +648,11 @@ function removeKeyboardScrollHandler() {
   keyboardScrollDialog = null;
 }
 
+/**
+ * Intercepts keyboard scroll keys on the dialog so they scroll `.chat-history` instead of
+ * the page behind. PageUp/PageDown are intercepted unconditionally; ArrowUp/ArrowDown are
+ * intercepted only when focus is outside a text input (where they move the cursor).
+ */
 function installKeyboardScrollHandler(dialog, mount) {
   removeKeyboardScrollHandler();
 
@@ -655,6 +660,10 @@ function installKeyboardScrollHandler(dialog, mount) {
     if (e.key !== 'PageUp' && e.key !== 'PageDown' && e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
 
     const activeEl = document.activeElement;
+
+    // Arrow keys are bypassed when focus is in an editable control so cursor/option
+    // movement is unaffected. Page keys are NOT bypassed — intentional: they always
+    // scroll chat-history, never the textarea behind.
     if (
       (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
       (activeEl?.tagName === 'TEXTAREA' ||

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -662,7 +662,7 @@ function installKeyboardScrollHandler(dialog, mount) {
     const activeEl = document.activeElement;
     if (
       (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
-      (activeEl?.tagName === 'TEXTAREA' || activeEl?.tagName === 'INPUT')
+      (activeEl?.tagName === 'TEXTAREA' || activeEl?.tagName === 'INPUT' || activeEl?.isContentEditable)
     )
       return;
 

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -63,6 +63,8 @@ let scrollPinRafId = null;
 let scrollPinUserScrollCleanup = null;
 let mountInteractionHandler = null;
 let mountWithHandler = null;
+let keyboardScrollHandler = null;
+let keyboardScrollDialog = null;
 
 /**
  * Removes persisted BC chat sessions from localStorage (transcript + metadata).
@@ -638,6 +640,51 @@ async function clearBrandConciergeConversation() {
   focusBcChatInputWhenReady(bcMount);
 }
 
+/**
+ * Intercepts keyboard scroll keys on the dialog so they scroll `.chat-history` instead of
+ * the page behind. PageUp/PageDown are intercepted unconditionally; ArrowUp/ArrowDown are
+ * intercepted only when focus is outside a text input (where they move the cursor).
+ */
+function removeKeyboardScrollHandler() {
+  if (keyboardScrollHandler && keyboardScrollDialog) {
+    keyboardScrollDialog.removeEventListener('keydown', keyboardScrollHandler, true);
+  }
+  keyboardScrollHandler = null;
+  keyboardScrollDialog = null;
+}
+
+function installKeyboardScrollHandler(dialog, mount) {
+  removeKeyboardScrollHandler();
+
+  keyboardScrollHandler = (e) => {
+    if (e.key !== 'PageUp' && e.key !== 'PageDown' && e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+
+    const activeEl = document.activeElement;
+    if (
+      (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
+      (activeEl?.tagName === 'TEXTAREA' || activeEl?.tagName === 'INPUT')
+    )
+      return;
+
+    // Always suppress page scroll for these keys inside the dialog, even if chat-history
+    // has no overflow yet (welcome state). showModal() traps focus but does not consume
+    // keyboard events, so unconsumed PageUp/PageDown would scroll the document behind.
+    e.preventDefault();
+
+    const history = mount?.querySelector('.chat-history');
+    if (!history || history.scrollHeight <= history.clientHeight) return;
+
+    const isPageKey = e.key === 'PageUp' || e.key === 'PageDown';
+    const scrollAmount = isPageKey ? history.clientHeight * 0.85 : 60;
+    const direction = (e.key === 'ArrowUp' || e.key === 'PageUp') ? -1 : 1;
+
+    history.scrollBy({ top: direction * scrollAmount, behavior: isPageKey ? 'smooth' : 'auto' });
+  };
+
+  keyboardScrollDialog = dialog;
+  dialog.addEventListener('keydown', keyboardScrollHandler, true);
+}
+
 function createMountPoint() {
   if (document.getElementById(DIALOG_ID)) return document.getElementById(DIALOG_ID);
 
@@ -688,6 +735,7 @@ function createMountPoint() {
   });
 
   const { element: dialog } = drawerHandle;
+  installKeyboardScrollHandler(dialog, mount);
 
   trigger.addEventListener('click', () => {
     dialog.showModal();
@@ -754,6 +802,7 @@ function injectAlloyStub() {
 export function destroyBrandConcierge() {
   scrollToBottomWatcher?.cleanup();
   scrollToBottomWatcher = null;
+  removeKeyboardScrollHandler();
   removeQuestionPinHandlers();
   inputLabelIconObserver?.disconnect();
   inputLabelIconObserver = null;

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -673,15 +673,19 @@ function installKeyboardScrollHandler(dialog, mount) {
     )
       return;
 
-    // Always suppress page scroll for these keys inside the dialog, even if chat-history
-    // has no overflow yet (welcome state). showModal() traps focus but does not consume
-    // keyboard events, so unconsumed PageUp/PageDown would scroll the document behind.
-    e.preventDefault();
+    const isPageKey = e.key === 'PageUp' || e.key === 'PageDown';
+
+    // Page keys always suppress document scroll — showModal() traps focus but does not
+    // consume keyboard events, so unconsumed PageUp/PageDown scroll the page behind.
+    // Arrow keys are only prevented when we will actually scroll, so any ARIA widget inside
+    // the dialog that checks e.defaultPrevented for its own navigation is not broken.
+    if (isPageKey) e.preventDefault();
 
     const history = mount.querySelector('.chat-history');
     if (!history || history.scrollHeight <= history.clientHeight) return;
 
-    const isPageKey = e.key === 'PageUp' || e.key === 'PageDown';
+    if (!isPageKey) e.preventDefault();
+
     const scrollAmount = isPageKey ? history.clientHeight * 0.85 : 60;
     const direction = e.key === 'ArrowUp' || e.key === 'PageUp' ? -1 : 1;
 

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -671,7 +671,7 @@ function installKeyboardScrollHandler(dialog, mount) {
     // keyboard events, so unconsumed PageUp/PageDown would scroll the document behind.
     e.preventDefault();
 
-    const history = mount?.querySelector('.chat-history');
+    const history = mount.querySelector('.chat-history');
     if (!history || history.scrollHeight <= history.clientHeight) return;
 
     const isPageKey = e.key === 'PageUp' || e.key === 'PageDown';


### PR DESCRIPTION
## Summary
- Adds a keyboard scroll handler that intercepts `PageUp`/`PageDown`/`ArrowUp`/`ArrowDown` inside the Brand Concierge dialog and redirects them to scroll `.chat-history` instead of the page behind
- Suppresses default page scroll for those keys unconditionally inside the dialog (even in welcome state), since `showModal()` traps focus but does not consume keyboard events
- Arrow keys are only intercepted when focus is outside a text input, so cursor movement in the chat textarea is unaffected
- Cleans up the handler on dialog close to avoid memory leaks

## Test Plan
- [x] Open the BC panel and send a few messages to fill the chat history
- [x] Press `PageDown`/`PageUp` — chat history should scroll, not the page behind
- [x] Press `ArrowDown`/`ArrowUp` outside the input — chat history should scroll
- [x] Click into the chat input and press `ArrowUp`/`ArrowDown` — cursor should move normally, not scroll
- [x] Close and reopen the BC panel — keyboard scroll should still work

Jira ID: [UGP-15376](https://jira.corp.adobe.com/browse/UGP-15376)

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://UGP-15376--exlm--adobe-experience-league.aem.live
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://UGP-15376--exlm--adobe-experience-league.aem.live/en/search?martech=off