### PR TITLE
feat(EXLM-5245): Add "Automatically translated" notice to Browse pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ skills/
 .vibe/
 .windsurf/
 .zencoder/
+plans/

--- a/blocks/browse-breadcrumb/browse-breadcrumb.css
+++ b/blocks/browse-breadcrumb/browse-breadcrumb.css
@@ -50,3 +50,71 @@
 .browse-breadcrumb.block > a:first-child {
   font-weight: var(--font-weight-normal);
 }
+
+/* AI translated notice, pushed to the rightmost side of the breadcrumb row */
+.browse-breadcrumb-ai-translated {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--spectrum-gray-700);
+  position: relative;
+  order: 1;
+  margin-left: auto;
+}
+
+.browse-breadcrumb-ai-translated-tooltip-container {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.browse-breadcrumb-ai-translated-tooltip-container .icon-info {
+  width: 16px;
+  height: 16px;
+}
+
+.browse-breadcrumb-ai-translated-tooltip {
+  background-color: var(--spectrum-gray-600);
+  border-radius: 4px;
+  color: var(--spectrum-gray-50);
+  display: none;
+  font-size: var(--spectrum-font-size-75);
+  font-weight: var(--font-weight-normal);
+  padding: 2px 8px 4px;
+  position: absolute;
+  text-align: center;
+  white-space: normal;
+  overflow-wrap: break-word;
+  max-width: 100px;
+  width: max-content;
+  z-index: 10;
+  line-height: 1.5;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+}
+
+.browse-breadcrumb-ai-translated-tooltip::after {
+  border-width: 4px;
+  border-style: solid;
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 100%;
+  margin-left: -4px;
+  border-color: var(--spectrum-gray-600) transparent transparent transparent;
+}
+
+.browse-breadcrumb-ai-translated-tooltip-container:hover .browse-breadcrumb-ai-translated-tooltip {
+  display: block;
+}
+
+@media (width < 600px) {
+  .browse-breadcrumb-ai-translated {
+    order: unset;
+    margin-left: 0;
+    flex-basis: 100%;
+    justify-content: flex-end;
+  }
+}

--- a/blocks/browse-breadcrumb/browse-breadcrumb.js
+++ b/blocks/browse-breadcrumb/browse-breadcrumb.js
@@ -1,5 +1,40 @@
 import ffetch from '../../scripts/ffetch.js';
-import { getEDSLink, getLink, getPathDetails, createPlaceholderSpan } from '../../scripts/scripts.js';
+import {
+  getEDSLink,
+  getLink,
+  getPathDetails,
+  createPlaceholderSpan,
+  fetchLanguagePlaceholders,
+  htmlToElement,
+} from '../../scripts/scripts.js';
+import { decorateIcons, getMetadata } from '../../scripts/lib-franklin.js';
+
+/* Fetch data from the Placeholder.json */
+let placeholders = {};
+try {
+  placeholders = await fetchLanguagePlaceholders();
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.error('Error fetching placeholders:', err);
+}
+
+function decorateAiTranslated(block) {
+  if (getMetadata('translation-mechanism')?.trim().toUpperCase() === 'MT' && getPathDetails().lang !== 'en') {
+    const aiTranslated = htmlToElement(`
+      <div class="browse-breadcrumb-ai-translated">
+        <span>${placeholders?.automaticTranslation || 'Automatically translated'}</span>
+        <div class="browse-breadcrumb-ai-translated-tooltip-container">
+          <span class="icon icon-info"></span>
+          <span class="browse-breadcrumb-ai-translated-tooltip">${
+            placeholders?.changeLanguageTooltip || 'Use the Language Selector to view the English version of this page.'
+          }</span>
+        </div>
+      </div>
+    `);
+    decorateIcons(aiTranslated);
+    block.append(aiTranslated);
+  }
+}
 
 export default async function decorate(block) {
   // to avoid dublication when editing
@@ -49,4 +84,6 @@ export default async function decorate(block) {
         return nextCrumbSubPath;
       });
     });
+
+  decorateAiTranslated(block);
 }


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

Jira ID: EXLM-5245

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5245--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5245--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5245--exlm--adobe-experience-league.aem.live/de/browse/analytics?martech=off
- After: https://exlm-5245--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off

## AI Review Notes

- No live content currently has `translation-mechanism=MT` metadata yet (EXLM-5031 content rollout pending), so the /de/browse/analytics test URL will not show the notice until a translated page has that metadata set. Verify the conditional logic by inspecting the code, or by temporarily injecting `<meta name="translation-mechanism" content="MT">` into the page head via devtools on a non-EN Browse page.
- Reused/adapted the existing article-marquee (Docs page) MT-notice pattern verbatim for visual and behavioral parity, per the ticket's explicit requirement to match Docs pages exactly.