### PR TITLE
feat: (AIME-194) route /es/ Brand Concierge to the Spanish datastream

### DIFF
--- a/scripts/brand-concierge/brand-concierge-config.js
+++ b/scripts/brand-concierge/brand-concierge-config.js
@@ -161,6 +161,9 @@ const BC_UI_EN = {
 const BC_LOCALES = {
   es: {
     language: 'es-ES',
+    // Spanish Brand Concierge datastream (same IMS org as the default). Routes /es/ conversations
+    // to the Spanish concierge/manifest instead of the default English datastream.
+    datastreamId: '3098f7cc-36bb-4965-bea3-6e80fc59571e',
     ui: {
       triggerAriaLabel: 'Abrir el asistente de IA',
       triggerAsk: 'Hacer una pregunta',
@@ -249,6 +252,9 @@ export function resolveBrandConciergeConfig(lang) {
       ...brandConciergeConfig.metadata,
       ...(overlay.language ? { language: overlay.language } : {}),
     },
+    // Locale-specific Edge datastream, consumed in brand-concierge.js; falls back to the
+    // default bcDatastreamId when a locale defines none.
+    ...(overlay.datastreamId ? { datastreamId: overlay.datastreamId } : {}),
   };
 }
 

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -862,13 +862,17 @@ export async function initBrandConcierge() {
   activeLang = getPathDetails().lang;
   activeConfig = resolveBrandConciergeConfig(activeLang);
 
+  // Route to the locale's Brand Concierge datastream (e.g. the Spanish concierge on /es/),
+  // falling back to the default datastream for locales without an override.
+  const datastreamId = activeConfig.datastreamId ?? bcDatastreamId;
+
   createMountPoint();
   injectAlloyStub();
 
   try {
-    log('[BC] loading Web SDK (alloyBC instance)', { bcEdgeDomain, bcDatastreamId });
+    log('[BC] loading Web SDK (alloyBC instance)', { bcEdgeDomain, datastreamId, locale: activeLang });
     await loadScript(bcAlloySdkUrl);
-    await configureWebSdk(bcDatastreamId, bcOrgId, bcEdgeDomain);
+    await configureWebSdk(datastreamId, bcOrgId, bcEdgeDomain);
     log('[BC] Web SDK configured');
 
     log('[BC] loading Web Client', bcWebClientUrl);


### PR DESCRIPTION
Jira ID: AIME-194

**Stacked on #2791** (base branch `exlm-bc-spanish-ui`) — this PR is only the backend routing; the UI localization lives in #2791. Review/merge #2791 first; GitHub will retarget this to `main` once #2791 merges.

## Summary

Routes the Brand Concierge conversation on `/es/` to the Spanish concierge datastream instead of the default English one. Same IMS org, so only the datastream ID changes per locale.

- `brand-concierge-config.js`: add `datastreamId` to the `es` overlay in `BC_LOCALES` and surface it from `resolveBrandConciergeConfig()`.
- `brand-concierge.js`: in `initBrandConcierge()`, configure the `alloyBC` instance with `activeConfig.datastreamId ?? bcDatastreamId`. English and other locales are unchanged.

## Verification

Confirmed locally (`aem up`) by inspecting the Edge Interact request:

- `/es/browse` → `edge.adobedc.net/…/v1/interact?configId=3098f7cc-…` (Spanish datastream), HTTP 200
- `/en/browse` → `…?configId=87ae6de9-…` (default datastream), HTTP 200

**Reviewer note:** a Spanish question in the widget should now be answered by the Spanish manifest — please confirm the response content/citations come from the Spanish concierge.

## AI Review Notes

- Datastream ID is intentionally a config literal (matching the existing `bcDatastreamId`); same IMS org, production-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)