### PR TITLE
Remove ability to tag against V2 EXLM-4825

### DIFF
--- a/blocks/browse-filters/browse-filters.js
+++ b/blocks/browse-filters/browse-filters.js
@@ -3,6 +3,7 @@ import {
   createTag,
   htmlToElement,
   getv2TagLabels,
+  isV2TagFormat,
   getPathDetails,
   fetchLanguagePlaceholders,
   matchesAnyTheme,
@@ -1495,9 +1496,7 @@ function decorateBrowseTopics(block) {
   // Check if block has v1 tags by finding any element that starts with "exl:"
   const hasExlTag = allDivs.some((el) => el?.textContent?.trim().startsWith('exl:'));
 
-  // v1 blocks have 8 divs: solution(v1), heading, topics(v1), contentType, solutionsv2, featuresv2, topicsv2, customElement
-  // v2-only blocks have 6 divs: heading, contentType, solutionsv2, featuresv2, topicsv2, customElement
-  // Use exl: tag check first, then fall back to div count
+  // blocks with v1 tags have 8 divs: solution(v1), heading, topics(v1), contentType, solutionsv2, featuresv2, topicsv2, customElement
   const hasV1Tags = hasExlTag || allDivs.length >= 8;
 
   let solutionsElement;
@@ -1521,7 +1520,7 @@ function decorateBrowseTopics(block) {
       customElement,
     ] = allDivs;
   } else {
-    // v2-only blocks with 6 divs
+    // blocks with v2 has only 6 divs
     [headingElement, contentTypeElement, solutionsv2Element, featuresv2Element, topicsv2Element, customElement] =
       allDivs;
   }
@@ -1537,13 +1536,6 @@ function decorateBrowseTopics(block) {
   const localizedTopicsContent = isFormElement ? '' : customElement?.textContent?.trim() ?? '';
   let allSolutionsTags;
   let allTopicsTags;
-
-  // Helper to check if content is valid v2 tag format (JSON)
-  const isV2TagFormat = (content) => {
-    if (!content) return false;
-    const trimmed = content.trim();
-    return trimmed.startsWith('[{') || trimmed.startsWith('{');
-  };
 
   // If new format (no v1 tags), always use v2 tags
   // If old format, use v2 tags if FF enabled, otherwise use v1 tags

--- a/blocks/browse-filters/browse-filters.js
+++ b/blocks/browse-filters/browse-filters.js
@@ -1493,7 +1493,12 @@ function decorateBrowseTopics(block) {
   const allDivs = [...block.children].map((row) => row.firstElementChild);
 
   // Check if block has v1 tags by finding any element that starts with "exl:"
-  const hasV1Tags = allDivs.some((el) => el?.textContent?.trim().startsWith('exl:'));
+  const hasExlTag = allDivs.some((el) => el?.textContent?.trim().startsWith('exl:'));
+
+  // v1 blocks have 8 divs: solution(v1), heading, topics(v1), contentType, solutionsv2, featuresv2, topicsv2, customElement
+  // v2-only blocks have 6 divs: heading, contentType, solutionsv2, featuresv2, topicsv2, customElement
+  // Use exl: tag check first, then fall back to div count
+  const hasV1Tags = hasExlTag || allDivs.length >= 8;
 
   let solutionsElement;
   let headingElement;
@@ -1516,6 +1521,7 @@ function decorateBrowseTopics(block) {
       customElement,
     ] = allDivs;
   } else {
+    // v2-only blocks with 6 divs
     [headingElement, contentTypeElement, solutionsv2Element, featuresv2Element, topicsv2Element, customElement] =
       allDivs;
   }
@@ -1531,15 +1537,23 @@ function decorateBrowseTopics(block) {
   const localizedTopicsContent = isFormElement ? '' : customElement?.textContent?.trim() ?? '';
   let allSolutionsTags;
   let allTopicsTags;
+
+  // Helper to check if content is valid v2 tag format (JSON)
+  const isV2TagFormat = (content) => {
+    if (!content) return false;
+    const trimmed = content.trim();
+    return trimmed.startsWith('[{') || trimmed.startsWith('{');
+  };
+
   // If new format (no v1 tags), always use v2 tags
   // If old format, use v2 tags if FF enabled, otherwise use v1 tags
-  if (!hasV1Tags || (isFeatureEnabled('isV2TagsEnabled') && solutionsv2Content)) {
-    const solutionsv2Labels = getv2TagLabels(solutionsv2Content);
+  if (!hasV1Tags || (isFeatureEnabled('isV2TagsEnabled') && isV2TagFormat(solutionsv2Content))) {
+    const solutionsv2Labels = isV2TagFormat(solutionsv2Content) ? getv2TagLabels(solutionsv2Content) : '';
     allSolutionsTags = solutionsv2Labels ? solutionsv2Labels.split(',').map((p) => p.trim()) : [];
 
     // Handle features v2 and topics v2 logic
-    const featuresv2Labels = featuresv2Content ? getv2TagLabels(featuresv2Content) : '';
-    const topicsv2Labels = topicsv2Content ? getv2TagLabels(topicsv2Content) : '';
+    const featuresv2Labels = isV2TagFormat(featuresv2Content) ? getv2TagLabels(featuresv2Content) : '';
+    const topicsv2Labels = isV2TagFormat(topicsv2Content) ? getv2TagLabels(topicsv2Content) : '';
 
     // Merge features and topics v2 tags; Set deduplicates if both fields contain overlapping labels.
     const featuresv2Array = featuresv2Labels ? featuresv2Labels.split(',').map((p) => p.trim()) : [];

--- a/blocks/curated-cards/curated-cards.js
+++ b/blocks/curated-cards/curated-cards.js
@@ -1,5 +1,5 @@
 import BrowseCardsDelegate from '../../scripts/browse-card/browse-cards-delegate.js';
-import { htmlToElement, getv2TagLabels } from '../../scripts/scripts.js';
+import { htmlToElement, getv2TagLabels, isV2TagFormat } from '../../scripts/scripts.js';
 import { buildCard } from '../../scripts/browse-card/browse-card.js';
 import BrowseCardShimmer from '../../scripts/browse-card/browse-card-shimmer.js';
 import { COVEO_SORT_OPTIONS } from '../../scripts/browse-card/browse-cards-constants.js';
@@ -22,9 +22,7 @@ export default async function decorate(block) {
   // Check if block has v1 tags by finding any element that starts with "exl:"
   const hasExlTag = configValues.some((el) => el?.startsWith('exl:'));
 
-  // v1 blocks have 11 config values (contentType, capabilities, role, level, authorType, sortBy, productv2, featurev2, subfeaturev2, rolev2, levelv2)
-  // v2-only blocks have 8 config values (contentType, authorType, sortBy, productv2, featurev2, subfeaturev2, rolev2, levelv2)
-  // Use exl: tag check first, then fall back to div count
+  // blocks wih v1 have 11 config values (contentType, capabilities, role, level, authorType, sortBy, productv2, featurev2, subfeaturev2, rolev2, levelv2)
   const hasV1Tags = hasExlTag || configValues.length >= 11;
 
   let contentType;
@@ -79,13 +77,6 @@ export default async function decorate(block) {
 
   // Appending header div to the block
   block.appendChild(headerDiv);
-
-  // Helper to check if content is valid v2 tag format (JSON)
-  const isV2TagFormat = (content) => {
-    if (!content) return false;
-    const trimmed = content.trim();
-    return trimmed.startsWith('[{') || trimmed.startsWith('{');
-  };
 
   let param;
   // If new format (no v1 tags), always use v2 tags

--- a/blocks/curated-cards/curated-cards.js
+++ b/blocks/curated-cards/curated-cards.js
@@ -20,7 +20,12 @@ export default async function decorate(block) {
   const configValues = configs.map((cell) => cell.textContent.trim());
 
   // Check if block has v1 tags by finding any element that starts with "exl:"
-  const hasV1Tags = configValues.some((el) => el?.startsWith('exl:'));
+  const hasExlTag = configValues.some((el) => el?.startsWith('exl:'));
+
+  // v1 blocks have 11 config values (contentType, capabilities, role, level, authorType, sortBy, productv2, featurev2, subfeaturev2, rolev2, levelv2)
+  // v2-only blocks have 8 config values (contentType, authorType, sortBy, productv2, featurev2, subfeaturev2, rolev2, levelv2)
+  // Use exl: tag check first, then fall back to div count
+  const hasV1Tags = hasExlTag || configValues.length >= 11;
 
   let contentType;
   let capabilities;
@@ -75,35 +80,42 @@ export default async function decorate(block) {
   // Appending header div to the block
   block.appendChild(headerDiv);
 
+  // Helper to check if content is valid v2 tag format (JSON)
+  const isV2TagFormat = (content) => {
+    if (!content) return false;
+    const trimmed = content.trim();
+    return trimmed.startsWith('[{') || trimmed.startsWith('{');
+  };
+
   let param;
   // If new format (no v1 tags), always use v2 tags
   // If old format, use v2 tags if FF enabled, otherwise use v1 tags
-  if (!hasV1Tags || (isFeatureEnabled('isV2TagsEnabled') && productv2)) {
-    const productsv2 = productv2
+  if (!hasV1Tags || (isFeatureEnabled('isV2TagsEnabled') && isV2TagFormat(productv2))) {
+    const productsv2 = isV2TagFormat(productv2)
       ? getv2TagLabels(productv2)
           .split(',')
           .map((p) => p.trim())
           .filter(Boolean)
       : [];
-    const featuresv2 = featurev2
+    const featuresv2 = isV2TagFormat(featurev2)
       ? getv2TagLabels(featurev2)
           .split(',')
           .map((f) => f.trim())
           .filter(Boolean)
       : [];
-    const versionsv2 = subfeaturev2
+    const versionsv2 = isV2TagFormat(subfeaturev2)
       ? getv2TagLabels(subfeaturev2)
           .split(',')
           .map((v) => v.trim())
           .filter(Boolean)
       : [];
-    const rolesv2 = rolev2
+    const rolesv2 = isV2TagFormat(rolev2)
       ? getv2TagLabels(rolev2)
           .split(',')
           .map((r) => r.trim())
           .filter(Boolean)
       : [];
-    const levelsv2 = levelv2
+    const levelsv2 = isV2TagFormat(levelv2)
       ? getv2TagLabels(levelv2)
           .split(',')
           .map((l) => l.trim())

--- a/blocks/events-cards/events-cards.js
+++ b/blocks/events-cards/events-cards.js
@@ -43,14 +43,21 @@ export default async function decorate(block) {
 
   const configValues = configs.map((cell) => cell.textContent.trim());
 
+  // Check if block has v1 tags by finding any element that starts with "exl:"
+  const hasExlTag = configValues.some((el) => el?.startsWith('exl:'));
+
+  // v1 blocks have 2 config values (solutions v1, solutionsv2)
+  // v2-only blocks have 1 config value (only solutionsv2)
+  // Use exl: tag check first, then fall back to div count
+  const hasV1Tags = hasExlTag || configValues.length >= 2;
+
   // Extract the solution values
   const [firstConfig, secondConfig] = configValues;
-  const hasV1Tag = firstConfig && firstConfig.startsWith('exl:solution/');
 
   let solutions;
   let solutionsv2;
 
-  if (hasV1Tag) {
+  if (hasV1Tags) {
     solutions = firstConfig;
     solutionsv2 = secondConfig || '';
   } else {
@@ -59,13 +66,20 @@ export default async function decorate(block) {
     solutionsv2 = firstConfig || '';
   }
 
+  // Helper to check if content is valid v2 tag format (JSON)
+  const isV2TagFormat = (content) => {
+    if (!content) return false;
+    const trimmed = content.trim();
+    return trimmed.startsWith('[{') || trimmed.startsWith('{');
+  };
+
   const contentType = CONTENT_TYPES.UPCOMING_EVENT.MAPPING_KEY;
   const noOfResults = 4;
   let solutionsParam = '';
 
   // If new format (no v1 tags), always use v2 tags
-  if (!hasV1Tag || (isFeatureEnabled('isV2TagsEnabled') && solutionsv2)) {
-    solutionsParam = solutionsv2
+  if (!hasV1Tags || (isFeatureEnabled('isV2TagsEnabled') && isV2TagFormat(solutionsv2))) {
+    solutionsParam = isV2TagFormat(solutionsv2)
       ? getv2TagLabels(solutionsv2)
           .split(',')
           .map((p) => p.trim())

--- a/blocks/events-cards/events-cards.js
+++ b/blocks/events-cards/events-cards.js
@@ -1,5 +1,5 @@
 import BrowseCardsDelegate from '../../scripts/browse-card/browse-cards-delegate.js';
-import { htmlToElement, getv2TagLabels } from '../../scripts/scripts.js';
+import { htmlToElement, getv2TagLabels, isV2TagFormat } from '../../scripts/scripts.js';
 import { buildCard } from '../../scripts/browse-card/browse-card.js';
 import BrowseCardShimmer from '../../scripts/browse-card/browse-card-shimmer.js';
 import { CONTENT_TYPES } from '../../scripts/data-service/coveo/coveo-exl-pipeline-constants.js';
@@ -46,9 +46,7 @@ export default async function decorate(block) {
   // Check if block has v1 tags by finding any element that starts with "exl:"
   const hasExlTag = configValues.some((el) => el?.startsWith('exl:'));
 
-  // v1 blocks have 2 config values (solutions v1, solutionsv2)
-  // v2-only blocks have 1 config value (only solutionsv2)
-  // Use exl: tag check first, then fall back to div count
+  // blocks with v1 have 2 config values (solutions v1, solutionsv2)
   const hasV1Tags = hasExlTag || configValues.length >= 2;
 
   // Extract the solution values
@@ -65,13 +63,6 @@ export default async function decorate(block) {
     solutions = '';
     solutionsv2 = firstConfig || '';
   }
-
-  // Helper to check if content is valid v2 tag format (JSON)
-  const isV2TagFormat = (content) => {
-    if (!content) return false;
-    const trimmed = content.trim();
-    return trimmed.startsWith('[{') || trimmed.startsWith('{');
-  };
 
   const contentType = CONTENT_TYPES.UPCOMING_EVENT.MAPPING_KEY;
   const noOfResults = 4;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1591,6 +1591,17 @@ export function updateTQTagsMetadata() {
 }
 
 /**
+ * Checks if content is valid v2 tag format (JSON)
+ * @param {string} content - Content to check
+ * @returns {boolean} True if content is valid JSON format
+ */
+export function isV2TagFormat(content) {
+  if (!content) return false;
+  const trimmed = content.trim();
+  return trimmed.startsWith('[{') || trimmed.startsWith('{');
+}
+
+/**
  * Extracts and returns a comma-separated string of label values from a JSON-encoded tag string.
  * @param {string} tag - A JSON string (possibly HTML-encoded) representing an array of objects with `label` properties.
  * @returns {string} A comma-separated string of labels, or an empty string if parsing fails or input is invalid.


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-4825--exlm--adobe-experience-league.aem.live
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://exlm-4825--exlm--adobe-experience-league.aem.live/en/search?martech=off