### PR TITLE
feat(EXLM-5503): add language label badge to code block

### DIFF
--- a/blocks/code/code.css
+++ b/blocks/code/code.css
@@ -6,6 +6,21 @@
   max-width: 100%;
 }
 
+.code .code-language-badge {
+  display: block;
+  width: fit-content;
+  margin: 0 0 0.4em auto;
+  padding: 0.15em 0.6em;
+  border-radius: 4px;
+  background-color: var(--spectrum-blue-900);
+  color: var(--spectrum-gray-50);
+  font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
+  font-size: var(--spectrum-font-size-50);
+  font-weight: var(--font-weight-extra-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
 /* Collapsible code styles start */
 .code pre.collapsible-code[data-collapsed='true'] {
   overflow-y: hidden;

--- a/blocks/code/code.js
+++ b/blocks/code/code.js
@@ -1,5 +1,28 @@
 import { htmlToElement, fetchLanguagePlaceholders } from '../../scripts/scripts.js';
 
+const LANGUAGE_LABELS = {
+  js: 'JS',
+  javascript: 'JS',
+  css: 'CSS',
+  html: 'HTML',
+  java: 'Java',
+};
+
+function getLanguageLabel(languageClass) {
+  const lang = languageClass.slice('language-'.length);
+  if (LANGUAGE_LABELS[lang]) return LANGUAGE_LABELS[lang];
+  return lang.charAt(0).toUpperCase() + lang.slice(1);
+}
+
+function createLanguageBadge(languageClass) {
+  const label = getLanguageLabel(languageClass);
+  const badge = document.createElement('span');
+  badge.className = 'code-language-badge';
+  badge.setAttribute('aria-label', `Language: ${label}`);
+  badge.textContent = label;
+  return badge;
+}
+
 function getDataLineValue(arr) {
   let dataLineValue = '';
   arr.forEach((className) => {
@@ -81,12 +104,19 @@ export default async function decorate(block) {
   block.innerHTML = preTagElement.outerHTML;
   const dataLine = [];
   const pre = block.querySelector('pre');
+  let languageClass;
 
   block.classList.forEach((className) => {
     switch (true) {
       case className === 'line-number':
+        pre.classList.add(className);
+        break;
+
       case className.startsWith('language-'):
         pre.classList.add(className);
+        if (className !== 'language-none') {
+          languageClass = className;
+        }
         break;
 
       case className.startsWith('data-start-'):
@@ -121,6 +151,10 @@ export default async function decorate(block) {
       pre.setAttribute(key, value);
     }
   });
+
+  if (languageClass) {
+    block.insertBefore(createLanguageBadge(languageClass), pre);
+  }
 
   if (block.classList.contains('expandable')) {
     addCollapsibleCodeFeature(block, pre, defaultLines, placeholders);


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

Jira ID: EXLM-5503

## Description

Adds a presentational language label badge (e.g. `JS`, `CSS`, `HTML`, `Python`) above the code block, right-aligned. The badge is derived from the existing `language-*` class already parsed during decoration — no new DOM parsing logic was added, and `data-start`/`data-line`/`data-line-offset`/`line-number` handling is untouched.

- No badge renders when there is no `language-*` class, including the site's `language-none` convention (used ~126 times across existing content for plaintext/no-highlight blocks) — verified this doesn't regress into an unwanted "None" badge.
- Unrecognized `language-*` values fall back to a capitalized label (e.g. `language-foobar` → "Foobar") instead of hiding the badge.
- Badge sits outside the collapsible wrapper so it remains stable through the `expandable` block's show more/show less toggle.
- Verified no visual overlap with the Prism copy-toolbar, the `line-numbers` gutter, or line-highlight markers across mobile/tablet/desktop.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5503--exlm--adobe-experience-league.aem.live
- After: https://exlm-5503--exlm--adobe-experience-league.aem.live/docs/authoring-guide-exl/using/markdown/syntax-style-guide?martech=off
- After: https://exlm-5503--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5503--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5503--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

- The `language-none` special-case in `blocks/code/code.js` is intentional — it's the site's established convention for "no specific language" and must not show a badge, even though it technically matches `language-*`.