### PR TITLE
EXLM 5298 - New header use same custom element

### DIFF
--- a/blocks/header/header-v2.js
+++ b/blocks/header/header-v2.js
@@ -1078,8 +1078,6 @@ class ExlHeader extends HTMLElement {
   }
 }
 
-customElements.define('exl-header-v2', ExlHeader);
-
 /**
  * Create header web component and attach to the DOM
  * @param {HTMLHeadElement} headerBlock
@@ -1087,6 +1085,9 @@ customElements.define('exl-header-v2', ExlHeader);
 export default async function decorate(headerBlock, options = {}) {
   // marks the semantic <header> so global styles (see styles/styles.css) can differ for v2
   headerBlock.parentElement?.classList.add('header-v2');
+  if (!customElements.get('exl-header')) {
+    customElements.define('exl-header', ExlHeader);
+  }
   const exlHeader = new ExlHeader(options);
   headerBlock.replaceChildren(exlHeader);
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -812,8 +812,6 @@ class ExlHeader extends HTMLElement {
   }
 }
 
-customElements.define('exl-header', ExlHeader);
-
 /**
  * Create header web component and attach to the DOM
  * @param {HTMLHeadElement} headerBlock
@@ -822,6 +820,9 @@ export default async function decorate(headerBlock, options = {}) {
   if (isFeatureEnabled('isHeaderV2') || (await isDomainAllowed('headerv2allowedDomains'))) {
     const { default: decorateV2 } = await import('./header-v2.js');
     return decorateV2(headerBlock, options);
+  }
+  if (!customElements.get('exl-header')) {
+    customElements.define('exl-header', ExlHeader);
   }
   const exlHeader = new ExlHeader(options);
   headerBlock.replaceChildren(exlHeader);


### PR DESCRIPTION

Jira ID: https://jira.corp.adobe.com/browse/EXLM-5298


Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5298-bug--exlm--adobe-experience-league.aem.live
- After: https://exlm-5298-bug--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5298-bug--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5298-bug--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5298-bug--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->