### PR TITLE
EXLM-5462: Add Featured Advocates carousel and Advocate Bio blocks

### DIFF
--- a/blocks/advocate-bio/advocate-bio.css
+++ b/blocks/advocate-bio/advocate-bio.css
@@ -1,0 +1,164 @@
+/* stylelint-disable no-descending-specificity */
+
+/* ----- Champion panel (shared by advocate-bio page and featured-advocates carousel) ----- */
+.advocate-panel {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 32px;
+  align-items: start;
+}
+
+.advocate-panel .advocate-media {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.advocate-panel .advocate-image {
+  width: 240px;
+  height: 240px;
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.advocate-panel .advocate-image img,
+.advocate-panel .advocate-image picture {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.advocate-panel .advocate-designation {
+  font-size: var(--spectrum-font-size-75);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--non-spectrum-adobe-dark-red);
+  text-align: center;
+}
+
+.advocate-panel .advocate-quote {
+  margin: 0 0 16px;
+  padding: 0;
+  border: none;
+  font-size: var(--spectrum-font-size-300);
+  line-height: var(--exlm-line-height-content);
+  color: var(--non-spectrum-dark-charcoal);
+}
+
+.advocate-panel .advocate-name {
+  display: inline-block;
+  font-size: var(--spectrum-font-size-200);
+  font-weight: var(--font-weight-bold);
+  color: var(--non-spectrum-dark-charcoal);
+  text-decoration: none;
+}
+
+.advocate-panel .advocate-name:hover {
+  text-decoration: underline;
+}
+
+.advocate-panel .advocate-title {
+  font-size: var(--spectrum-font-size-100);
+  color: var(--non-spectrum-charcoal-gray);
+  margin-top: 4px;
+}
+
+/* ----- Associated content cards ----- */
+.advocate-panel .advocate-associated-content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.advocate-content-card {
+  border: 1px solid var(--spectrum-gray-200, #e1e1e1);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.advocate-content-card .advocate-content-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--spectrum-font-size-75);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--non-spectrum-charcoal-gray);
+}
+
+.advocate-content-card .advocate-content-eyebrow .icon,
+.advocate-content-card .advocate-content-time .icon {
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+}
+
+.advocate-content-card .advocate-content-eyebrow .icon img,
+.advocate-content-card .advocate-content-time .icon img {
+  width: 100%;
+  height: 100%;
+}
+
+.advocate-content-card .advocate-content-title {
+  font-size: var(--spectrum-font-size-200);
+  font-weight: var(--font-weight-bold);
+  color: var(--non-spectrum-dark-charcoal);
+}
+
+.advocate-content-card .advocate-content-description {
+  font-size: var(--spectrum-font-size-100);
+  line-height: var(--exlm-line-height-content);
+  color: var(--non-spectrum-charcoal-gray);
+}
+
+.advocate-content-card .advocate-content-time {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--spectrum-font-size-75);
+  color: var(--non-spectrum-charcoal-gray);
+}
+
+.advocate-content-card .advocate-content-cta {
+  font-size: var(--spectrum-font-size-100);
+  font-weight: var(--font-weight-bold);
+  color: var(--non-spectrum-adobe-dark-red);
+  text-decoration: none;
+  margin-top: 4px;
+}
+
+.advocate-content-card .advocate-content-cta:hover {
+  text-decoration: underline;
+}
+
+/* ----- tablet ----- */
+@media (min-width: 768px) {
+  .advocate-panel {
+    grid-template-columns: 280px 1fr;
+    gap: 48px;
+  }
+
+  .advocate-panel .advocate-associated-content {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* ----- desktop ----- */
+@media (min-width: 1200px) {
+  .advocate-panel {
+    grid-template-columns: 320px 1fr;
+  }
+
+  .advocate-panel .advocate-image {
+    width: 300px;
+    height: 300px;
+  }
+}

--- a/blocks/advocate-bio/advocate-bio.js
+++ b/blocks/advocate-bio/advocate-bio.js
@@ -1,0 +1,72 @@
+import { createOptimizedPicture, decorateIcons } from '../../scripts/lib-franklin.js';
+import { htmlToElement } from '../../scripts/scripts.js';
+import { extractAdvocateInfo, getContentTypeIcon, getTimeIcon } from '../../scripts/utils/advocate-utils.js';
+
+/**
+ * Builds the DOM for a single associated-content card.
+ * Shared with the featured-advocates carousel.
+ * @param {object} card
+ */
+export function buildAssociatedContentCard(card) {
+  const cardEl = htmlToElement(`
+    <div class="advocate-content-card">
+      <div class="advocate-content-eyebrow">
+        <span class="icon icon-${getContentTypeIcon(card.contentType)}"></span>
+        <span>${card.contentType}</span>
+      </div>
+      <div class="advocate-content-title">${card.title}</div>
+      ${card.description ? `<div class="advocate-content-description">${card.description}</div>` : ''}
+      ${
+        card.timeText
+          ? `<div class="advocate-content-time"><span class="icon icon-${getTimeIcon(card.timeType)}"></span><span>${
+              card.timeText
+            }</span></div>`
+          : ''
+      }
+      ${
+        card.ctaLink && card.ctaText ? `<a class="advocate-content-cta" href="${card.ctaLink}">${card.ctaText}</a>` : ''
+      }
+    </div>
+  `);
+  decorateIcons(cardEl);
+  return cardEl;
+}
+
+/**
+ * Builds the DOM for the Champion panel (image, identity, quote, associated content).
+ * Shared with the featured-advocates carousel.
+ * @param {object} info result of extractAdvocateInfo
+ */
+export function buildAdvocatePanel(info) {
+  const picture = info.image ? createOptimizedPicture(info.image, info.name, false).outerHTML : '';
+  const panel = htmlToElement(`
+    <div class="advocate-panel">
+      <div class="advocate-media">
+        <div class="advocate-image">${picture}</div>
+        ${info.productDesignation ? `<div class="advocate-designation">${info.productDesignation}</div>` : ''}
+      </div>
+      <div class="advocate-info">
+        ${info.quote ? `<blockquote class="advocate-quote">${info.quote}</blockquote>` : ''}
+        <a class="advocate-name" href="${info.profileLink || '#'}">${info.name}</a>
+        ${info.title ? `<div class="advocate-title">${info.title}</div>` : ''}
+        <div class="advocate-associated-content"></div>
+      </div>
+    </div>
+  `);
+
+  const cardsContainer = panel.querySelector('.advocate-associated-content');
+  info.associatedContent
+    .filter((card) => card.title && card.contentType)
+    .slice(0, 3)
+    .forEach((card) => cardsContainer.append(buildAssociatedContentCard(card)));
+
+  decorateIcons(panel);
+  return panel;
+}
+
+export default function decorate(block) {
+  const info = extractAdvocateInfo(block);
+  const panel = buildAdvocatePanel(info);
+  block.textContent = '';
+  block.append(panel);
+}

--- a/blocks/featured-advocates/featured-advocates.css
+++ b/blocks/featured-advocates/featured-advocates.css
@@ -1,0 +1,88 @@
+.featured-advocates.block {
+  position: relative;
+}
+
+.featured-advocates.block .featured-advocates-heading {
+  margin-bottom: 24px;
+}
+
+.featured-advocates.block .featured-advocates-heading :where(h1, h2, h3, h4, h5, h6) {
+  margin: 0;
+  font-size: var(--spectrum-font-size-900);
+  font-weight: var(--font-weight-bold);
+  color: var(--non-spectrum-dark-charcoal);
+}
+
+/* ----- slides ----- */
+.featured-advocates.block .featured-advocates-track {
+  position: relative;
+}
+
+.featured-advocates.block .featured-advocates-slide {
+  display: none;
+}
+
+.featured-advocates.block .featured-advocates-slide.active {
+  display: block;
+}
+
+/* ----- controls ----- */
+.featured-advocates.block .featured-advocates-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.featured-advocates.block .featured-advocates-nav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--spectrum-gray-300, #cacaca);
+  border-radius: 50%;
+  background: var(--background-color, #fff);
+  cursor: pointer;
+  padding: 0;
+}
+
+.featured-advocates.block .featured-advocates-nav:hover {
+  border-color: var(--non-spectrum-charcoal-gray);
+}
+
+.featured-advocates.block .featured-advocates-nav .icon {
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+}
+
+.featured-advocates.block .featured-advocates-nav .icon img {
+  width: 100%;
+  height: 100%;
+}
+
+.featured-advocates.block .featured-advocates-dots {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.featured-advocates.block .featured-advocates-dot {
+  width: 10px;
+  height: 10px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--spectrum-gray-300, #cacaca);
+  cursor: pointer;
+}
+
+.featured-advocates.block .featured-advocates-dot.selected {
+  background: var(--non-spectrum-adobe-dark-red);
+}
+
+.featured-advocates.block.featured-advocates-empty {
+  display: none;
+}

--- a/blocks/featured-advocates/featured-advocates.js
+++ b/blocks/featured-advocates/featured-advocates.js
@@ -1,0 +1,150 @@
+import ffetch from '../../scripts/ffetch.js';
+import { decorateIcons } from '../../scripts/lib-franklin.js';
+import { getPathDetails } from '../../scripts/scripts.js';
+import { buildAdvocatePanel } from '../advocate-bio/advocate-bio.js';
+import { fetchAdvocateInfo, isAdvocateComplete } from '../../scripts/utils/advocate-utils.js';
+
+const MAX_ADVOCATES = 18;
+const ROTATION_KEY = 'featured-advocates-seen';
+
+/**
+ * Returns the ordered list of advocate paths for this page load.
+ * Champions appear in a random order; a Champion is not repeated until every
+ * Champion has been surfaced, tracked across page loads via sessionStorage.
+ * @param {string[]} paths all available champion page paths
+ */
+function rotateOrder(paths) {
+  let seen = [];
+  try {
+    seen = JSON.parse(sessionStorage.getItem(ROTATION_KEY)) || [];
+  } catch {
+    seen = [];
+  }
+  // Drop anything no longer available, and reset once the full list is exhausted.
+  seen = seen.filter((p) => paths.includes(p));
+  if (seen.length >= paths.length) seen = [];
+
+  const unseen = paths.filter((p) => !seen.includes(p));
+  const pool = unseen.length ? unseen : paths;
+  const start = pool[Math.floor(Math.random() * pool.length)];
+
+  try {
+    sessionStorage.setItem(ROTATION_KEY, JSON.stringify([...seen, start]));
+  } catch {
+    // sessionStorage unavailable — rotation is best-effort only.
+  }
+
+  const startIndex = paths.indexOf(start);
+  return [...paths.slice(startIndex), ...paths.slice(0, startIndex)];
+}
+
+function buildControls(total) {
+  const controls = document.createElement('div');
+  controls.classList.add('featured-advocates-controls');
+  controls.innerHTML = `
+    <button class="featured-advocates-nav featured-advocates-prev" type="button" aria-label="Previous advocate">
+      <span class="icon icon-back-arrow"></span>
+    </button>
+    <div class="featured-advocates-dots" role="tablist" aria-label="Featured advocates"></div>
+    <button class="featured-advocates-nav featured-advocates-next" type="button" aria-label="Next advocate">
+      <span class="icon icon-front-arrow"></span>
+    </button>
+  `;
+  const dots = controls.querySelector('.featured-advocates-dots');
+  for (let i = 0; i < total; i += 1) {
+    const dot = document.createElement('button');
+    dot.type = 'button';
+    dot.classList.add('featured-advocates-dot');
+    dot.dataset.index = i;
+    dot.setAttribute('role', 'tab');
+    dot.setAttribute('aria-label', `Advocate ${i + 1} of ${total}`);
+    dots.append(dot);
+  }
+  return controls;
+}
+
+export default async function decorate(block) {
+  const [headingRow] = [...block.children];
+  const heading = headingRow?.querySelector('h1,h2,h3,h4,h5,h6') ?? null;
+
+  const { lang } = getPathDetails();
+  const championRoot = `/${lang}/champions/`;
+  let entries = [];
+  try {
+    entries = await ffetch(`/${lang}/query-index.json`).all();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Error loading query index:', err);
+  }
+
+  // Champion pages are the sub-pages beneath the main Champions page.
+  const paths = entries
+    .map((entry) => entry.path)
+    .filter((path) => path && path.startsWith(championRoot) && path !== championRoot.slice(0, -1));
+
+  // Fetch and parse each Champion page, then apply the acceptance-criteria filter.
+  const advocates = (await Promise.all(paths.map((path) => fetchAdvocateInfo(path))))
+    .map((info, i) => ({ info, path: paths[i] }))
+    .filter(({ info }) => isAdvocateComplete(info))
+    .slice(0, MAX_ADVOCATES);
+
+  block.textContent = '';
+
+  if (heading) {
+    const headingWrapper = document.createElement('div');
+    headingWrapper.classList.add('featured-advocates-heading');
+    headingWrapper.append(heading);
+    block.append(headingWrapper);
+  }
+
+  if (!advocates.length) {
+    block.classList.add('featured-advocates-empty');
+    return;
+  }
+
+  const order = rotateOrder(advocates.map((a) => a.path));
+  const ordered = order.map((path) => advocates.find((a) => a.path === path)).filter(Boolean);
+
+  const track = document.createElement('div');
+  track.classList.add('featured-advocates-track');
+  ordered.forEach((advocate, i) => {
+    const slide = document.createElement('div');
+    slide.classList.add('featured-advocates-slide');
+    slide.setAttribute('role', 'group');
+    slide.setAttribute('aria-roledescription', 'slide');
+    slide.setAttribute('aria-label', `${i + 1} of ${ordered.length}`);
+    if (i !== 0) slide.setAttribute('aria-hidden', 'true');
+    slide.append(buildAdvocatePanel(advocate.info));
+    track.append(slide);
+  });
+  block.append(track);
+
+  if (ordered.length <= 1) return;
+
+  const controls = buildControls(ordered.length);
+  block.append(controls);
+  decorateIcons(controls);
+
+  const slides = [...track.children];
+  const dots = [...controls.querySelectorAll('.featured-advocates-dot')];
+  let current = 0;
+
+  const goTo = (index) => {
+    current = (index + slides.length) % slides.length;
+    slides.forEach((slide, i) => {
+      slide.classList.toggle('active', i === current);
+      slide.setAttribute('aria-hidden', i === current ? 'false' : 'true');
+    });
+    dots.forEach((dot, i) => {
+      dot.classList.toggle('selected', i === current);
+      dot.setAttribute('aria-selected', i === current ? 'true' : 'false');
+    });
+  };
+
+  controls.querySelector('.featured-advocates-prev').addEventListener('click', () => goTo(current - 1));
+  controls.querySelector('.featured-advocates-next').addEventListener('click', () => goTo(current + 1));
+  dots.forEach((dot) => dot.addEventListener('click', () => goTo(Number(dot.dataset.index))));
+
+  slides[0].classList.add('active');
+  goTo(0);
+}

--- a/component-definition.json
+++ b/component-definition.json
@@ -501,6 +501,63 @@
           }
         },
         {
+          "title": "Advocate Bio",
+          "id": "advocate-bio",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Advocate Bio",
+                  "model": "advocate-bio",
+                  "filter": "advocate-bio",
+                  "product-designation": "Adobe Champion - Adobe Experience Manager",
+                  "item": {
+                    "sling:resourceType": "core/franklin/components/block/v1/block/item",
+                    "name": "Advocate Content",
+                    "model": "advocate-content",
+                    "content-type": "Perspective",
+                    "time-type": "clock"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Advocate Content",
+          "id": "advocate-content",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block/item",
+                "template": {
+                  "name": "Advocate Content",
+                  "model": "advocate-content",
+                  "content-type": "Perspective",
+                  "time-type": "clock"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Featured Advocates",
+          "id": "featured-advocates",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Featured Advocates",
+                  "model": "featured-advocates",
+                  "headingType": "h2"
+                }
+              }
+            }
+          }
+        },
+        {
           "title": "Author Summary",
           "id": "author-summary",
           "plugins": {

--- a/component-filters.json
+++ b/component-filters.json
@@ -102,6 +102,8 @@
       "block-quote",
       "callout",
       "featured-authors",
+      "advocate-bio",
+      "featured-advocates",
       "inline-survey",
       "featured-content",
       "browse-filters",
@@ -506,6 +508,10 @@
   {
     "id": "accordion",
     "components": ["accordion"]
+  },
+  {
+    "id": "advocate-bio",
+    "components": ["advocate-content"]
   },
   {
     "id": "authorable-card",

--- a/component-models.json
+++ b/component-models.json
@@ -6284,6 +6284,168 @@
     ]
   },
   {
+    "id": "advocate-bio",
+    "fields": [
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "fileReference",
+        "label": "Champion image",
+        "description": "Sets the image of the Champion",
+        "multi": false
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "advocate-name",
+        "value": "",
+        "label": "Champion name",
+        "description": "Sets the name of the Champion"
+      },
+      {
+        "component": "aem-content",
+        "valueType": "string",
+        "name": "profile-link",
+        "value": "",
+        "label": "Community profile URL",
+        "description": "The Champion name links to this Community profile"
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "advocate-title",
+        "value": "",
+        "label": "Champion title",
+        "description": "Sets the Champion's job title"
+      },
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "product-designation",
+        "value": "Adobe Champion - Adobe Experience Manager",
+        "label": "Product designation",
+        "description": "Sets the Champion's Adobe product designation",
+        "options": [
+          { "name": "Adobe Champion - Adobe Experience Manager", "value": "Adobe Champion - Adobe Experience Manager" },
+          {
+            "name": "Adobe Champion - Adobe Experience Platform",
+            "value": "Adobe Champion - Adobe Experience Platform"
+          },
+          { "name": "Adobe Champion - Analytics", "value": "Adobe Champion - Analytics" },
+          { "name": "Adobe Champion - Commerce", "value": "Adobe Champion - Commerce" },
+          { "name": "Adobe Champion - Marketo Engage", "value": "Adobe Champion - Marketo Engage" },
+          { "name": "Adobe Champion - Workfront", "value": "Adobe Champion - Workfront" }
+        ]
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "advocate-quote",
+        "value": "",
+        "label": "Quote / bio",
+        "description": "Plain-text quote or bio. Quotation marks may be included if desired."
+      }
+    ]
+  },
+  {
+    "id": "advocate-content",
+    "fields": [
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "content-type",
+        "value": "Perspective",
+        "label": "Content type",
+        "description": "Content type shown as the eyebrow, with a matching icon",
+        "options": [
+          { "name": "Perspective", "value": "Perspective" },
+          { "name": "Documentation", "value": "Documentation" },
+          { "name": "Event", "value": "Event" },
+          { "name": "Playlist", "value": "Playlist" },
+          { "name": "Course", "value": "Course" },
+          { "name": "Community", "value": "Community" }
+        ]
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "content-title",
+        "value": "",
+        "label": "Title"
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "content-description",
+        "value": "",
+        "label": "Description",
+        "description": "Optional supporting description"
+      },
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "time-type",
+        "value": "clock",
+        "label": "Time commitment icon",
+        "options": [
+          { "name": "Clock", "value": "clock" },
+          { "name": "Checkmark", "value": "checkmark" },
+          { "name": "Video", "value": "video" }
+        ]
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "time-text",
+        "value": "",
+        "label": "Time commitment text",
+        "description": "e.g. \"5 min read\" or \"Watch now\""
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "cta-text",
+        "value": "",
+        "label": "CTA label"
+      },
+      {
+        "component": "aem-content",
+        "valueType": "string",
+        "name": "cta-link",
+        "value": "",
+        "label": "CTA destination"
+      }
+    ]
+  },
+  {
+    "id": "featured-advocates",
+    "fields": [
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "heading",
+        "value": "",
+        "label": "Heading",
+        "description": "Optional heading shown above the carousel"
+      },
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "headingType",
+        "value": "h2",
+        "label": "Heading Type",
+        "options": [
+          { "name": "H1", "value": "h1" },
+          { "name": "H2", "value": "h2" },
+          { "name": "H3", "value": "h3" },
+          { "name": "H4", "value": "h4" },
+          { "name": "H5", "value": "h5" },
+          { "name": "H6", "value": "h6" }
+        ]
+      }
+    ]
+  },
+  {
     "id": "events-search",
     "fields": []
   },

--- a/scripts/utils/advocate-utils.js
+++ b/scripts/utils/advocate-utils.js
@@ -1,0 +1,113 @@
+/**
+ * Maps a content-type designation to the icon name authored on the Champion page.
+ * Falls back to a neutral document icon when no mapping exists.
+ */
+const CONTENT_TYPE_ICONS = {
+  perspective: 'atomic-search-perspective',
+  documentation: 'atomic-search-documentation',
+  event: 'atomic-search-event',
+  playlist: 'atomic-search-playlist',
+  course: 'book',
+  community: 'user',
+};
+
+/**
+ * Maps a time-commitment designation to the icon name authored on the Champion page.
+ */
+const TIME_ICONS = {
+  clock: 'time',
+  checkmark: 'check-circle',
+  video: 'play-outline',
+};
+
+export function getContentTypeIcon(contentType) {
+  return CONTENT_TYPE_ICONS[contentType?.toLowerCase()?.trim()] || 'documentation';
+}
+
+export function getTimeIcon(timeType) {
+  return TIME_ICONS[timeType?.toLowerCase()?.trim()] || 'time';
+}
+
+// Number of Champion-level rows that precede the associated-content card rows.
+const CHAMPION_FIELD_ROWS = 6;
+
+/**
+ * Extract a single associated-content card from a child row of the advocate-bio block.
+ * Row cells (in order): content type, title, description, time icon, time text, cta text, cta url.
+ * @param {HTMLElement} row
+ */
+function extractAssociatedContent(row) {
+  const cells = [...row.children];
+  const cellText = (i) => cells[i]?.textContent.trim() ?? '';
+  const linkHref = cells[6]?.querySelector('a')?.getAttribute('href');
+  return {
+    contentType: cellText(0),
+    title: cellText(1),
+    description: cellText(2),
+    timeType: cellText(3),
+    timeText: cellText(4),
+    ctaText: cellText(5),
+    ctaLink: linkHref ?? cellText(6),
+  };
+}
+
+/**
+ * Extract Champion / Advocate information from the advocate-bio block markup.
+ * The block is a container: the first rows are the Champion identity fields and
+ * the remaining rows are the associated-content cards (up to three).
+ * @param {HTMLElement} block the `.advocate-bio` element
+ */
+export function extractAdvocateInfo(block) {
+  const rows = [...block.children];
+  const fieldEl = rows.slice(0, CHAMPION_FIELD_ROWS).map((row) => row.firstElementChild);
+  const contentRows = rows.slice(CHAMPION_FIELD_ROWS);
+  const profileLink = fieldEl[2]?.querySelector('a')?.getAttribute('href') ?? fieldEl[2]?.textContent.trim() ?? '';
+  return {
+    image: fieldEl[0]?.querySelector('img')?.getAttribute('src') ?? '',
+    name: fieldEl[1]?.textContent.trim() ?? '',
+    profileLink,
+    title: fieldEl[3]?.textContent.trim() ?? '',
+    productDesignation: fieldEl[4]?.textContent.trim() ?? '',
+    quote: fieldEl[5]?.textContent.trim() ?? '',
+    associatedContent: contentRows.map(extractAssociatedContent),
+  };
+}
+
+/**
+ * Determines whether a Champion has enough data to be displayed.
+ * Per the acceptance criteria: every field except the description/quote must
+ * be populated. We treat name, title, product designation, image and profile
+ * link as required, and require at least one complete associated-content card.
+ * @param {ReturnType<typeof extractAdvocateInfo>} info
+ */
+export function isAdvocateComplete(info) {
+  if (!info) return false;
+  const requiredChampionFields = [info.image, info.name, info.profileLink, info.title, info.productDesignation];
+  if (requiredChampionFields.some((field) => !field)) return false;
+  const hasCompleteCard = info.associatedContent.some(
+    (card) => card.contentType && card.title && card.ctaLink && card.ctaText,
+  );
+  return hasCompleteCard;
+}
+
+/**
+ * Fetch and parse a Champion page's advocate-bio block.
+ * @param {HTMLAnchorElement|string} anchor
+ */
+export async function fetchAdvocateInfo(anchor) {
+  const link = typeof anchor === 'string' ? anchor : anchor?.href;
+  if (!link) return null;
+  try {
+    const response = await fetch(link);
+    if (!response.ok) return null;
+    const html = await response.text();
+    const htmlDoc = new DOMParser().parseFromString(html, 'text/html');
+    const advocateEl = htmlDoc.querySelector('.advocate-bio');
+    if (!advocateEl) return null;
+    return extractAdvocateInfo(advocateEl);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching advocate info:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
Jira ID: EXLM-5462

Adds the **Featured Advocates** carousel and **Advocate Bio** content-fragment blocks for the Champions/Advocacy program, following the project's existing content-fragment pattern (mirrors `author-bio` / `featured-authors`).

### What's included
- **advocate-bio** — container block authored on each Champion sub-page: image, name, Community-profile link, title, product designation, plain-text quote/bio, and up to 3 associated-content child cards (**advocate-content**: content type + icon, title, optional description, time-commitment icon + text, CTA).
- **featured-advocates** — carousel on the main Champions page. Auto-collects Champion sub-pages from the existing `query-index`, applies the completeness filter (hide unless every field except the description is populated), caps at 18, and renders paginated slides with prev/next + dot navigation. Rotates the starting Champion each load with no repeats until the full list is seen.
- **advocate-utils.js** — shared parser, completeness filter, and content-type/time icon mappings.
- Registered all three blocks in the Universal Editor authoring config (`component-definition.json`, `component-models.json`, `component-filters.json`).

### Notes / follow-ups
- Champion pages live under `/{lang}/champions/`; carousel goes on the main `/{lang}/champions` page.
- Uses the existing site `query-index.json` (no `helix-query.yaml` change needed).
- Order follows the query-index (auto-collect model chosen). Beyond 18 valid Champions, extras are not rendered.

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://5462-ema--exlm--adobe-experience-league.aem.live/en/champions?martech=off

## AI Review Notes

- The `featured-advocates` block has no per-Champion authored fields by design — Champions are auto-collected from `/{lang}/champions/` sub-pages, not authored as references. Order and the 18 cap are therefore runtime concerns, not UE-enforced.
- `advocate-bio` and `advocate-content` follow the container + `block/item` pattern used by `course-breakdown` / `accordion-group`.