### PR TITLE
fix(EXLM-5517): Filter out stale upcoming events on Browse all page

### DIFF
--- a/scripts/browse-card/browse-cards-constants.js
+++ b/scripts/browse-card/browse-cards-constants.js
@@ -50,9 +50,6 @@ export const AUTHOR_TYPE = Object.freeze({
   ADOBE: 'Adobe',
 });
 
-export const BASE_COVEO_ADVANCED_QUERY = '(@el_contenttype NOT "Community|User")';
-export const BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT =
-  '(@el_contenttype = "Event") OR (@el_contenttype = "Upcoming Event")';
 /**
  * Upcoming events that have not started yet (Events Hub / Upcoming Event V2).
  *
@@ -70,10 +67,21 @@ export const COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ =
   '(@el_contenttype = "Event|Upcoming Event" AND @el_event_start_time >= now)';
 export const BASE_COVEO_ADVANCED_QUERY_EVENTS = `(@el_contenttype = "Event|On Demand Event") OR ${COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ}`;
 /**
+ * Base aq for the Events browse page (browse-filters, Upcoming Event V2 flow).
+ * Reuses BASE_COVEO_ADVANCED_QUERY_EVENTS so stale Upcoming Events are excluded
+ * here the same way they are for the events-search block (EXLM-5517).
+ */
+export const BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT = BASE_COVEO_ADVANCED_QUERY_EVENTS;
+/**
  * Exclude stale Upcoming Events while keeping all other content types.
  * Used by Atomic Search (/en/search) which has no Events-only base aq.
  */
 export const COVEO_EXCLUDE_STALE_UPCOMING_AQ = `(NOT @el_contenttype = "Event|Upcoming Event") OR ${COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ}`;
+/**
+ * Default browse-filters base aq (non-Events-V2 flow, e.g. /en/browse#f-el_contenttype=Event|Upcoming Event).
+ * Excludes Community|User content and, per EXLM-5517, stale Upcoming Events.
+ */
+export const BASE_COVEO_ADVANCED_QUERY = `(@el_contenttype NOT "Community|User") AND (${COVEO_EXCLUDE_STALE_UPCOMING_AQ})`;
 
 export const VIDEO_THUMBNAIL_FORMAT = /^https:\/\/video\.tv\.adobe\.com\/v\/\w+\?format=jpeg$/;
 


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-5517

🤖 Auto-generated draft from Jira. Review before marking ready.

## What was implemented
The `/en/browse` page's base Coveo advanced-query (`BASE_COVEO_ADVANCED_QUERY`) and its Events-V2 counterpart (`BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT`) in `scripts/browse-card/browse-cards-constants.js` never applied a date check, so events tagged "Upcoming Event" kept showing after they'd already occurred. Both constants now reuse the existing `COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ` / `COVEO_EXCLUDE_STALE_UPCOMING_AQ` helpers already relied on by the `events-search` and `atomic-search` blocks, so stale upcoming events are excluded consistently everywhere. Only `scripts/browse-card/browse-cards-constants.js` was touched; `npm run lint` passes clean.

## ⚠️ Open Questions / Gaps
- Headless-browser verification (Playwright) wasn't possible in the sandboxed build environment (missing Chromium shared libraries, and installing system packages was out of scope for an unattended run). Verified instead via lint, `node --check` syntax validation, and manual boolean-logic verification of the Coveo `aq` string construction.
- Per the existing code comment on `COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ` (EXLM-5361), this date filter only takes effect if the Coveo field `el_event_start_time` is configured as **Date** type in the index — if it's still **String**, `>= now` is a no-op and stale events will still appear. That's a Coveo-admin/schema change outside this repo's scope; please confirm the field type in production before/after merging.
- The fix compares against `el_event_start_time` (event start), matching the pre-existing pattern used by `events-search`/`atomic-search`/`upcoming-event-v2`. A multi-day event that has started but not yet ended would now be excluded once its start time passes. Flagging in case "still in progress" events are expected to remain visible under "Upcoming Events" — that would need a separate end-date comparison.

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5517--exlm--adobe-experience-league.aem.live
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://exlm-5517--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->