### PR TITLE
fix: remove stale admin/authoring/development entries from skills-lock.json

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,11 +1,6 @@
 {
   "version": 1,
   "skills": {
-    "admin": {
-      "source": "adobe/skills",
-      "sourceType": "github",
-      "computedHash": "348c473f0352a5e18e1785f29f82e0c14f70b6a925b6985578c6f02fa85b689f"
-    },
     "aem-cli": {
       "source": "adobe/skills",
       "sourceType": "github",
@@ -23,11 +18,6 @@
       "sourceType": "github",
       "skillPath": "plugins/aem/project-management/skills/auth/SKILL.md",
       "computedHash": "70a68ce30a4fab8f972605eb1399e343dfcee71095da26e255e8e8fd07af1520"
-    },
-    "authoring": {
-      "source": "adobe/skills",
-      "sourceType": "github",
-      "computedHash": "ad8cb193bcdcb897e633c4e26b1f7be532894e068bda4fc28e830879573daad6"
     },
     "authoring-analysis": {
       "source": "adobe/skills",
@@ -88,11 +78,6 @@
       "sourceType": "github",
       "skillPath": "plugins/aem/edge-delivery-services/skills/da-content/SKILL.md",
       "computedHash": "70980c44ca712f8cabef4202e7e7c65b7736f3b6676690b6f6dcca8e58a0f926"
-    },
-    "development": {
-      "source": "adobe/skills",
-      "sourceType": "github",
-      "computedHash": "c80a546fd1ea69cdfa3c317b9eeb455be002c34e97088a6db38053b91113371b"
     },
     "docs-search": {
       "source": "adobe/skills",


### PR DESCRIPTION
Jira ID: N/A (CI infrastructure fix, no ticket)

## Description

Removes 3 stale entries (admin, authoring, development) from skills-lock.json. These skill names were renamed upstream in adobe/skills to handover-admin, handover-author, and handover-developer, which are already present in this same lock file, but the old entries were never cleaned up.

This is currently breaking the "Restore AI skills" step (npx skills experimental_install --yes) in the Claude PR Review workflow on every open PR, since those 3 names no longer resolve against the current adobe/skills catalog.

No app code is touched, this only trims stale config from the skills lock file.

## AI Review Notes

- This PR intentionally does not include page test URLs, it is a CI-infrastructure-only fix with no runtime/page impact.