### PR TITLE
refactor: UGP-15406: Update bcWebClientUrl in getConfig function for deployment readiness

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -916,11 +916,8 @@ export function getConfig() {
     bcDatastreamId: '87ae6de9-a49c-4734-a88a-17ec707ded09',
     bcOrgId: 'E4722728699EC56A0A495CA2@AdobeOrg',
     bcAlloySdkUrl: 'https://cdn1.adoberesources.net/alloy/2.31.1/alloy.min.js',
-
-    // TODO: Delete this line and uncomment the line below when the code is deployed on the actual URL.
-    bcWebClientUrl: 'https://d3mey6isb8np59.cloudfront.net/experience-league-prod/main.js',
-    // bcWebClientUrl:
-    // 'https://experience.adobe.net/solutions/experience-platform-brand-concierge-web-agent/static-assets/main.js',
+    bcWebClientUrl:
+      'https://experience.adobe.net/solutions/experience-platform-brand-concierge-web-agent/static-assets/main.js',
     bcEdgeDomain: 'edge.adobedc.net',
     bcAuthRequired: true,
   };


### PR DESCRIPTION
Jira ID: [UGP-15406](https://jira.corp.adobe.com/browse/UGP-15406)

## Summary
- Switched `bcWebClientUrl` to the production Adobe Experience URL now that the code is deployed on the actual URL
- Removed the temporary CloudFront URL and the associated TODO comment

## Test Plan
- [ ] Verify Brand Concierge web client loads correctly from the new URL in a deployed environment
Please provide the Jira Issue your PR is for.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://UGP-15406--exlm--adobe-experience-league.aem.live
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://UGP-15406--exlm--adobe-experience-league.aem.live/en/search?martech=off