### PR TITLE
Community search displays incorrect content type filters-fix

### DIFF
--- a/scripts/search/search.js
+++ b/scripts/search/search.js
@@ -126,13 +126,33 @@ export function getHeaderSearchFilterValue(searchOptions, { preferCommunity = fa
   return defaultValue;
 }
 
+/**
+ * Normalizes each comma-separated content-type value to its real indexed form.
+ * @param {string} rawValue - e.g. "Community;Community|Questions" or "TypeA,TypeB"
+ * @returns {string} normalized value, e.g. "Community|Questions"
+ */
+export function normalizeContentTypeFilterValue(rawValue) {
+  return (rawValue || '')
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .map((segment) => {
+      const parts = segment
+        .split(';')
+        .map((part) => part.trim())
+        .filter(Boolean);
+      return parts[parts.length - 1] || segment;
+    })
+    .join(',');
+}
+
 // Redirects to the search page based on the provided search input and filters
 export const redirectToSearchPage = (searchUrl, searchInput, filters = '') => {
   pushTopNavSearchEvent(filters, searchInput);
 
   const isLegacySearch = searchUrl.includes('.html');
   let targetUrlWithLanguage = isLegacySearch ? `${searchUrl}?lang=${languageCode}` : searchUrl;
-  const filterValue = filters?.toLowerCase() === 'all' ? '' : filters;
+  const filterValue = filters?.toLowerCase() === 'all' ? '' : normalizeContentTypeFilterValue(filters);
   if (searchInput) {
     const trimmedSearchInput = encodeURIComponent(searchInput.trim());
     targetUrlWithLanguage += `#q=${trimmedSearchInput}`;


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: https://jira.corp.adobe.com/browse/EXLM-5449

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5449--exlm--adobe-experience-league.aem.live
- After: https://exlm-5449--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->