### PR TITLE
feat(EXLM-5245): Add "Automatically translated" notice to Browse pages

### DIFF
--- a/blocks/browse-breadcrumb/browse-breadcrumb.css
+++ b/blocks/browse-breadcrumb/browse-breadcrumb.css
@@ -50,3 +50,62 @@
 .browse-breadcrumb.block > a:first-child {
   font-weight: var(--font-weight-normal);
 }
+
+.browse-breadcrumb-mt-notice {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  margin-left: auto;
+  color: var(--spectrum-gray-700);
+  font-size: var(--spectrum-font-size-200);
+  position: relative;
+}
+
+.browse-breadcrumb-mt-tooltip-container {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.browse-breadcrumb-mt-tooltip-container .icon-info {
+  width: 16px;
+  height: 16px;
+}
+
+.browse-breadcrumb-mt-tooltip {
+  background-color: var(--spectrum-gray-600);
+  border-radius: 4px;
+  color: var(--spectrum-gray-50);
+  display: none;
+  font-size: var(--spectrum-font-size-75);
+  font-weight: var(--font-weight-normal);
+  padding: 2px 8px 4px;
+  position: absolute;
+  text-align: center;
+  white-space: normal;
+  overflow-wrap: break-word;
+  max-width: 150px;
+  width: max-content;
+  z-index: 10;
+  line-height: 1.5;
+  right: 100%;
+  bottom: 50%;
+  transform: translateY(50%);
+  margin-right: 10px;
+}
+
+.browse-breadcrumb-mt-tooltip::after {
+  border-width: 4px;
+  border-style: solid;
+  content: '';
+  position: absolute;
+  right: -8px;
+  top: 50%;
+  margin-top: -4px;
+  border-color: transparent transparent transparent var(--spectrum-gray-600);
+}
+
+.browse-breadcrumb-mt-tooltip-container:hover .browse-breadcrumb-mt-tooltip {
+  display: block;
+}

--- a/blocks/browse-breadcrumb/browse-breadcrumb.js
+++ b/blocks/browse-breadcrumb/browse-breadcrumb.js
@@ -1,5 +1,41 @@
 import ffetch from '../../scripts/ffetch.js';
-import { getEDSLink, getLink, getPathDetails, createPlaceholderSpan } from '../../scripts/scripts.js';
+import {
+  getEDSLink,
+  getLink,
+  getPathDetails,
+  createPlaceholderSpan,
+  fetchLanguagePlaceholders,
+  htmlToElement,
+} from '../../scripts/scripts.js';
+import { decorateIcons, getMetadata } from '../../scripts/lib-franklin.js';
+
+async function addMTNotice(block) {
+  const { lang } = getPathDetails();
+  const translationMechanism = getMetadata('translation-mechanism');
+  if (lang === 'en' || translationMechanism?.trim().toUpperCase() !== 'MT') return;
+
+  let placeholders = {};
+  try {
+    placeholders = await fetchLanguagePlaceholders();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching placeholders:', err);
+  }
+
+  const notice = htmlToElement(`
+    <div class="browse-breadcrumb-mt-notice">
+      <span>${placeholders?.automaticTranslation || 'Automatically translated'}</span>
+      <div class="browse-breadcrumb-mt-tooltip-container">
+        <span class="icon icon-info"></span>
+        <span class="browse-breadcrumb-mt-tooltip">${
+          placeholders?.changeLanguageTooltip || 'Use the Language Selector to view the English version of this page.'
+        }</span>
+      </div>
+    </div>
+  `);
+  decorateIcons(notice);
+  block.appendChild(notice);
+}
 
 export default async function decorate(block) {
   // to avoid dublication when editing
@@ -21,7 +57,7 @@ export default async function decorate(block) {
   block.append(rootCrumbElem);
 
   // get the browse index
-  ffetch(`/${getPathDetails().lang}/browse-index.json`)
+  await ffetch(`/${getPathDetails().lang}/browse-index.json`)
     .all()
     .then((index) => {
       // build the remaining breadcrumbs
@@ -49,4 +85,6 @@ export default async function decorate(block) {
         return nextCrumbSubPath;
       });
     });
+
+  addMTNotice(block);
 }


### PR DESCRIPTION
Jira ID: EXLM-5245

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5245--exlm--adobe-experience-league.aem.live
- After: https://exlm-5245--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5245--exlm--adobe-experience-league.aem.live/it/browse?martech=off
- After: https://exlm-5245--exlm--adobe-experience-league.aem.live/it/browse/analytics?martech=off

## AI Review Notes

- The "Automatically translated" notice only renders on non-EN Browse pages whose `translation-mechanism` page metadata is `MT` (same convention already used in `article-marquee.js` / `course-marquee.js`), so it will not appear on `/en/browse` or on non-MT localized pages — this is expected, not a missed case.
- `decorate()` now awaits the breadcrumb-building `ffetch` chain before appending the MT notice, fixing a latent ordering bug where the notice could end up left of later-appended crumbs. This is a necessary correctness fix, not scope creep.