### PR TITLE
feat(EXLM-5245): Add "Automatically translated" notice to Browse pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ skills/
 .vibe/
 .windsurf/
 .zencoder/
+plans/

--- a/blocks/browse-breadcrumb/browse-breadcrumb.css
+++ b/blocks/browse-breadcrumb/browse-breadcrumb.css
@@ -50,3 +50,79 @@
 .browse-breadcrumb.block > a:first-child {
   font-weight: var(--font-weight-normal);
 }
+
+/* machine-translation notice */
+.browse-breadcrumb.block > .browse-breadcrumb-ai-translated {
+  align-items: center;
+  display: flex;
+  flex-basis: 100%;
+  font-size: var(--spectrum-font-size-75);
+}
+
+/* on tablet and up, push the notice to the rightmost side of the breadcrumb row */
+@media (width >= 600px) {
+  .browse-breadcrumb.block > .browse-breadcrumb-ai-translated {
+    flex-basis: auto;
+    margin-left: auto;
+  }
+}
+
+.browse-breadcrumb.block > .browse-breadcrumb-ai-translated::before {
+  content: none;
+}
+
+.browse-breadcrumb-ai-translated .browse-breadcrumb-ai-translated-tooltip-container {
+  margin-left: 10px;
+  position: relative;
+  cursor: pointer;
+  line-height: var(--spectrum-line-height-l);
+}
+
+.browse-breadcrumb-ai-translated .icon-info {
+  width: 16px;
+  height: 16px;
+}
+
+.browse-breadcrumb-ai-translated .browse-breadcrumb-ai-translated-tooltip {
+  background-color: var(--spectrum-gray-600);
+  border-radius: 4px;
+  color: var(--spectrum-gray-50);
+  display: none;
+  font-size: var(--spectrum-font-size-75);
+  font-weight: var(--font-weight-normal);
+  padding: 2px 8px 4px;
+  position: absolute;
+  text-align: center;
+  transition: all 130ms ease-in-out;
+  white-space: normal;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  min-width: 150px;
+  z-index: 1;
+  line-height: 1.5;
+  left: auto;
+  right: 100%;
+  bottom: 50%;
+  transform: translateY(50%);
+  margin-right: 10px;
+}
+
+.browse-breadcrumb-ai-translated .browse-breadcrumb-ai-translated-tooltip::after {
+  border-width: 4px;
+  border-style: solid;
+  content: '';
+  position: absolute;
+  right: -8px;
+  top: 50%;
+  margin-top: -4px;
+  border-color: transparent transparent transparent var(--spectrum-gray-600);
+}
+
+.browse-breadcrumb.block
+  .browse-breadcrumb-ai-translated-tooltip-container:hover
+  .browse-breadcrumb-ai-translated-tooltip,
+.browse-breadcrumb.block
+  .browse-breadcrumb-ai-translated-tooltip-container:focus-within
+  .browse-breadcrumb-ai-translated-tooltip {
+  display: block;
+}

--- a/blocks/browse-breadcrumb/browse-breadcrumb.js
+++ b/blocks/browse-breadcrumb/browse-breadcrumb.js
@@ -1,5 +1,33 @@
 import ffetch from '../../scripts/ffetch.js';
-import { getEDSLink, getLink, getPathDetails, createPlaceholderSpan } from '../../scripts/scripts.js';
+import {
+  getEDSLink,
+  getLink,
+  getPathDetails,
+  createPlaceholderSpan,
+  fetchLanguagePlaceholders,
+  htmlToElement,
+} from '../../scripts/scripts.js';
+import { getMetadata, decorateIcons } from '../../scripts/lib-franklin.js';
+
+function appendMachineTranslatedNotice(block, placeholders) {
+  const { lang } = getPathDetails();
+  const isMachineTranslated = getMetadata('translation-mechanism')?.trim().toUpperCase() === 'MT';
+  if (lang === 'en' || !isMachineTranslated) return;
+
+  const notice = htmlToElement(`
+    <div class="browse-breadcrumb-ai-translated">
+      <span>${placeholders?.automaticTranslation || 'Automatically translated'}</span>
+      <div class="browse-breadcrumb-ai-translated-tooltip-container" tabindex="0">
+        <span class="icon icon-info"></span>
+        <span class="browse-breadcrumb-ai-translated-tooltip" role="tooltip">${
+          placeholders?.changeLanguageTooltip || 'Use the Language Selector to view the English version of this page.'
+        }</span>
+      </div>
+    </div>
+  `);
+  decorateIcons(notice);
+  block.append(notice);
+}
 
 export default async function decorate(block) {
   // to avoid dublication when editing
@@ -48,5 +76,13 @@ export default async function decorate(block) {
         // go to next sub path
         return nextCrumbSubPath;
       });
+    })
+    .finally(() => {
+      fetchLanguagePlaceholders()
+        .then((placeholders) => appendMachineTranslatedNotice(block, placeholders))
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error('Error fetching placeholders:', err);
+        });
     });
 }


### PR DESCRIPTION
Jira ID: EXLM-5245

## Description
Adds a localized "Automatically translated" notice with a hover/focus tooltip to the `browse-breadcrumb` block, shown only when a Browse page is non-EN and its `translation-mechanism` page metadata (from EXLM-5031) resolves to `MT`. The notice is right-aligned in the breadcrumb row on tablet/desktop and drops to its own full-width line on mobile, reusing the same metadata check, placeholder keys (`automaticTranslation`, `changeLanguageTooltip`), and info-icon/tooltip visual treatment already used by `article-marquee`, `course-marquee`, and `doc-actions`.

This PR is currently a **draft**: in-browser validation against a real non-EN Browse page with `translation-mechanism: MT` metadata is still pending — no such test content was identified during this session.

### Next Steps to Complete PR
- Identify or create a non-EN Browse page with `translation-mechanism: MT` metadata and confirm the notice + tooltip render correctly, matching the Docs-page look/feel
- Confirm the notice does *not* render on EN Browse pages, or non-EN Browse pages with HT/no translation metadata
- Add the confirmed preview URL(s) below and mark this PR ready for review

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://browseMT--exlm--adobe-experience-league.aem.live
- After: https://browseMT--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://browseMT--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://browseMT--exlm--adobe-experience-league.aem.live/it/browse?martech=off

## AI Review Notes

- The mobile-first `@media (width >= 600px)` breakpoint used here (vs. a max-width override) matches the convention already used in `article-marquee.css`, `course-marquee.css`, and `doc-actions.css`.
- `role="tooltip"` and `tabindex="0"`/`:focus-within` were added for keyboard/screen-reader accessibility; this is intentionally more accessible than the older `doc-actions`/`article-marquee` hover-only pattern, matching the direction already taken in `course-marquee.js`.