### PR TITLE
fix(EXLM-5499): "Browse all [Product] Content" hyperlink should be single-line

### DIFF
--- a/blocks/header/exl-header-v2.css
+++ b/blocks/header/exl-header-v2.css
@@ -673,6 +673,7 @@ button:focus {
     display: inline-flex;
     align-items: center;
     gap: 6px;
+    white-space: nowrap;
   }
 
   .header .nav-items-secondary a::before {
@@ -1525,6 +1526,7 @@ profile-block {
   font-size: 14px;
   line-height: 21px;
   padding: 12px 20px;
+  white-space: nowrap;
 }
 
 .nav-mobile-body .nav-item-content-level-0 .nav-items-secondary a::before {


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-5499

🤖 Auto-generated draft from Jira. Review before marking ready.

## What was implemented

Added `white-space: nowrap` to the top-nav secondary CTA anchor ("Browse all [Product]
content") in `blocks/header/exl-header-v2.css`, for both the desktop tab-style "Learn by
Product" dropdown and the mobile accordion drawer, so the link renders on a single line
regardless of locale/translation length. 1 file changed.

## ⚠️ Open Questions / Gaps

None — fully implemented, pending review.

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5499--exlm--adobe-experience-league.aem.live
- After: https://exlm-5499--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5499--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5499--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5499--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->