### PR TITLE
Fix pending removals logic in syncFilterUIFromHeadlessState function

### DIFF
--- a/blocks/events-search/events-search.js
+++ b/blocks/events-search/events-search.js
@@ -562,7 +562,9 @@ function syncFilterUIFromHeadlessState(block, groups) {
         });
       } else if (!isSelected) {
         if (existingIndex !== -1) activeTags.splice(existingIndex, 1);
-        pendingRemovals.delete(compositeKey);
+        if (!selectedValues.has(checkbox.value)) {
+          pendingRemovals.delete(compositeKey);
+        }
       }
       checkbox.closest('.events-search-filter-option')?.classList.toggle('checked', checkbox.checked);
     });


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live/en/events
- After: https://calloutsFix--exlm--adobe-experience-league.aem.live/en/events

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->