### PR TITLE
Exlm 5298 - Hardcode Header Fragment in Header.js

### DIFF
--- a/blocks/header/header-v2.js
+++ b/blocks/header/header-v2.js
@@ -10,7 +10,7 @@ import {
   getConfig,
   getPathDetails,
   fetchLanguagePlaceholders,
-  fetchGlobalFragment,
+  fetchWithFallback,
 } from '../../scripts/scripts.js';
 import { isSignedInUser } from '../../scripts/auth/profile.js';
 import { isPLEligible } from '../../scripts/utils/premium-learning-utils.js';
@@ -56,6 +56,15 @@ import ProfileMenu from './profile-menu.js';
  */
 
 const HEADER_CSS = `/blocks/header/exl-header-v2.css`;
+
+/** fetch the header fragment relative to /${lang}/global-fragments/, ignoring any page metadata override */
+async function fetchHeaderFragment(fragmentPath, lang) {
+  const fragmentUrl = fragmentPath.replace('/en/', `/${lang}/`);
+  const path = `${window.hlx.codeBasePath}${fragmentUrl}.plain.html`;
+  const fallbackPath = `${window.hlx.codeBasePath}${fragmentPath}.plain.html`;
+  const response = await fetchWithFallback(path, fallbackPath);
+  return response.text();
+}
 
 let searchElementPromise = null;
 const { khorosProfileUrl, communityHost } = getConfig();
@@ -993,9 +1002,8 @@ class ExlHeader extends HTMLElement {
   }
 
   async decorate() {
-    const headerMeta = 'header-fragment';
-    const fallback = '/en/global-fragments/header-v2';
-    const headerFragment = await fetchGlobalFragment(headerMeta, fallback, this.decoratorOptions.lang);
+    const fragmentPath = '/en/global-fragments/header-v2';
+    const headerFragment = await fetchHeaderFragment(fragmentPath, this.decoratorOptions.lang);
     if (headerFragment) {
       loadSearchElement();
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -10,7 +10,7 @@ import {
   getConfig,
   getLink,
   getPathDetails,
-  fetchGlobalFragment,
+  fetchWithFallback,
   fetchLanguagePlaceholders,
 } from '../../scripts/scripts.js';
 import getProducts from '../../scripts/utils/product-utils.js';
@@ -57,6 +57,15 @@ import ProfileMenu from './profile-menu.js';
  */
 
 const HEADER_CSS = `/blocks/header/exl-header.css`;
+
+/** fetch the header fragment relative to /${lang}/global-fragments/, ignoring any page metadata override */
+async function fetchHeaderFragment(fragmentPath, lang) {
+  const fragmentUrl = fragmentPath.replace('/en/', `/${lang}/`);
+  const path = `${window.hlx.codeBasePath}${fragmentUrl}.plain.html`;
+  const fallbackPath = `${window.hlx.codeBasePath}${fragmentPath}.plain.html`;
+  const response = await fetchWithFallback(path, fallbackPath);
+  return response.text();
+}
 
 let searchElementPromise = null;
 const { khorosProfileUrl, communityHost } = getConfig();
@@ -733,9 +742,8 @@ class ExlHeader extends HTMLElement {
   }
 
   async decorate() {
-    const headerMeta = 'header-fragment';
-    const fallback = '/en/global-fragments/header';
-    const headerFragment = await fetchGlobalFragment(headerMeta, fallback, this.decoratorOptions.lang);
+    const fragmentPath = '/en/global-fragments/header';
+    const headerFragment = await fetchHeaderFragment(fragmentPath, this.decoratorOptions.lang);
     if (headerFragment) {
       loadSearchElement();
 


### PR DESCRIPTION
Jira ID: https://jira.corp.adobe.com/browse/EXLM-5298 

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5298-bug--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5298-bug--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5298-bug--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5298-bug--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->