### PR TITLE
fix(EXLM-5517): Filter out stale upcoming events on Browse all page

### DIFF
--- a/blocks/browse-filters/browse-filters.js
+++ b/blocks/browse-filters/browse-filters.js
@@ -36,6 +36,7 @@ import {
 import {
   BASE_COVEO_ADVANCED_QUERY,
   BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT,
+  COVEO_EXCLUDE_STALE_UPCOMING_AQ,
 } from '../../scripts/browse-card/browse-cards-constants.js';
 import { COVEO_SEARCH_CUSTOM_EVENTS } from '../../scripts/search/search-utils.js';
 import {
@@ -1743,9 +1744,9 @@ function decorateBrowseTopics(block) {
 
 export default async function decorate(block) {
   const isUpcomingEventFlow = isEventsPage && isFeatureEnabled('isEventsV2');
-  window.headlessBaseSolutionQuery = isUpcomingEventFlow
-    ? BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT
-    : BASE_COVEO_ADVANCED_QUERY;
+  const baseSolutionQuery = isUpcomingEventFlow ? BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT : BASE_COVEO_ADVANCED_QUERY;
+  // Exclude stale Upcoming Events from Browse results (same rule as Atomic Search / Events Hub).
+  window.headlessBaseSolutionQuery = `(${baseSolutionQuery}) AND (${COVEO_EXCLUDE_STALE_UPCOMING_AQ})`;
   enableTagsAsProxy(block);
   appendFormEl(block);
   constructFilterInputContainer(block);


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-5517

🤖 Auto-generated draft from Jira. Review before marking ready.

## What was implemented

Selecting the "Upcoming Events" filter on `/en/browse` returned many events
that had already occurred. A prior ticket (EXLM-5361) fixed this exact class
of bug for Atomic Search (`/en/search`) and the upcoming-event-v2 widget by
excluding stale "Upcoming Event" items via a `@date >= now` guard, but the
Browse-all page's `browse-filters.js` never adopted that guard. This PR
applies the same existing `COVEO_EXCLUDE_STALE_UPCOMING_AQ` constant to the
Browse-all base solution query (both the default and dedicated-events-page
flows), so only events that haven't occurred yet show under the Upcoming
Events filter. 1 file changed.

## ⚠️ Open Questions / Gaps

None — fully implemented, pending review

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5517--exlm--adobe-experience-league.aem.live
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->

- Reused the existing `COVEO_EXCLUDE_STALE_UPCOMING_AQ` constant from `scripts/browse-card/browse-cards-constants.js` verbatim (already validated for the `@date` vs. staged-string `el_event_start_time` field quirk in EXLM-5361) rather than introducing new query logic.