### PR TITLE
Exlm 5361: filter out stale upcoming events

### DIFF
--- a/blocks/atomic-search/atomic-search.js
+++ b/blocks/atomic-search/atomic-search.js
@@ -25,6 +25,7 @@ import atomicResultPageHandler from './components/atomic-search-results-per-page
 import loadCoveoToken from '../../scripts/data-service/coveo/coveo-token-service.js';
 import { pushPageDataLayer } from '../../scripts/analytics/lib-analytics.js';
 import { buildCaptionElContentTypeResourceBundle } from './components/atomic-facet-engine-helpers.js';
+import { COVEO_EXCLUDE_STALE_UPCOMING_AQ } from '../../scripts/browse-card/browse-cards-constants.js';
 
 let placeholders = {};
 
@@ -125,6 +126,16 @@ export default function decorate(block) {
           },
         });
         document.dispatchEvent(preProcessEvent);
+
+        // Drop stale Upcoming Events at query time (same rule as Events Hub).
+        if (metadata?.method === 'search') {
+          const existingAq = (bodyJSON.aq || '').trim();
+          bodyJSON.aq = existingAq
+            ? `(${existingAq}) AND (${COVEO_EXCLUDE_STALE_UPCOMING_AQ})`
+            : COVEO_EXCLUDE_STALE_UPCOMING_AQ;
+          request.body = JSON.stringify(bodyJSON);
+        }
+
         return request;
       },
     });

--- a/blocks/upcoming-event-v2/upcoming-event-v2.css
+++ b/blocks/upcoming-event-v2/upcoming-event-v2.css
@@ -51,22 +51,42 @@
   display: none;
 }
 
-/** List view styles start **/
+/** Empty / no-results (match Upcoming Event v1 + other browse empty states) **/
 
-.event-no-results {
+.upcoming-event-v2.has-no-results .browse-cards-block-view,
+.upcoming-event-v2.has-no-results .browse-cards-view-switcher {
+  display: none;
+}
+
+.upcoming-event-v2.has-no-results .browse-cards-block-content {
+  display: block;
+  min-height: unset;
+  gap: 0;
+}
+
+.upcoming-event-v2 .event-no-results,
+.upcoming-event-v2 .browse-card-no-results {
   background-color: var(--spectrum-gray-200);
+  border-radius: 4px;
   color: var(--non-spectrum-grey);
   font-size: var(--spectrum-font-size-200);
-  padding: 72px 0;
+  line-height: var(--spectrum-line-height-s);
+  letter-spacing: normal;
+  padding: 72px 24px;
   text-align: center;
   width: 100%;
   box-sizing: border-box;
   grid-column: 1 / -1;
+  margin-top: 0;
 }
 
-.upcoming-event-v2 .browse-cards-block-content > .event-no-results {
-  min-height: unset;
-  height: 170px;
+.upcoming-event-v2 .browse-cards-block-content > .event-no-results,
+.upcoming-event-v2 .browse-cards-block-content > .browse-card-no-results {
+  height: auto;
+  min-height: 170px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /** List view styles end **/

--- a/blocks/upcoming-event-v2/upcoming-event-v2.js
+++ b/blocks/upcoming-event-v2/upcoming-event-v2.js
@@ -7,6 +7,21 @@ import { COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ } from '../../scripts/browse-card/
 import BrowseCardViewSwitcher from '../../scripts/browse-card/browse-cards-view-switcher.js';
 import { loadCSS } from '../../scripts/lib-franklin.js';
 
+const UEAuthorMode = window.hlx.aemRoot || window.location.href.includes('.html');
+
+/**
+ * Hide the block (and its section if emptied) when there is nothing to show —
+ * e.g. all Upcoming events were filtered out as stale.
+ * @param {HTMLElement} block
+ */
+function hideUpcomingEventBlock(block) {
+  const section = block.closest('.section');
+  block.parentElement?.remove();
+  if (section && section.children.length === 0) {
+    section.remove();
+  }
+}
+
 export default async function decorate(block) {
   const [headingElement, descriptionElement] = [...block.children].map((row) => row.firstElementChild);
 
@@ -30,7 +45,9 @@ export default async function decorate(block) {
 
   // Create and initialize the view switcher
   BrowseCardViewSwitcher.create({ block }).then((viewSwitcher) => {
-    viewSwitcher.appendTo(headerDiv);
+    if (document.contains(headerDiv)) {
+      viewSwitcher.appendTo(headerDiv);
+    }
   });
 
   await loadCSS(`${window.hlx.codeBasePath}/scripts/browse-card/browse-card-upcoming-events.css`);
@@ -51,7 +68,14 @@ export default async function decorate(block) {
     .then((results) => {
       buildCardsShimmer.removeShimmer();
 
-      if (!results?.length) return;
+      if (!results?.length) {
+        // All upcoming events are stale (or none exist): hide block on published site.
+        // Keep the block visible in Universal Editor so authors can still see/edit it.
+        if (!UEAuthorMode) {
+          hideUpcomingEventBlock(block);
+        }
+        return;
+      }
 
       results.forEach((cardData) => {
         const cardDiv = document.createElement('div');

--- a/blocks/upcoming-event-v2/upcoming-event-v2.js
+++ b/blocks/upcoming-event-v2/upcoming-event-v2.js
@@ -3,6 +3,7 @@ import { htmlToElement } from '../../scripts/scripts.js';
 import { buildCard } from '../../scripts/browse-card/browse-card.js';
 import BrowseCardShimmer from '../../scripts/browse-card/browse-card-shimmer.js';
 import { CONTENT_TYPES } from '../../scripts/data-service/coveo/coveo-exl-pipeline-constants.js';
+import { COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ } from '../../scripts/browse-card/browse-cards-constants.js';
 import BrowseCardViewSwitcher from '../../scripts/browse-card/browse-cards-view-switcher.js';
 import { loadCSS } from '../../scripts/lib-franklin.js';
 
@@ -43,6 +44,7 @@ export default async function decorate(block) {
   const parameters = {
     contentType: [CONTENT_TYPES.UPCOMING_EVENT_V2.MAPPING_KEY],
     sortCriteria: 'date ascending',
+    aq: COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ,
   };
 
   BrowseCardsDelegate.fetchCardData(parameters)

--- a/blocks/upcoming-event-v2/upcoming-event-v2.js
+++ b/blocks/upcoming-event-v2/upcoming-event-v2.js
@@ -7,21 +7,6 @@ import { COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ } from '../../scripts/browse-card/
 import BrowseCardViewSwitcher from '../../scripts/browse-card/browse-cards-view-switcher.js';
 import { loadCSS } from '../../scripts/lib-franklin.js';
 
-const UEAuthorMode = window.hlx.aemRoot || window.location.href.includes('.html');
-
-/**
- * Hide the block (and its section if emptied) when there is nothing to show —
- * e.g. all Upcoming events were filtered out as stale.
- * @param {HTMLElement} block
- */
-function hideUpcomingEventBlock(block) {
-  const section = block.closest('.section');
-  block.parentElement?.remove();
-  if (section && section.children.length === 0) {
-    section.remove();
-  }
-}
-
 export default async function decorate(block) {
   const [headingElement, descriptionElement] = [...block.children].map((row) => row.firstElementChild);
 
@@ -45,9 +30,7 @@ export default async function decorate(block) {
 
   // Create and initialize the view switcher
   BrowseCardViewSwitcher.create({ block }).then((viewSwitcher) => {
-    if (document.contains(headerDiv)) {
-      viewSwitcher.appendTo(headerDiv);
-    }
+    viewSwitcher.appendTo(headerDiv);
   });
 
   await loadCSS(`${window.hlx.codeBasePath}/scripts/browse-card/browse-card-upcoming-events.css`);
@@ -68,14 +51,9 @@ export default async function decorate(block) {
     .then((results) => {
       buildCardsShimmer.removeShimmer();
 
-      if (!results?.length) {
-        // All upcoming events are stale (or none exist): hide block on published site.
-        // Keep the block visible in Universal Editor so authors can still see/edit it.
-        if (!UEAuthorMode) {
-          hideUpcomingEventBlock(block);
-        }
-        return;
-      }
+      // Keep existing empty-state behaviour (EXLM-5176 / prior Upcoming V2): do not
+      // hide the block or invent a new no-results UI when all Upcoming are stale.
+      if (!results?.length) return;
 
       results.forEach((cardData) => {
         const cardDiv = document.createElement('div');

--- a/blocks/upcoming-event-v2/upcoming-event-v2.js
+++ b/blocks/upcoming-event-v2/upcoming-event-v2.js
@@ -1,11 +1,24 @@
 import BrowseCardsDelegate from '../../scripts/browse-card/browse-cards-delegate.js';
-import { htmlToElement } from '../../scripts/scripts.js';
+import { htmlToElement, fetchLanguagePlaceholders } from '../../scripts/scripts.js';
 import { buildCard } from '../../scripts/browse-card/browse-card.js';
 import BrowseCardShimmer from '../../scripts/browse-card/browse-card-shimmer.js';
 import { CONTENT_TYPES } from '../../scripts/data-service/coveo/coveo-exl-pipeline-constants.js';
 import { COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ } from '../../scripts/browse-card/browse-cards-constants.js';
 import BrowseCardViewSwitcher from '../../scripts/browse-card/browse-cards-view-switcher.js';
 import { loadCSS } from '../../scripts/lib-franklin.js';
+
+/**
+ * Empty-state markup used by Upcoming Event v1/v2 (see upcoming-event.js + upcoming-event-v2.css).
+ * @param {HTMLElement} contentDiv
+ * @param {Record<string, string>} placeholders
+ */
+function showNoResultsContent(contentDiv, placeholders = {}) {
+  const noResultsText =
+    placeholders.noResultsTextBrowse ||
+    placeholders.noResultsText ||
+    'We are sorry, no results found matching the criteria. Try adjusting your search to view more content.';
+  contentDiv.appendChild(htmlToElement(`<div class="event-no-results">${noResultsText}</div>`));
+}
 
 export default async function decorate(block) {
   const [headingElement, descriptionElement] = [...block.children].map((row) => row.firstElementChild);
@@ -28,11 +41,6 @@ export default async function decorate(block) {
 
   block.appendChild(headerDiv);
 
-  // Create and initialize the view switcher
-  BrowseCardViewSwitcher.create({ block }).then((viewSwitcher) => {
-    viewSwitcher.appendTo(headerDiv);
-  });
-
   await loadCSS(`${window.hlx.codeBasePath}/scripts/browse-card/browse-card-upcoming-events.css`);
 
   const contentDiv = document.createElement('div');
@@ -47,24 +55,35 @@ export default async function decorate(block) {
     aq: COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ,
   };
 
-  BrowseCardsDelegate.fetchCardData(parameters)
-    .then((results) => {
-      buildCardsShimmer.removeShimmer();
+  const placeholdersPromise = fetchLanguagePlaceholders().catch(() => ({}));
 
-      // Keep existing empty-state behaviour (EXLM-5176 / prior Upcoming V2): do not
-      // hide the block or invent a new no-results UI when all Upcoming are stale.
-      if (!results?.length) return;
+  try {
+    const results = await BrowseCardsDelegate.fetchCardData(parameters);
+    buildCardsShimmer.removeShimmer();
+    block.appendChild(contentDiv);
 
-      results.forEach((cardData) => {
-        const cardDiv = document.createElement('div');
-        buildCard(cardDiv, cardData);
-        contentDiv.appendChild(cardDiv);
-      });
-      block.appendChild(contentDiv);
-    })
-    .catch((err) => {
-      buildCardsShimmer.removeShimmer();
-      // eslint-disable-next-line no-console
-      console.error('Error loading upcoming event cards:', err);
+    if (!results?.length) {
+      const placeholders = await placeholdersPromise;
+      block.classList.add('has-no-results');
+      showNoResultsContent(contentDiv, placeholders);
+      return;
+    }
+
+    // Only mount grid/list toggle when there are cards to switch.
+    BrowseCardViewSwitcher.create({ block }).then((viewSwitcher) => {
+      if (document.contains(headerDiv)) {
+        viewSwitcher.appendTo(headerDiv);
+      }
     });
+
+    results.forEach((cardData) => {
+      const cardDiv = document.createElement('div');
+      buildCard(cardDiv, cardData);
+      contentDiv.appendChild(cardDiv);
+    });
+  } catch (err) {
+    buildCardsShimmer.removeShimmer();
+    // eslint-disable-next-line no-console
+    console.error('Error loading upcoming event cards:', err);
+  }
 }

--- a/blocks/upcoming-event-v2/upcoming-event-v2.js
+++ b/blocks/upcoming-event-v2/upcoming-event-v2.js
@@ -13,10 +13,11 @@ import { loadCSS } from '../../scripts/lib-franklin.js';
  * @param {Record<string, string>} placeholders
  */
 function showNoResultsContent(contentDiv, placeholders = {}) {
+  // Prefer Events empty copy without "search"/"filters" wording — this block has neither.
+  // event-search-no-results-message → "Sorry, no results were found."
+  // no-results-text → "We are sorry, no results found matching the criteria."
   const noResultsText =
-    placeholders.noResultsTextBrowse ||
-    placeholders.noResultsText ||
-    'We are sorry, no results found matching the criteria. Try adjusting your search to view more content.';
+    placeholders.eventSearchNoResultsMessage || placeholders.noResultsText || 'Sorry, no results were found.';
   contentDiv.appendChild(htmlToElement(`<div class="event-no-results">${noResultsText}</div>`));
 }
 

--- a/blocks/upcoming-event-v2/upcoming-event-v2.js
+++ b/blocks/upcoming-event-v2/upcoming-event-v2.js
@@ -9,15 +9,12 @@ import { loadCSS } from '../../scripts/lib-franklin.js';
 
 /**
  * Empty-state markup used by Upcoming Event v1/v2 (see upcoming-event.js + upcoming-event-v2.css).
+ * Placeholder key: upcoming-event-no-results-text (must be authored in placeholders).
  * @param {HTMLElement} contentDiv
  * @param {Record<string, string>} placeholders
  */
 function showNoResultsContent(contentDiv, placeholders = {}) {
-  // Prefer Events empty copy without "search"/"filters" wording — this block has neither.
-  // event-search-no-results-message → "Sorry, no results were found."
-  // no-results-text → "We are sorry, no results found matching the criteria."
-  const noResultsText =
-    placeholders.eventSearchNoResultsMessage || placeholders.noResultsText || 'Sorry, no results were found.';
+  const noResultsText = placeholders.upcomingEventNoResultsText || 'Sorry, no results were found.';
   contentDiv.appendChild(htmlToElement(`<div class="event-no-results">${noResultsText}</div>`));
 }
 

--- a/scripts/browse-card/browse-cards-constants.js
+++ b/scripts/browse-card/browse-cards-constants.js
@@ -66,6 +66,11 @@ export const BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT =
  */
 export const COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ = '(@el_contenttype = "Event|Upcoming Event" AND @date >= now)';
 export const BASE_COVEO_ADVANCED_QUERY_EVENTS = `(@el_contenttype = "Event|On Demand Event") OR ${COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ}`;
+/**
+ * Exclude stale Upcoming Events while keeping all other content types.
+ * Used by Atomic Search (/en/search) which has no Events-only base aq.
+ */
+export const COVEO_EXCLUDE_STALE_UPCOMING_AQ = `(NOT @el_contenttype = "Event|Upcoming Event") OR ${COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ}`;
 
 export const VIDEO_THUMBNAIL_FORMAT = /^https:\/\/video\.tv\.adobe\.com\/v\/\w+\?format=jpeg$/;
 

--- a/scripts/browse-card/browse-cards-constants.js
+++ b/scripts/browse-card/browse-cards-constants.js
@@ -53,8 +53,19 @@ export const AUTHOR_TYPE = Object.freeze({
 export const BASE_COVEO_ADVANCED_QUERY = '(@el_contenttype NOT "Community|User")';
 export const BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT =
   '(@el_contenttype = "Event") OR (@el_contenttype = "Upcoming Event")';
-export const BASE_COVEO_ADVANCED_QUERY_EVENTS =
-  '(@el_contenttype = "Event|On Demand Event") OR (@el_contenttype = "Event|Upcoming Event")';
+/**
+ * Upcoming events that have not started yet.
+ *
+ * Coveo stages `el_event_start_time` as a string field, so date operators like
+ * `@el_event_start_time >= now` are ignored. Event start is reflected on the
+ * standard Date field `@date` (verified against stage Events Hub), which does
+ * support `>= now`. Prefer switching `el_event_start_time` to a Date field in
+ * Coveo when available, then update this expression.
+ *
+ * @see https://docs.coveo.com/en/1814/ (date operators, `now`)
+ */
+export const COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ = '(@el_contenttype = "Event|Upcoming Event" AND @date >= now)';
+export const BASE_COVEO_ADVANCED_QUERY_EVENTS = `(@el_contenttype = "Event|On Demand Event") OR ${COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ}`;
 
 export const VIDEO_THUMBNAIL_FORMAT = /^https:\/\/video\.tv\.adobe\.com\/v\/\w+\?format=jpeg$/;
 


### PR DESCRIPTION
Jira ID: EXLM-5361

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5361--exlm--adobe-experience-league.aem.live
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://exlm-5361--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->