### PR TITLE
fix: streamline content type key generation and remove unused imports

### DIFF
--- a/blocks/tabbed-cards/tabbed-cards.js
+++ b/blocks/tabbed-cards/tabbed-cards.js
@@ -3,11 +3,7 @@ import { htmlToElement, decorateExternalLinks, fetchLanguagePlaceholders } from 
 import BrowseCardShimmer from '../../scripts/browse-card/browse-card-shimmer.js';
 import { COVEO_SORT_OPTIONS } from '../../scripts/browse-card/browse-cards-constants.js';
 import { buildCard, buildNoResultsContent } from '../../scripts/browse-card/browse-card.js';
-import {
-  createDateCriteria,
-  formatTitleCase,
-  convertToTitleCase,
-} from '../../scripts/browse-card/browse-card-utils.js';
+import { createDateCriteria, convertToTitleCase } from '../../scripts/browse-card/browse-card-utils.js';
 import { decorateIcons } from '../../scripts/lib-franklin.js';
 
 const lang = document.querySelector('html').lang || 'en';
@@ -35,6 +31,16 @@ const urlMap = {
 function formatFallbackLabel(contentType) {
   const label = contentType.includes('|') ? contentType.split('|').pop() : contentType;
   return convertToTitleCase(label.trim());
+}
+
+/**
+ * Builds the placeholder key segment for a content type (e.g. "event|upcoming event" -> "UpcomingEvent"),
+ * dropping any "event|" style prefix so the resulting placeholder key is a clean, authorable string.
+ * @param {string} contentType - Lowercased content type value.
+ * @returns {string} Placeholder key segment.
+ */
+function getContentTypeKey(contentType) {
+  return formatFallbackLabel(contentType).replace(/\s+/g, '');
 }
 
 /**
@@ -162,7 +168,7 @@ export default async function decorate(block) {
     const tabListUlElement = document.createElement('ul');
     contentTypeList.forEach((contentType) => {
       const contentTypeLowerCase = contentType.toLowerCase();
-      const contentTypeTitleCase = formatTitleCase(contentType);
+      const contentTypeTitleCase = getContentTypeKey(contentType);
       const tabLabel = document.createElement('li');
       tabLabel.textContent =
         placeholders[`tabbedCard${contentTypeTitleCase}TabLabel`] || formatFallbackLabel(contentType);
@@ -212,7 +218,7 @@ export default async function decorate(block) {
 
     // Update view link for initial content type
     viewLinkURLElement.innerHTML =
-      placeholders[`tabbedCard${formatTitleCase(initialContentType)}ViewAllLabel`] || 'View All';
+      placeholders[`tabbedCard${getContentTypeKey(initialContentType)}ViewAllLabel`] || 'View All';
     viewLinkURLElement.setAttribute('href', urlMap[initialContentType]);
     tabList.appendChild(viewLinkURLElement);
     tabList.children[0].children[0].classList.add('active');


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live/en/events
- After: https://tabbedPlaceholderFix--exlm--adobe-experience-league.aem.live/en/events


## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->