### PR TITLE
EXLM 5537 - fix: event search sort

### DIFF
--- a/blocks/events-search/events-search.js
+++ b/blocks/events-search/events-search.js
@@ -1288,7 +1288,7 @@ async function initHeadlessSearch(block, groups, placeholders) {
     facetOverrides: getEventsSearchHeadlessFacetOverrides(),
     hideAqFromUrl: true,
     baseAdvancedQuery: BASE_COVEO_ADVANCED_QUERY_EVENTS,
-    dateSortField: 'el_event_start_time',
+    dateSortFields: ['el_event_video_id', 'el_event_start_time'],
     renderSearchQuerySummary: () => {
       const totalCount = window.headlessQuerySummary?.state?.total || 0;
       updateResultsCount(block, totalCount, placeholders);

--- a/blocks/events-search/events-search.js
+++ b/blocks/events-search/events-search.js
@@ -1288,6 +1288,7 @@ async function initHeadlessSearch(block, groups, placeholders) {
     facetOverrides: getEventsSearchHeadlessFacetOverrides(),
     hideAqFromUrl: true,
     baseAdvancedQuery: BASE_COVEO_ADVANCED_QUERY_EVENTS,
+    dateSortField: 'el_event_start_time',
     renderSearchQuerySummary: () => {
       const totalCount = window.headlessQuerySummary?.state?.total || 0;
       updateResultsCount(block, totalCount, placeholders);

--- a/scripts/coveo-headless/index.js
+++ b/scripts/coveo-headless/index.js
@@ -2,6 +2,7 @@ import buildHeadlessSearchEngine from './engine.js';
 import { fetchLanguagePlaceholders } from '../scripts.js';
 import { handleCoverSearchSubmit } from '../../blocks/browse-filters/browse-filter-utils.js';
 import { COVEO_SEARCH_CUSTOM_EVENTS } from '../search/search-utils.js';
+import { CONTENT_TYPES } from '../data-service/coveo/coveo-exl-pipeline-constants.js';
 
 /* Fetch data from the Placeholder.json */
 let placeholders = {};
@@ -18,6 +19,35 @@ const locales = new Map([
   ['zh-hans', 'zh-CN'],
   ['zh-hant', 'zh-TW'],
 ]);
+
+function buildDateSortCriteria(module, order, dateSortField) {
+  if (!dateSortField) return module.buildDateSortCriterion(order);
+  // Chained criterion: sorts by dateSortField first, falling back to the date field
+  // (e.g. items missing dateSortField) automatically.
+  return [module.buildFieldSortCriterion(dateSortField, order), module.buildDateSortCriterion(order)];
+}
+
+/**
+ * True when the el_contenttype facet is narrowed to Upcoming Events only (not On Demand, not both/none).
+ * Upcoming events have a future el_event_start_time, so "Newest" there means soonest (ascending),
+ * the reverse of "Newest" for past/on-demand content (most recent, descending).
+ */
+function isExclusiveUpcomingEventFilter(hash) {
+  const match = /(?:^|&)f-el_contenttype=([^&]*)/.exec(hash);
+  if (!match) return false;
+  const values = decodeURIComponent(match[1]).split(',').filter(Boolean);
+  return values.length === 1 && values[0] === CONTENT_TYPES.UPCOMING_EVENT_V2.MAPPING_KEY;
+}
+
+function getDateSortOrder(isNewest, dateSortField, hash) {
+  const flip = !!dateSortField && isExclusiveUpcomingEventFilter(hash);
+  if (isNewest) return flip ? 'ascending' : 'descending';
+  return flip ? 'descending' : 'ascending';
+}
+
+function buildDateSortHashValue(order, dateSortField) {
+  return dateSortField ? `@${dateSortField} ${order},date ${order}` : `date ${order}`;
+}
 
 function configureSearchHeadlessEngine({ module, searchEngine, searchHub, contextObject, advancedQueryRule }) {
   const advancedQuery = module.loadAdvancedSearchQueryActions(searchEngine).registerAdvancedSearchQueries({
@@ -143,6 +173,7 @@ export default async function initiateCoveoHeadlessSearch({
   facetOverrides = {},
   hideAqFromUrl = false,
   baseAdvancedQuery = '',
+  dateSortField = null,
 }) {
   return new Promise((resolve, reject) => {
     // eslint-disable-next-line import/no-relative-packages
@@ -398,8 +429,8 @@ export default async function initiateCoveoHeadlessSearch({
         const sortingOptions = [
           { label: sortLabel.relevance, sortCriteria: 'relevancy' },
           { label: sortLabel.popularity, sortCriteria: 'el_view_count descending' },
-          { label: sortLabel.newest, sortCriteria: 'descending' },
-          { label: sortLabel.oldest, sortCriteria: 'ascending' },
+          { label: sortLabel.newest, sortCriteria: 'newest' },
+          { label: sortLabel.oldest, sortCriteria: 'oldest' },
         ];
 
         sortingOptions.forEach((option) => {
@@ -417,8 +448,13 @@ export default async function initiateCoveoHeadlessSearch({
           const sortDropdown = sortContainer.querySelector('.sort-dropdown-content');
           const sortAnchors = sortDropdown.querySelectorAll('a');
           const sortBtn = sortContainer.querySelector('.sort-drop-btn');
-          let criteria = [[]];
+          let criteria = [[sortLabel.relevance, module.buildRelevanceSortCriterion()]];
           const isSortValueInHash = hashURL.split('&');
+          // Resolved against the facet state captured in hashURL at load time.
+          const newestOrderOnLoad = getDateSortOrder(true, dateSortField, hashURL);
+          const oldestOrderOnLoad = getDateSortOrder(false, dateSortField, hashURL);
+          const newestHashValue = buildDateSortHashValue(newestOrderOnLoad, dateSortField);
+          const oldestHashValue = buildDateSortHashValue(oldestOrderOnLoad, dateSortField);
           // eslint-disable-next-line
           isSortValueInHash.forEach((item) => {
             if (item.includes('sortCriteria')) {
@@ -433,13 +469,16 @@ export default async function initiateCoveoHeadlessSearch({
                   setSortButtonCaption(sortBtn, sortLabel.popularity);
                   criteria = [[sortLabel.popularity, module.buildFieldSortCriterion('el_view_count', 'descending')]];
                   break;
+                // legacy links may still carry the plain 'date descending'/'date ascending' value
+                case newestHashValue:
                 case 'date descending':
                   setSortButtonCaption(sortBtn, sortLabel.newest);
-                  criteria = [[sortLabel.newest, module.buildDateSortCriterion('descending')]];
+                  criteria = [[sortLabel.newest, buildDateSortCriteria(module, newestOrderOnLoad, dateSortField)]];
                   break;
+                case oldestHashValue:
                 case 'date ascending':
                   setSortButtonCaption(sortBtn, sortLabel.oldest);
-                  criteria = [[sortLabel.oldest, module.buildDateSortCriterion('ascending')]];
+                  criteria = [[sortLabel.oldest, buildDateSortCriteria(module, oldestOrderOnLoad, dateSortField)]];
                   break;
               }
             }
@@ -477,11 +516,19 @@ export default async function initiateCoveoHeadlessSearch({
                   case 'el_view_count descending':
                     headlessBuildSort.sortBy(module.buildFieldSortCriterion('el_view_count', 'descending'));
                     break;
-                  case 'descending':
-                    headlessBuildSort.sortBy(module.buildDateSortCriterion('descending'));
+                  case 'newest':
+                    headlessBuildSort.sortBy(
+                      buildDateSortCriteria(module, getDateSortOrder(true, dateSortField, fragment()), dateSortField),
+                    );
                     break;
-                  case 'ascending':
-                    headlessBuildSort.sortBy(module.buildDateSortCriterion('ascending'));
+                  case 'oldest':
+                    headlessBuildSort.sortBy(
+                      buildDateSortCriteria(
+                        module,
+                        getDateSortOrder(false, dateSortField, fragment()),
+                        dateSortField,
+                      ),
+                    );
                     break;
                 }
               });

--- a/scripts/coveo-headless/index.js
+++ b/scripts/coveo-headless/index.js
@@ -20,11 +20,14 @@ const locales = new Map([
   ['zh-hant', 'zh-TW'],
 ]);
 
-function buildDateSortCriteria(module, order, dateSortField) {
-  if (!dateSortField) return module.buildDateSortCriterion(order);
-  // Chained criterion: sorts by dateSortField first, falling back to the date field
-  // (e.g. items missing dateSortField) automatically.
-  return [module.buildFieldSortCriterion(dateSortField, order), module.buildDateSortCriterion(order)];
+function buildDateSortCriteria(module, order, dateSortFields) {
+  if (!dateSortFields || dateSortFields.length === 0) return module.buildDateSortCriterion(order);
+  // Chained criterion: tries each field in priority order first, falling back to the date field
+  // (e.g. for items missing every listed field) automatically.
+  return [
+    ...dateSortFields.map((field) => module.buildFieldSortCriterion(field, order)),
+    module.buildDateSortCriterion(order),
+  ];
 }
 
 /**
@@ -39,14 +42,15 @@ function isExclusiveUpcomingEventFilter(hash) {
   return values.length === 1 && values[0] === CONTENT_TYPES.UPCOMING_EVENT_V2.MAPPING_KEY;
 }
 
-function getDateSortOrder(isNewest, dateSortField, hash) {
-  const flip = !!dateSortField && isExclusiveUpcomingEventFilter(hash);
+function getDateSortOrder(isNewest, dateSortFields, hash) {
+  const flip = !!dateSortFields?.length && isExclusiveUpcomingEventFilter(hash);
   if (isNewest) return flip ? 'ascending' : 'descending';
   return flip ? 'descending' : 'ascending';
 }
 
-function buildDateSortHashValue(order, dateSortField) {
-  return dateSortField ? `@${dateSortField} ${order},date ${order}` : `date ${order}`;
+function buildDateSortHashValue(order, dateSortFields) {
+  if (!dateSortFields || dateSortFields.length === 0) return `date ${order}`;
+  return [...dateSortFields.map((field) => `@${field} ${order}`), `date ${order}`].join(',');
 }
 
 function configureSearchHeadlessEngine({ module, searchEngine, searchHub, contextObject, advancedQueryRule }) {
@@ -79,6 +83,7 @@ function configureSearchHeadlessEngine({ module, searchEngine, searchHub, contex
       'el_contenttype',
       'el_event_series',
       'el_event_start_time',
+      'el_event_video_id',
       'el_event_type',
       'el_event_speakers_name',
       'el_event_speakers_profile_picture_url',
@@ -173,7 +178,7 @@ export default async function initiateCoveoHeadlessSearch({
   facetOverrides = {},
   hideAqFromUrl = false,
   baseAdvancedQuery = '',
-  dateSortField = null,
+  dateSortFields = null,
 }) {
   return new Promise((resolve, reject) => {
     // eslint-disable-next-line import/no-relative-packages
@@ -451,10 +456,10 @@ export default async function initiateCoveoHeadlessSearch({
           let criteria = [[sortLabel.relevance, module.buildRelevanceSortCriterion()]];
           const isSortValueInHash = hashURL.split('&');
           // Resolved against the facet state captured in hashURL at load time.
-          const newestOrderOnLoad = getDateSortOrder(true, dateSortField, hashURL);
-          const oldestOrderOnLoad = getDateSortOrder(false, dateSortField, hashURL);
-          const newestHashValue = buildDateSortHashValue(newestOrderOnLoad, dateSortField);
-          const oldestHashValue = buildDateSortHashValue(oldestOrderOnLoad, dateSortField);
+          const newestOrderOnLoad = getDateSortOrder(true, dateSortFields, hashURL);
+          const oldestOrderOnLoad = getDateSortOrder(false, dateSortFields, hashURL);
+          const newestHashValue = buildDateSortHashValue(newestOrderOnLoad, dateSortFields);
+          const oldestHashValue = buildDateSortHashValue(oldestOrderOnLoad, dateSortFields);
           // Tracks whether the active sort is date-based (and which direction) so the el_contenttype
           // facet subscription below can re-derive/reapply it when the Upcoming-only condition flips.
           let activeDateSortSemantic = null;
@@ -477,14 +482,14 @@ export default async function initiateCoveoHeadlessSearch({
                 case newestHashValue:
                 case 'date descending':
                   setSortButtonCaption(sortBtn, sortLabel.newest);
-                  criteria = [[sortLabel.newest, buildDateSortCriteria(module, newestOrderOnLoad, dateSortField)]];
+                  criteria = [[sortLabel.newest, buildDateSortCriteria(module, newestOrderOnLoad, dateSortFields)]];
                   activeDateSortSemantic = 'newest';
                   activeDateSortOrder = newestOrderOnLoad;
                   break;
                 case oldestHashValue:
                 case 'date ascending':
                   setSortButtonCaption(sortBtn, sortLabel.oldest);
-                  criteria = [[sortLabel.oldest, buildDateSortCriteria(module, oldestOrderOnLoad, dateSortField)]];
+                  criteria = [[sortLabel.oldest, buildDateSortCriteria(module, oldestOrderOnLoad, dateSortFields)]];
                   activeDateSortSemantic = 'oldest';
                   activeDateSortOrder = oldestOrderOnLoad;
                   break;
@@ -502,11 +507,11 @@ export default async function initiateCoveoHeadlessSearch({
           // pushState/replaceState, which does not fire 'hashchange'. So the Upcoming-only
           // flip must be re-derived here too, not just on sort-anchor click / initial load.
           headlessTypeFacet.subscribe(() => {
-            if (!dateSortField || !activeDateSortSemantic) return;
-            const nextOrder = getDateSortOrder(activeDateSortSemantic === 'newest', dateSortField, fragment());
+            if (!dateSortFields || !activeDateSortSemantic) return;
+            const nextOrder = getDateSortOrder(activeDateSortSemantic === 'newest', dateSortFields, fragment());
             if (nextOrder === activeDateSortOrder) return;
             activeDateSortOrder = nextOrder;
-            headlessBuildSort.sortBy(buildDateSortCriteria(module, nextOrder, dateSortField));
+            headlessBuildSort.sortBy(buildDateSortCriteria(module, nextOrder, dateSortFields));
           });
 
           if (sortAnchors.length > 0) {
@@ -540,10 +545,10 @@ export default async function initiateCoveoHeadlessSearch({
                   case 'newest':
                   case 'oldest': {
                     const isNewest = anchorSortCriteria === 'newest';
-                    const order = getDateSortOrder(isNewest, dateSortField, fragment());
+                    const order = getDateSortOrder(isNewest, dateSortFields, fragment());
                     activeDateSortSemantic = anchorSortCriteria;
                     activeDateSortOrder = order;
-                    headlessBuildSort.sortBy(buildDateSortCriteria(module, order, dateSortField));
+                    headlessBuildSort.sortBy(buildDateSortCriteria(module, order, dateSortFields));
                     break;
                   }
                 }

--- a/scripts/coveo-headless/index.js
+++ b/scripts/coveo-headless/index.js
@@ -455,6 +455,10 @@ export default async function initiateCoveoHeadlessSearch({
           const oldestOrderOnLoad = getDateSortOrder(false, dateSortField, hashURL);
           const newestHashValue = buildDateSortHashValue(newestOrderOnLoad, dateSortField);
           const oldestHashValue = buildDateSortHashValue(oldestOrderOnLoad, dateSortField);
+          // Tracks whether the active sort is date-based (and which direction) so the el_contenttype
+          // facet subscription below can re-derive/reapply it when the Upcoming-only condition flips.
+          let activeDateSortSemantic = null;
+          let activeDateSortOrder = null;
           // eslint-disable-next-line
           isSortValueInHash.forEach((item) => {
             if (item.includes('sortCriteria')) {
@@ -474,11 +478,15 @@ export default async function initiateCoveoHeadlessSearch({
                 case 'date descending':
                   setSortButtonCaption(sortBtn, sortLabel.newest);
                   criteria = [[sortLabel.newest, buildDateSortCriteria(module, newestOrderOnLoad, dateSortField)]];
+                  activeDateSortSemantic = 'newest';
+                  activeDateSortOrder = newestOrderOnLoad;
                   break;
                 case oldestHashValue:
                 case 'date ascending':
                   setSortButtonCaption(sortBtn, sortLabel.oldest);
                   criteria = [[sortLabel.oldest, buildDateSortCriteria(module, oldestOrderOnLoad, dateSortField)]];
+                  activeDateSortSemantic = 'oldest';
+                  activeDateSortOrder = oldestOrderOnLoad;
                   break;
               }
             }
@@ -488,6 +496,17 @@ export default async function initiateCoveoHeadlessSearch({
 
           const headlessBuildSort = module.buildSort(headlessSearchEngine, {
             initialState: { criterion: initialCriterion },
+          });
+
+          // el_contenttype is a checkbox facet: toggling it updates the URL via history
+          // pushState/replaceState, which does not fire 'hashchange'. So the Upcoming-only
+          // flip must be re-derived here too, not just on sort-anchor click / initial load.
+          headlessTypeFacet.subscribe(() => {
+            if (!dateSortField || !activeDateSortSemantic) return;
+            const nextOrder = getDateSortOrder(activeDateSortSemantic === 'newest', dateSortField, fragment());
+            if (nextOrder === activeDateSortOrder) return;
+            activeDateSortOrder = nextOrder;
+            headlessBuildSort.sortBy(buildDateSortCriteria(module, nextOrder, dateSortField));
           });
 
           if (sortAnchors.length > 0) {
@@ -511,25 +530,22 @@ export default async function initiateCoveoHeadlessSearch({
                 // eslint-disable-next-line
                 switch (anchorSortCriteria) {
                   case 'relevancy':
+                    activeDateSortSemantic = null;
                     headlessBuildSort.sortBy(module.buildRelevanceSortCriterion());
                     break;
                   case 'el_view_count descending':
+                    activeDateSortSemantic = null;
                     headlessBuildSort.sortBy(module.buildFieldSortCriterion('el_view_count', 'descending'));
                     break;
                   case 'newest':
-                    headlessBuildSort.sortBy(
-                      buildDateSortCriteria(module, getDateSortOrder(true, dateSortField, fragment()), dateSortField),
-                    );
+                  case 'oldest': {
+                    const isNewest = anchorSortCriteria === 'newest';
+                    const order = getDateSortOrder(isNewest, dateSortField, fragment());
+                    activeDateSortSemantic = anchorSortCriteria;
+                    activeDateSortOrder = order;
+                    headlessBuildSort.sortBy(buildDateSortCriteria(module, order, dateSortField));
                     break;
-                  case 'oldest':
-                    headlessBuildSort.sortBy(
-                      buildDateSortCriteria(
-                        module,
-                        getDateSortOrder(false, dateSortField, fragment()),
-                        dateSortField,
-                      ),
-                    );
-                    break;
+                  }
                 }
               });
             });


### PR DESCRIPTION
Jira ID:  https://jira.corp.adobe.com/browse/EXLM-5537 

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5537--exlm--adobe-experience-league.aem.live
- After: https://exlm-5537--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5537--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5537--exlm--adobe-experience-league.aem.live/en/events?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->