### PR TITLE
fix(EXLM-5516): reset pagination when switching locale on browse pages

### DIFF
--- a/blocks/language/language.js
+++ b/blocks/language/language.js
@@ -33,7 +33,13 @@ const getLanguagePath = (language) => {
 const switchLanguage = (language) => {
   const { lang } = pathDetails;
   if (lang !== language) {
-    window.location.pathname = getLanguagePath(language);
+    const newPathname = getLanguagePath(language);
+    // Strip firstResult so pagination resets to page 1 after locale switch.
+    // Keeping it causes a "no results" state when the new locale has fewer results.
+    const cleanHash = window.location.hash
+      .replace(/&firstResult=[^&]*/g, '')
+      .replace(/#firstResult=[^&]*&?/, '#');
+    window.location.href = newPathname + window.location.search + (cleanHash === '#' || cleanHash === '' ? '' : cleanHash);
   }
 };
 

--- a/blocks/language/language.js
+++ b/blocks/language/language.js
@@ -36,10 +36,9 @@ const switchLanguage = (language) => {
     const newPathname = getLanguagePath(language);
     // Strip firstResult so pagination resets to page 1 after locale switch.
     // Keeping it causes a "no results" state when the new locale has fewer results.
-    const cleanHash = window.location.hash
-      .replace(/&firstResult=[^&]*/g, '')
-      .replace(/#firstResult=[^&]*&?/, '#');
-    window.location.href = newPathname + window.location.search + (cleanHash === '#' || cleanHash === '' ? '' : cleanHash);
+    const cleanHash = window.location.hash.replace(/&firstResult=[^&]*/g, '').replace(/#firstResult=[^&]*&?/, '#');
+    window.location.href =
+      newPathname + window.location.search + (cleanHash === '#' || cleanHash === '' ? '' : cleanHash);
   }
 };
 


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-5516
🤖 Auto-generated draft from Jira. Review before marking ready.

## What was implemented

When a user switches locale on a Browse page while on a page number that exceeds the
result count of the target locale, the `firstResult` hash parameter was carried over
unchanged, causing an empty "no results" state. This fix strips `firstResult` from the
URL hash in `switchLanguage` before navigating, so pagination resets to page 1 while
preserving all other active filter params (content type, role, topic, search query).

## ⚠️ Open Questions / Gaps

None — fully implemented, pending review

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5516--exlm--adobe-experience-league.aem.live
- After: https://exlm-5516--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5516--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5516--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5516--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

- switchLanguage now uses window.location.href instead of window.location.pathname to allow stripping firstResult from the hash; this is intentional and does not change any other navigation behaviour.