### PR TITLE
url structure cleanup for event-search

### DIFF
--- a/blocks/events-search/events-search.js
+++ b/blocks/events-search/events-search.js
@@ -1167,17 +1167,10 @@ function bindClearFilters(block, groups) {
     const state = getFilterState(block);
     const { tags: activeTags, pendingRemovals } = state;
 
-    state.isClearing = true;
-
     // Uncheck all checkboxes without per-checkbox Headless toggles
     block.querySelectorAll('.events-search-filter-option input[type="checkbox"]').forEach((checkbox) => {
       checkbox.checked = false;
       checkbox.closest('.events-search-filter-option')?.classList.remove('checked');
-    });
-
-    // deselect all Headless facet controllers.
-    ['el_product', 'el_event_series', 'el_contenttype'].forEach((filterType) => {
-      getFacetController(filterType)?.deselectAll?.();
     });
 
     // Reset ordered tags array (browse-filters clearAllSelectedTag pattern).
@@ -1186,6 +1179,13 @@ function bindClearFilters(block, groups) {
     groups.forEach((group) => {
       group.selected = 0;
       updateGroupSelectionCount(block, group.id, 0);
+    });
+
+    state.isClearing = true;
+
+    // deselect all Headless facet controllers.
+    ['el_product', 'el_event_series', 'el_contenttype'].forEach((filterType) => {
+      getFacetController(filterType)?.deselectAll?.();
     });
 
     if (window.headlessSearchBox) {
@@ -1202,20 +1202,15 @@ function bindClearFilters(block, groups) {
       window.headlessPager.selectPage(1);
     }
 
-    // Remove facet params so urlManager won't re-apply them on hashchange.
-    const fragmentWithoutFacets = window.location.hash
-      .slice(1)
-      .split('&')
-      .filter((p) => p && !p.startsWith('f-'))
-      .join('&');
-    window.history.replaceState(
-      null,
-      document.title,
-      fragmentWithoutFacets ? `#${fragmentWithoutFacets}` : window.location.pathname + window.location.search,
-    );
-
     const hashBeforeClear = window.location.hash;
-    handleCoverSearchSubmit('');
+    const [currentSearchString] = hashBeforeClear.match(/\bq=([^&#]*)/) || [];
+    if (currentSearchString) {
+      let updatedHash = hashBeforeClear.replace(currentSearchString, '');
+      if (updatedHash.slice(1).startsWith('&')) {
+        updatedHash = `#${updatedHash.slice(2)}`;
+      }
+      window.location.hash = updatedHash;
+    }
     if (window.location.hash === hashBeforeClear) {
       executeSearch();
     }
@@ -1255,6 +1250,8 @@ async function initHeadlessSearch(block, groups, placeholders) {
     renderPageNumbers,
     numberOfResults: getBrowseFiltersResultCount(),
     facetOverrides: getEventsSearchHeadlessFacetOverrides(),
+    hideAqFromUrl: true,
+    baseAdvancedQuery: BASE_COVEO_ADVANCED_QUERY_EVENTS,
     renderSearchQuerySummary: () => {
       const totalCount = window.headlessQuerySummary?.state?.total || 0;
       updateResultsCount(block, totalCount, placeholders);
@@ -1272,11 +1269,8 @@ async function initHeadlessSearch(block, groups, placeholders) {
   bindEventsSearchLoadingUI(block);
   bindEventsSearchPagination(block);
 
-  if (window.headlessQueryActionCreators && window.headlessSearchEngine) {
-    const action = window.headlessQueryActionCreators.updateAdvancedSearchQueries({
-      aq: BASE_COVEO_ADVANCED_QUERY_EVENTS,
-    });
-    window.headlessSearchEngine.dispatch(action);
+  // aq is now set up-front via baseAdvancedQuery and reasserted on every hash change.
+  if (window.headlessSearchEngine) {
     executeSearch();
   }
   renderPageNumbers();

--- a/scripts/coveo-headless/index.js
+++ b/scripts/coveo-headless/index.js
@@ -141,6 +141,8 @@ export default async function initiateCoveoHeadlessSearch({
   renderSearchQuerySummary,
   handleSearchBoxSubscription,
   facetOverrides = {},
+  hideAqFromUrl = false,
+  baseAdvancedQuery = '',
 }) {
   return new Promise((resolve, reject) => {
     // eslint-disable-next-line import/no-relative-packages
@@ -154,7 +156,7 @@ export default async function initiateCoveoHeadlessSearch({
           searchEngine: headlessSearchEngine,
           searchHub: 'Experience League Learning Hub',
           contextObject: null,
-          advancedQueryRule: '',
+          advancedQueryRule: baseAdvancedQuery,
         });
 
         const headlessSearchBox = module.buildSearchBox(headlessSearchEngine, {
@@ -223,8 +225,32 @@ export default async function initiateCoveoHeadlessSearch({
           initialState: { fragment: fragment() },
         });
 
+        if (hideAqFromUrl && !baseAdvancedQuery) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            'initiateCoveoHeadlessSearch: hideAqFromUrl is enabled without baseAdvancedQuery — aq will be cleared (and never reapplied) on every hash change.',
+          );
+        }
+
+        // Used by events-search to keep its static aq out of the URL.
+        function visibleHash() {
+          const rawFragment = urlManager.state.fragment;
+          const visibleFragment = hideAqFromUrl
+            ? rawFragment
+                .split('&')
+                .filter((param) => param && !param.startsWith('aq='))
+                .join('&')
+            : rawFragment;
+          return visibleFragment ? `#${visibleFragment}` : window.location.pathname + window.location.search;
+        }
+
+        function currentVisibleUrl() {
+          return window.location.hash || window.location.pathname + window.location.search;
+        }
+
         urlManager.subscribe(() => {
-          const hash = `#${urlManager.state.fragment}`;
+          const hash = visibleHash();
+          if (hash === currentVisibleUrl()) return;
           if (!statusControllers.state.firstSearchExecuted) {
             window.history.replaceState(null, document.title, hash);
             return;
@@ -246,10 +272,28 @@ export default async function initiateCoveoHeadlessSearch({
           }
         });
 
+        function rerunSearch() {
+          const logSubmit = logSearchboxSubmit;
+          headlessSearchEngine.dispatch(
+            headlessSearchActionCreators.executeSearch(typeof logSubmit === 'function' ? logSubmit() : undefined),
+          );
+        }
+
+        // synchronize() restores aq from the (aq-less) URL and searches with it, so reassert the real aq and rerun the search right after.
+        function reapplyBaseAdvancedQuery({ rerunSearch: shouldRerunSearch = false } = {}) {
+          if (!hideAqFromUrl || !baseAdvancedQuery) return;
+          headlessSearchEngine.dispatch(
+            headlessQueryActionCreators.updateAdvancedSearchQueries({ aq: baseAdvancedQuery }),
+          );
+          if (shouldRerunSearch) rerunSearch();
+        }
+
         urlManager.synchronize(fragment());
+        reapplyBaseAdvancedQuery();
 
         function onHashChange() {
           urlManager.synchronize(fragment());
+          reapplyBaseAdvancedQuery({ rerunSearch: true });
         }
         window.addEventListener('hashchange', onHashChange);
 


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: https://jira.corp.adobe.com/browse/EXLM-5396

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5396--exlm--adobe-experience-league.aem.live
- After: https://exlm-5396--exlm--adobe-experience-league.aem.live/en/events?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->