### PR TITLE
feat: (AIME-194) point /es/ Brand Concierge at the new sandbox datastream

### DIFF
--- a/scripts/brand-concierge/brand-concierge-config.js
+++ b/scripts/brand-concierge/brand-concierge-config.js
@@ -177,7 +177,7 @@ export async function loadBrandConciergeConfig(lang) {
  * client. Same IMS org as the default datastream.
  */
 const BC_DATASTREAMS = {
-  es: '3098f7cc-36bb-4965-bea3-6e80fc59571e',
+  es: '152f88b1-ef07-4afe-8a23-6c0e21c6f017',
 };
 
 /**


### PR DESCRIPTION
Jira ID: AIME-194

**Stacked on #2791** (base branch `exlm-bc-spanish-ui`) — follow-up to #2798, which is already merged into that branch. Review/merge #2791 first; GitHub will retarget this to `main` once #2791 merges.

## Summary

We are moving the Spanish Brand Concierge to a different concierge in a different sandbox, so `/es/` needs a different datastream ID.

- `brand-concierge-config.js`: `BC_DATASTREAMS.es` `3098f7cc-…` → `152f88b1-…`.

That is the whole change. Same IMS org as before, so `bcOrgId`, `bcEdgeDomain`, `bcAlloySdkUrl` and `bcWebClientUrl` in `scripts.js` are untouched, and the per-locale routing added in #2798 (`getBrandConciergeDatastreamId()`) is reused as-is. English and all other locales still use the default datastream.

## Verification

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-bc-es-ds--exlm--adobe-experience-league.aem.live/es/browse?martech=off
- After: https://exlm-bc-es-ds--exlm--adobe-experience-league.aem.live/en/browse?martech=off

**Reviewer note:** the Brand Concierge widget caches transcripts in `localStorage` keyed by URL path, not by datastream — clear site data (or use the widget's clear button) before testing, otherwise cached answers from the previous Spanish concierge will look like the swap did nothing.

What to check:

1. On `/es/browse`, open the widget and confirm the `edge.adobedc.net/…/v1/interact` request carries `configId=152f88b1-ef07-4afe-8a23-6c0e21c6f017` and returns HTTP 200.
2. On `/en/browse`, confirm it still carries the default `configId=87ae6de9-…`.
3. Ask a Spanish question and confirm the response content/citations come from the **new** concierge's manifest.
4. No `bootstrap not available` warning in the console (would indicate Brand Concierge is not enabled on the new datastream).

## AI Review Notes

- The datastream ID is intentionally a config literal, matching the existing `bcDatastreamId` in `scripts.js` and the pattern established in #2798.
- Base branch is `exlm-bc-spanish-ui`, not `main`, on purpose — the routing code this modifies has not reached `main` yet.