### PR TITLE
feat: UGP-15793: Enable Brand Concierge for unauthenticated users

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -5,8 +5,6 @@ import loadGainsight from './gainsight/gainsight.js';
 import loadQualtrics from './qualtrics.js';
 import { sendCoveoPageViewEvent } from './coveo-analytics.js';
 import { loadPrism } from './utils/prism-utils.js';
-// eslint-disable-next-line import/no-cycle
-import { getConfig, loadIms } from './scripts.js';
 
 // add more delayed functionality here
 
@@ -31,16 +29,9 @@ function isBrandConciergeExcludedPath() {
  * Loads Brand Concierge on eligible page types.
  * Guards:
  *   - hidden on Support and Premium Learning routes
- *   - bcAuthRequired → when true, user must be signed in
  */
 async function loadBrandConcierge() {
   if (isBrandConciergeExcludedPath()) return;
-
-  const { bcAuthRequired } = getConfig();
-  if (bcAuthRequired) {
-    await loadIms();
-    if (!window.adobeIMS?.isSignedInUser()) return;
-  }
 
   const { default: initBrandConcierge } = await import('./brand-concierge/brand-concierge.js');
   await initBrandConcierge();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -913,7 +913,6 @@ export function getConfig() {
     bcWebClientUrl:
       'https://experience.adobe.net/solutions/experience-platform-brand-concierge-web-agent/static-assets/main.js',
     bcEdgeDomain: 'edge.adobedc.net',
-    bcAuthRequired: true,
   };
   return window.exlm.config;
 }


### PR DESCRIPTION
Jira ID: [UGP-15793](https://jira.corp.adobe.com/browse/UGP-15793)

Removed support for authenticated users, so with this change any users should be able to see the Brand Concierge floating button and should be able to conversate.

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://UGP-15793--exlm--adobe-experience-league.aem.live
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://UGP-15793--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->