### PR TITLE
fix(EXLM-5332): Event links should open in new tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ helix-importer-ui
 .agents/
 .skills/
 .upskill/
+plans/
 .cursor/
 .claude/
 skills/

--- a/scripts/browse-card/browse-card.js
+++ b/scripts/browse-card/browse-card.js
@@ -286,6 +286,8 @@ const buildCardCtaContent = ({ cardFooter, contentType, viewLinkText, viewLink }
         CONTENT_TYPES.UPCOMING_EVENT_V2.MAPPING_KEY.toLowerCase(),
         CONTENT_TYPES.UPCOMING_EVENT.MAPPING_KEY,
         CONTENT_TYPES.INSTRUCTOR_LED.MAPPING_KEY,
+        CONTENT_TYPES.ON_DEMAND_EVENT.MAPPING_KEY.toLowerCase(),
+        CONTENT_TYPES.EVENT.MAPPING_KEY,
       ].includes(contentType?.toLowerCase())
     ) {
       icon = 'new-tab-blue';
@@ -782,11 +784,14 @@ export async function buildCard(element, model) {
     if (
       [
         CONTENT_TYPES.UPCOMING_EVENT.MAPPING_KEY,
-        CONTENT_TYPES.UPCOMING_EVENT_V2.MAPPING_KEY,
+        CONTENT_TYPES.UPCOMING_EVENT_V2.MAPPING_KEY.toLowerCase(),
         CONTENT_TYPES.INSTRUCTOR_LED.MAPPING_KEY,
+        CONTENT_TYPES.EVENT.MAPPING_KEY,
+        CONTENT_TYPES.ON_DEMAND_EVENT.MAPPING_KEY.toLowerCase(),
       ].includes(contentType?.toLowerCase())
     ) {
       cardContainer.setAttribute('target', '_blank');
+      cardContainer.setAttribute('rel', 'noopener noreferrer');
     }
     cardContainer.appendChild(card);
     element.appendChild(cardContainer);
@@ -801,6 +806,7 @@ export async function buildCard(element, model) {
 
     if (shouldOpenInNewTab) {
       element.querySelector('a')?.setAttribute('target', '_blank');
+      element.querySelector('a')?.setAttribute('rel', 'noopener noreferrer');
     }
     const cardOptions = card.querySelector('.browse-card-options');
     if (cardOptions) {


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-5332

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://5332-exlm--exlm--adobe-experience-league.aem.live
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://5332-exlm--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->

## AI Review Notes

- Extended the existing target="_blank" content-type allowlist to include On-Demand Event (Watch Now), matching the existing Upcoming Event / Instructor-Led (Register) behavior. Same list also fixes a pre-existing case-sensitivity bug where the v2 upcoming-event mapping key ('Event|Upcoming Event') was never lowercased before comparison, so it never actually matched — Register links in v2 format were not opening in a new tab despite the code appearing to support it.
- Added rel="noopener noreferrer" everywhere target="_blank" is set on the card anchor (both branches) — this is a deliberate security fix (reverse-tabnabbing) bundled with the ticket's behavior change, not scope creep.
- Mirrored the same two content types into the icon-selection list a few lines above so the "opens in new tab" icon renders for Watch Now cards too, consistent with existing Register cards.