### PR TITLE
EXLM-5361: filter Upcoming via el_event_start_time >= now in aq

### DIFF
--- a/scripts/browse-card/browse-cards-constants.js
+++ b/scripts/browse-card/browse-cards-constants.js
@@ -54,17 +54,20 @@ export const BASE_COVEO_ADVANCED_QUERY = '(@el_contenttype NOT "Community|User")
 export const BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT =
   '(@el_contenttype = "Event") OR (@el_contenttype = "Upcoming Event")';
 /**
- * Upcoming events that have not started yet.
+ * Upcoming events that have not started yet (Events Hub / Upcoming Event V2).
  *
- * Coveo stages `el_event_start_time` as a string field, so date operators like
- * `@el_event_start_time >= now` are ignored. Event start is reflected on the
- * standard Date field `@date` (verified against stage Events Hub), which does
- * support `>= now`. Prefer switching `el_event_start_time` to a Date field in
- * Coveo when available, then update this expression.
+ * Uses `el_event_start_time` (the same value shown as the event date on cards).
+ * Requires Coveo field type **Date** — if the field is still String, `>= now` is
+ * ignored and all Upcoming return. Do not use `@date`: on prod it is index/batch
+ * time (same for all Upcoming), so `@date >= now` drops every Upcoming.
+ *
+ * Depends on: Coveo change String → Date for `el_event_start_time` + reindex.
  *
  * @see https://docs.coveo.com/en/1814/ (date operators, `now`)
+ * @see EXLM-5361
  */
-export const COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ = '(@el_contenttype = "Event|Upcoming Event" AND @date >= now)';
+export const COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ =
+  '(@el_contenttype = "Event|Upcoming Event" AND @el_event_start_time >= now)';
 export const BASE_COVEO_ADVANCED_QUERY_EVENTS = `(@el_contenttype = "Event|On Demand Event") OR ${COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ}`;
 /**
  * Exclude stale Upcoming Events while keeping all other content types.


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-5361

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://EXLM-5361-aq-fix--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->