### PR TITLE
fix(EXLM-5468): Removal of "Beta" from Brand Concierge UI

### DIFF
--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -62,7 +62,7 @@
   align-items: center;
   line-height: 0;
 
-  /* Pull “Ask” closer than flex gap allows without tightening Ask–BETA */
+  /* Pull “Ask” closer than the flex gap allows */
   margin-inline-end: -8px;
 }
 
@@ -79,21 +79,6 @@
   color: var(--spectrum-gray-500);
   letter-spacing: -0.01em;
   transition: color 0.2s ease;
-}
-
-#bc-trigger .bc-trigger-beta {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: -6px;
-  padding: 2px 5px;
-  border-radius: 5px;
-  background-color: #ebebef;
-  color: #9d59b7;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  line-height: 1;
 }
 
 #bc-trigger .bc-trigger-send {

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -750,13 +750,10 @@ function createMountPoint() {
   triggerAsk.className = 'bc-trigger-ask';
   triggerAsk.textContent = 'Ask a question';
   trigger.append(triggerIcon, triggerAsk);
-  const betaBadge = document.createElement('span');
-  betaBadge.className = 'bc-trigger-beta';
-  betaBadge.textContent = 'BETA';
   const sendIcon = document.createElement('span');
   sendIcon.className = 'icon icon-bc-message-send bc-trigger-send';
   sendIcon.setAttribute('aria-hidden', 'true');
-  trigger.append(betaBadge, sendIcon);
+  trigger.append(sendIcon);
   decorateIcon(triggerIcon);
   decorateIcon(sendIcon);
   document.body.append(trigger);
@@ -784,7 +781,6 @@ function createMountPoint() {
     id: DIALOG_ID,
     ariaLabel: 'AI assistant',
     title: 'Ask',
-    titleBadge: 'BETA',
     titleIcon: 'bc-ask-sparkles',
     content: mount,
     canExpand: true,


### PR DESCRIPTION
Jira ID: EXLM-5468

🤖 Auto-generated draft from Jira. Review before marking ready.

## What was implemented
Removed the "BETA" badge from the Brand Concierge floating chat trigger and from the shared dialog header title used by both the side-panel drawer and its expanded modal state (same header, so one change covers both surfaces). Deleted the now-dead `.bc-trigger-beta` CSS rule. 2 files changed (`scripts/brand-concierge/brand-concierge.js`, `scripts/brand-concierge/brand-concierge.css`).

## ⚠️ Open Questions / Gaps
None — fully implemented, pending review

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5468--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5468--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5468--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

- The floating trigger, side-panel drawer, and expanded modal all render from a single header (`openDrawer` in `createMountPoint()`), so removing `titleBadge: 'BETA'` once covers both the side panel and expanded modal ACs.
- Left the "Use of this beta AI chatbot..." legal disclaimer copy untouched — the AC targets the visual "Beta" badge/label, not this informational sentence.
- Did not touch the generic `titleBadge` support in `scripts/dialog/dialog.js`/`dialog.css` since it's a reusable dialog primitive; only the Brand Concierge caller stopped using it.