### PR TITLE
feat: UGP-15380: Implement keyboard tip feature in Brand Concierge

### DIFF
--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -100,7 +100,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-left: auto;
   line-height: 0;
   flex-shrink: 0;
 }
@@ -271,6 +270,36 @@
   overflow: visible !important;
   background: #fff !important;
   border: 1px solid var(--spectrum-gray-300) !important;
+}
+
+#brand-concierge-mount .bc-keyboard-tip {
+  margin: auto 0 12px;
+  padding: 0;
+  text-align: center;
+  font-family: var(--body-font-family);
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--spectrum-gray-500);
+  line-height: 1.4;
+  pointer-events: none;
+}
+
+#brand-concierge-mount .bc-keyboard-tip kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 3px;
+  border: 1px solid var(--spectrum-gray-300);
+  background-color: var(--spectrum-gray-100);
+  color: var(--spectrum-gray-500);
+  font-family: var(--body-font-family);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  vertical-align: middle;
 }
 
 #brand-concierge-mount label.ai-chat-label .bc-input-label-sparkle {

--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -100,6 +100,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-left: auto;
   line-height: 0;
   flex-shrink: 0;
 }

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -11,6 +11,7 @@ const DIALOG_ID = 'bc-dialog';
 const TRIGGER_ID = 'bc-trigger';
 const HEADER_CLEAR_ID = 'bc-header-clear';
 const PANEL_DISCLAIMER_ID = 'bc-panel-disclaimer';
+const KEYBOARD_TIP_ID = 'bc-keyboard-tip';
 
 /** Pixels from the bottom of `.chat-history` treated as “at bottom”. */
 const SCROLL_BOTTOM_THRESHOLD = 32;
@@ -65,6 +66,8 @@ let mountInteractionHandler = null;
 let mountWithHandler = null;
 let keyboardScrollHandler = null;
 let keyboardScrollDialog = null;
+let slashShortcutHandler = null;
+let keyboardTipObserver = null;
 
 /**
  * Removes persisted BC chat sessions from localStorage (transcript + metadata).
@@ -174,6 +177,37 @@ function watchPanelDisclaimer(mount) {
   panelDisclaimerObserver?.disconnect();
   panelDisclaimerObserver = new MutationObserver(() => installPanelDisclaimer(mount));
   panelDisclaimerObserver.observe(mount, { childList: true, subtree: true });
+}
+
+function removeKeyboardTip() {
+  keyboardTipObserver?.disconnect();
+  keyboardTipObserver = null;
+  document.getElementById(KEYBOARD_TIP_ID)?.remove();
+}
+
+function insertKeyboardTip(mount) {
+  const history = mount.querySelector('.chat-history');
+  if (history && history.children.length > 0) {
+    removeKeyboardTip();
+    return;
+  }
+  const inputSection = mount.querySelector('.input-section');
+  if (!inputSection || document.getElementById(KEYBOARD_TIP_ID)) return;
+  const tip = document.createElement('p');
+  tip.id = KEYBOARD_TIP_ID;
+  tip.className = 'bc-keyboard-tip';
+  const kbd = document.createElement('kbd');
+  kbd.textContent = '/';
+  tip.append('Tip: Press ', kbd, ' to open this chat from anywhere on the page');
+  tip.setAttribute('aria-hidden', 'true');
+  inputSection.insertBefore(tip, inputSection.querySelector('.input-container') ?? null);
+}
+
+function watchKeyboardTip(mount) {
+  removeKeyboardTip();
+  insertKeyboardTip(mount);
+  keyboardTipObserver = new MutationObserver(() => insertKeyboardTip(mount));
+  keyboardTipObserver.observe(mount, { childList: true, subtree: true });
 }
 
 /**
@@ -407,6 +441,8 @@ function handleBrandConciergeClientEvent(event) {
   const mount = getBrandConciergeMount();
   if (!mount) return;
 
+  if (event.eventType === BC_EVENT_QUERY_SUBMITTED) removeKeyboardTip();
+
   // response:started intentionally re-pins: if a new response begins while the user is still
   // reading a previous answer we want to re-anchor to their most recent question, not leave
   // them watching the bottom of a growing history panel.
@@ -637,9 +673,38 @@ async function clearBrandConciergeConversation() {
   panelDisclaimerObserver?.disconnect();
   panelDisclaimerObserver = null;
   watchPanelDisclaimer(bcMount);
+  watchKeyboardTip(bcMount);
   focusBcChatInputWhenReady(bcMount);
 }
 
+function removeSlashShortcut() {
+  if (slashShortcutHandler) {
+    document.removeEventListener('keydown', slashShortcutHandler, true);
+    slashShortcutHandler = null;
+  }
+}
+
+function installSlashShortcut(dialog, trigger, mount) {
+  removeSlashShortcut();
+
+  slashShortcutHandler = (e) => {
+    if (e.key !== '/') return;
+
+    const activeEl = document.activeElement;
+    if (activeEl?.tagName === 'TEXTAREA' || activeEl?.tagName === 'INPUT' || activeEl?.isContentEditable) return;
+
+    e.preventDefault();
+
+    if (!dialog.open) {
+      dialog.showModal();
+      trigger.setAttribute('aria-expanded', 'true');
+    }
+
+    focusBcChatInputWhenReady(mount);
+  };
+
+  document.addEventListener('keydown', slashShortcutHandler, true);
+}
 function removeKeyboardScrollHandler() {
   if (keyboardScrollHandler && keyboardScrollDialog) {
     keyboardScrollDialog.removeEventListener('keydown', keyboardScrollHandler, true);
@@ -747,6 +812,7 @@ function createMountPoint() {
 
   const { element: dialog } = drawerHandle;
   installKeyboardScrollHandler(dialog, mount);
+  installSlashShortcut(dialog, trigger, mount);
 
   trigger.addEventListener('click', () => {
     dialog.showModal();
@@ -814,11 +880,13 @@ export function destroyBrandConcierge() {
   scrollToBottomWatcher?.cleanup();
   scrollToBottomWatcher = null;
   removeKeyboardScrollHandler();
+  removeSlashShortcut();
   removeQuestionPinHandlers();
   inputLabelIconObserver?.disconnect();
   inputLabelIconObserver = null;
   panelDisclaimerObserver?.disconnect();
   panelDisclaimerObserver = null;
+  removeKeyboardTip();
   drawerHandle?.destroy();
   drawerHandle = null;
   document.getElementById(TRIGGER_ID)?.remove();
@@ -848,6 +916,7 @@ export async function initBrandConcierge() {
     installQuestionPinHandlers(bcMount);
     patchBcSparkleIcons(bcMount);
     watchPanelDisclaimer(bcMount);
+    watchKeyboardTip(bcMount);
 
     // Appended after bootstrap() so this <link> follows BC's injected <style> in document
     // order, giving our overrides cascade priority at equal specificity.

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -688,10 +688,16 @@ function installSlashShortcut(dialog, trigger, mount) {
   removeSlashShortcut();
 
   slashShortcutHandler = (e) => {
-    if (e.key !== '/') return;
+    if (e.key !== '/' || e.ctrlKey || e.metaKey || e.altKey) return;
 
     const activeEl = document.activeElement;
-    if (activeEl?.tagName === 'TEXTAREA' || activeEl?.tagName === 'INPUT' || activeEl?.isContentEditable) return;
+    if (
+      activeEl?.tagName === 'TEXTAREA' ||
+      activeEl?.tagName === 'INPUT' ||
+      activeEl?.tagName === 'SELECT' ||
+      activeEl?.isContentEditable
+    )
+      return;
 
     e.preventDefault();
 


### PR DESCRIPTION
Jira ID: [UGP-15380](https://jira.corp.adobe.com/browse/UGP-15380)

## Summary

Adds a keyboard-first way to open Brand Concierge and a first-run hint that
teaches it.

- **`/` shortcut** — pressing `/` anywhere on the page opens the BC dialog and
  focuses the chat input. Ignored while the user is typing in a `TEXTAREA`,
  `INPUT`, or `contentEditable` field so it never hijacks real text entry. The
  handler is registered/torn down alongside the existing keyboard handlers
  (`installSlashShortcut` / `removeSlashShortcut`).
- **Keyboard tip** — a small hint (`Tip: Press / to open this chat from
  anywhere on the page`) shown above the input in the welcome state only. It is
  removed on first query submit (`query:submitted`) and while a conversation
  exists, so it acts as a one-time discovery cue. A `MutationObserver`
  (`watchKeyboardTip`) keeps it in sync as BC re-renders the panel.

The tip is decorative (`aria-hidden="true"`) since the `/` shortcut is also
discoverable by keyboard users directly; it slots into the existing
`.input-section` grid above `.input-container`.

## Manual test steps

1. Open a page and press `/` (with no field focused) → BC opens and the input
   is focused.
2. With focus in a page text field, press `/` → the character types normally,
   BC does not open.
3. Open BC fresh → the "Press /" tip shows above the input.
4. Submit a question → the tip disappears and does not reappear for that
   conversation.
5. Clear the conversation → welcome state returns with the tip; teardown leaves
   no stray listeners or tip element.


<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://UGP-15380--exlm--adobe-experience-league.aem.live
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://UGP-15380--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->