### PR TITLE
Champions index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -440,8 +440,6 @@ indices:
   champion-en: &base-champion
     include:
       - /en/champions/*
-    exclude:
-      - /en/champions
     target: /en/champion-index.json
     properties:
       title:
@@ -463,72 +461,54 @@ indices:
     <<: *base-champion
     include:
       - /fr/champions/*
-    exclude:
-      - /fr/champions
     target: /fr/champion-index.json
 
   champion-de:
     <<: *base-champion
     include:
       - /de/champions/*
-    exclude:
-      - /de/champions
     target: /de/champion-index.json
 
   champion-es:
     <<: *base-champion
     include:
       - /es/champions/*
-    exclude:
-      - /es/champions
     target: /es/champion-index.json
 
   champion-it:
     <<: *base-champion
     include:
       - /it/champions/*
-    exclude:
-      - /it/champions
     target: /it/champion-index.json
 
   champion-pt-br:
     <<: *base-champion
     include:
       - /pt-br/champions/*
-    exclude:
-      - /pt-br/champions
     target: /pt-br/champion-index.json
 
   champion-ko:
     <<: *base-champion
     include:
       - /ko/champions/*
-    exclude:
-      - /ko/champions
     target: /ko/champion-index.json
 
   champion-ja:
     <<: *base-champion
     include:
       - /ja/champions/*
-    exclude:
-      - /ja/champions
     target: /ja/champion-index.json
 
   champion-zh-hans:
     <<: *base-champion
     include:
       - /zh-hans/champions/*
-    exclude:
-      - /zh-hans/champions
     target: /zh-hans/champion-index.json
 
   champion-zh-hant:
     <<: *base-champion
     include:
       - /zh-hant/champions/*
-    exclude:
-      - /zh-hant/champions
     target: /zh-hant/champion-index.json
 
   # Sitemap indicies, split in 2 google has a limit of 50k (and 50MB) urls per sitemap


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://champion-index--exlm--adobe-experience-league.aem.live
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://champion-index--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->