### PR TITLE
EXLM-5361: exclude stale Upcoming from Browse filters and tabbed cards

### DIFF
--- a/blocks/browse-filters/browse-filters.js
+++ b/blocks/browse-filters/browse-filters.js
@@ -36,6 +36,7 @@ import {
 import {
   BASE_COVEO_ADVANCED_QUERY,
   BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT,
+  COVEO_EXCLUDE_STALE_UPCOMING_AQ,
 } from '../../scripts/browse-card/browse-cards-constants.js';
 import { COVEO_SEARCH_CUSTOM_EVENTS } from '../../scripts/search/search-utils.js';
 import {
@@ -1743,9 +1744,12 @@ function decorateBrowseTopics(block) {
 
 export default async function decorate(block) {
   const isUpcomingEventFlow = isEventsPage && isFeatureEnabled('isEventsV2');
+  // Browse (and other non-Events-V2 filter pages): drop stale Upcoming at query time —
+  // same rule as Events Hub / global search (EXLM-5361). Events-page legacy flow keeps
+  // its own base aq (wired separately via Events Search / upcoming-event-v2).
   window.headlessBaseSolutionQuery = isUpcomingEventFlow
     ? BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT
-    : BASE_COVEO_ADVANCED_QUERY;
+    : `(${BASE_COVEO_ADVANCED_QUERY}) AND (${COVEO_EXCLUDE_STALE_UPCOMING_AQ})`;
   enableTagsAsProxy(block);
   appendFormEl(block);
   constructFilterInputContainer(block);

--- a/scripts/browse-card/browse-cards-constants.js
+++ b/scripts/browse-card/browse-cards-constants.js
@@ -71,7 +71,8 @@ export const COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ =
 export const BASE_COVEO_ADVANCED_QUERY_EVENTS = `(@el_contenttype = "Event|On Demand Event") OR ${COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ}`;
 /**
  * Exclude stale Upcoming Events while keeping all other content types.
- * Used by Atomic Search (/en/search) which has no Events-only base aq.
+ * Used by Atomic Search (/en/search), Browse filters, and Coveo card pipelines
+ * (tabbed cards / BrowseCardsDelegate) which are not Events-only base aq.
  */
 export const COVEO_EXCLUDE_STALE_UPCOMING_AQ = `(NOT @el_contenttype = "Event|Upcoming Event") OR ${COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ}`;
 

--- a/scripts/coveo-headless/engine.js
+++ b/scripts/coveo-headless/engine.js
@@ -1,7 +1,7 @@
 import loadCoveoToken from '../data-service/coveo/coveo-token-service.js';
 import { getConfig } from '../scripts.js';
 import { generateCustomContext, generateMlParameters, COVEO_SEARCH_CUSTOM_EVENTS } from '../search/search-utils.js';
-import { COVEO_EXCLUDE_STALE_UPCOMING_AQ } from '../browse-card/browse-cards-constants.js';
+import { COVEO_EXCLUDE_STALE_UPCOMING_AQ, BASE_COVEO_ADVANCED_QUERY } from '../browse-card/browse-cards-constants.js';
 
 /**
  * Ensure Browse / Headless searches never return past Upcoming Events (EXLM-5361).
@@ -15,8 +15,9 @@ function withExcludeStaleUpcoming(aq) {
   if (existing.includes('el_event_start_time >= now')) {
     return existing;
   }
+  // Empty aq would otherwise drop Browse's Community|User guard — keep both.
   if (!existing) {
-    return COVEO_EXCLUDE_STALE_UPCOMING_AQ;
+    return `(${BASE_COVEO_ADVANCED_QUERY}) AND (${COVEO_EXCLUDE_STALE_UPCOMING_AQ})`;
   }
   return `(${existing}) AND (${COVEO_EXCLUDE_STALE_UPCOMING_AQ})`;
 }

--- a/scripts/coveo-headless/engine.js
+++ b/scripts/coveo-headless/engine.js
@@ -15,8 +15,16 @@ function withExcludeStaleUpcoming(aq) {
   if (existing.includes('el_event_start_time >= now')) {
     return existing;
   }
-  // Empty aq would otherwise drop Browse's Community|User guard — keep both.
   if (!existing) {
+    // Prefer page-configured base (Browse products/topics, Events V2, etc.).
+    const pageBase =
+      typeof window !== 'undefined' ? String(window.headlessBaseSolutionQuery || '').trim() : '';
+    if (pageBase) {
+      return pageBase.includes('el_event_start_time >= now')
+        ? pageBase
+        : `(${pageBase}) AND (${COVEO_EXCLUDE_STALE_UPCOMING_AQ})`;
+    }
+    // Fallback when Headless has not set a page base yet.
     return `(${BASE_COVEO_ADVANCED_QUERY}) AND (${COVEO_EXCLUDE_STALE_UPCOMING_AQ})`;
   }
   return `(${existing}) AND (${COVEO_EXCLUDE_STALE_UPCOMING_AQ})`;

--- a/scripts/coveo-headless/engine.js
+++ b/scripts/coveo-headless/engine.js
@@ -1,6 +1,25 @@
 import loadCoveoToken from '../data-service/coveo/coveo-token-service.js';
 import { getConfig } from '../scripts.js';
 import { generateCustomContext, generateMlParameters, COVEO_SEARCH_CUSTOM_EVENTS } from '../search/search-utils.js';
+import { COVEO_EXCLUDE_STALE_UPCOMING_AQ } from '../browse-card/browse-cards-constants.js';
+
+/**
+ * Ensure Browse / Headless searches never return past Upcoming Events (EXLM-5361).
+ * URL hash `aq=` can overwrite `headlessBaseSolutionQuery`, so enforce at request time.
+ * @param {string} aq
+ * @returns {string}
+ */
+function withExcludeStaleUpcoming(aq) {
+  const existing = (aq || '').trim();
+  // Already constrained (Events Hub base aq / prior merge).
+  if (existing.includes('el_event_start_time >= now')) {
+    return existing;
+  }
+  if (!existing) {
+    return COVEO_EXCLUDE_STALE_UPCOMING_AQ;
+  }
+  return `(${existing}) AND (${COVEO_EXCLUDE_STALE_UPCOMING_AQ})`;
+}
 
 export default async function buildHeadlessSearchEngine(module) {
   const { coveoOrganizationId } = getConfig();
@@ -21,6 +40,11 @@ export default async function buildHeadlessSearchEngine(module) {
             ...context,
             ...customContext,
           };
+          request.body = JSON.stringify(bodyJSON);
+        }
+        // Drop stale Upcoming at query time (Browse filters + any Headless consumer).
+        if (metadata?.method === 'search') {
+          bodyJSON.aq = withExcludeStaleUpcoming(bodyJSON.aq);
           request.body = JSON.stringify(bodyJSON);
         }
         const preProcessEvent = new CustomEvent(COVEO_SEARCH_CUSTOM_EVENTS.PREPROCESS, {

--- a/scripts/data-service/coveo/coveo-exl-pipeline-helpers.js
+++ b/scripts/data-service/coveo/coveo-exl-pipeline-helpers.js
@@ -197,16 +197,6 @@ function mergeAdvancedQueryParts(...parts) {
   return cleaned.map((part) => `(${part})`).join(' AND ');
 }
 
-/**
- * True when request targets Upcoming Event V2 (tabbed cards / browse card blocks).
- * @param {object} param
- * @returns {boolean}
- */
-function contentTypesIncludeUpcomingEventV2(param) {
-  const upcomingKey = CONTENT_TYPES.UPCOMING_EVENT_V2.MAPPING_KEY.toLowerCase();
-  return (param.contentType || []).some((type) => String(type).toLowerCase() === upcomingKey);
-}
-
 export function getExlPipelineDataSourceParams(param, fields = fieldsToInclude) {
   let context = { entitlements: {}, role: {}, interests: {}, industryInterests: {} };
   if (param.context) {
@@ -216,14 +206,14 @@ export function getExlPipelineDataSourceParams(param, fields = fieldsToInclude) 
     };
   }
 
-  // Preserve prior precedence (feature aq / explicit aq) but merge instead of
-  // silently dropping dateCriteria when both exist — needed so Upcoming + authored
-  // date filters still apply the stale-Upcoming start-time rule (EXLM-5361).
+  // Always drop stale Upcoming (EXLM-5361) — not only when Upcoming V2 is the
+  // authored contentType. Topic/recommended/feature pipelines can otherwise still
+  // surface past Event|Upcoming Event cards while Browse Headless hides them.
   const aq = mergeAdvancedQueryParts(
     param.dateCriteria && !param.feature ? contructDateAdvancedQuery(param.dateCriteria) : '',
     param.feature ? constructCoveoAdvancedQuery(param) : '',
     param.aq || '',
-    contentTypesIncludeUpcomingEventV2(param) ? COVEO_EXCLUDE_STALE_UPCOMING_AQ : '',
+    COVEO_EXCLUDE_STALE_UPCOMING_AQ,
   );
 
   const dataSource = {

--- a/scripts/data-service/coveo/coveo-exl-pipeline-helpers.js
+++ b/scripts/data-service/coveo/coveo-exl-pipeline-helpers.js
@@ -2,6 +2,7 @@ import { URL_SPECIAL_CASE_LOCALES, fetchLanguagePlaceholders, getConfig } from '
 import { rewriteDocsPath } from '../../utils/path-utils.js';
 import CoveoDataService from './coveo-data-service.js';
 import { CONTENT_TYPES, COMMUNITY_SEARCH_FACET } from './coveo-exl-pipeline-constants.js';
+import { COVEO_EXCLUDE_STALE_UPCOMING_AQ } from '../../browse-card/browse-cards-constants.js';
 
 const { coveoSearchResultsUrl } = getConfig();
 const MAX_NUMBER_OF_VALUES_PER_BATCH = 100;
@@ -184,6 +185,28 @@ export function getFacets(param) {
   return constructCoveoFacet(facets, param);
 }
 
+/**
+ * Join Coveo advanced-query clauses with AND (each clause wrapped).
+ * @param {...string} parts
+ * @returns {string|undefined}
+ */
+function mergeAdvancedQueryParts(...parts) {
+  const cleaned = parts.map((part) => (part == null ? '' : String(part).trim())).filter(Boolean);
+  if (!cleaned.length) return undefined;
+  if (cleaned.length === 1) return cleaned[0];
+  return cleaned.map((part) => `(${part})`).join(' AND ');
+}
+
+/**
+ * True when request targets Upcoming Event V2 (tabbed cards / browse card blocks).
+ * @param {object} param
+ * @returns {boolean}
+ */
+function contentTypesIncludeUpcomingEventV2(param) {
+  const upcomingKey = CONTENT_TYPES.UPCOMING_EVENT_V2.MAPPING_KEY.toLowerCase();
+  return (param.contentType || []).some((type) => String(type).toLowerCase() === upcomingKey);
+}
+
 export function getExlPipelineDataSourceParams(param, fields = fieldsToInclude) {
   let context = { entitlements: {}, role: {}, interests: {}, industryInterests: {} };
   if (param.context) {
@@ -192,6 +215,17 @@ export function getExlPipelineDataSourceParams(param, fields = fieldsToInclude) 
       ...param.context,
     };
   }
+
+  // Preserve prior precedence (feature aq / explicit aq) but merge instead of
+  // silently dropping dateCriteria when both exist — needed so Upcoming + authored
+  // date filters still apply the stale-Upcoming start-time rule (EXLM-5361).
+  const aq = mergeAdvancedQueryParts(
+    param.dateCriteria && !param.feature ? contructDateAdvancedQuery(param.dateCriteria) : '',
+    param.feature ? constructCoveoAdvancedQuery(param) : '',
+    param.aq || '',
+    contentTypesIncludeUpcomingEventV2(param) ? COVEO_EXCLUDE_STALE_UPCOMING_AQ : '',
+  );
+
   const dataSource = {
     url: coveoSearchResultsUrl,
     param: {
@@ -208,10 +242,8 @@ export function getExlPipelineDataSourceParams(param, fields = fieldsToInclude) 
       parentField: '@foldingchild',
       childField: '@foldingparent',
       ...(param.q && !param.feature ? { q: param.q } : ''),
-      ...(param.dateCriteria && !param.feature ? { aq: contructDateAdvancedQuery(param.dateCriteria) } : ''),
+      ...(aq ? { aq } : ''),
       ...(!param.feature ? { facets: getFacets(param) } : ''),
-      ...(param.feature ? { aq: constructCoveoAdvancedQuery(param) } : ''),
-      ...(param.aq ? { aq: param.aq } : ''),
       ...(param.fields?.length > 0
         ? { batch: param.fields.map((field) => ({ field, maximumNumberOfValues: MAX_NUMBER_OF_VALUES_PER_BATCH })) }
         : ''),


### PR DESCRIPTION
Jira ID: EXLM-5361

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://EXLM-5361-browse-aq--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->