### PR TITLE
fix(EXLM-5515): Browse All | Filter is retaining the selection count on switching from different locale

### DIFF
--- a/blocks/browse-filters/browse-filters.js
+++ b/blocks/browse-filters/browse-filters.js
@@ -422,13 +422,11 @@ function handleUriHash(isInitialLoad) {
           }
         });
         const btnEl = filterOptionEl.querySelector(':scope > button');
-        const selectedCount = facetValues.reduce((acc, curr) => {
-          const [key] = curr.split('|');
-          if (!acc.includes(key)) {
-            acc.push(key);
-          }
-          return acc;
-        }, []).length;
+        // Base the count on checkboxes actually applied above, not the raw hash values —
+        // a facet value from the hash may not exist for the current locale (e.g. right
+        // after a locale switch), which previously left the count out of sync with the
+        // (empty) selection shown below it.
+        const selectedCount = filterOptionEl.querySelectorAll('.custom-checkbox input[type="checkbox"]:checked').length;
         ddObject.selected = selectedCount;
         btnEl.firstChild.textContent = selectedCount === 0 ? name : `${name} (${selectedCount})`;
       }


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-5515

🤖 Auto-generated draft from Jira. Review before marking ready.

## What was implemented
Fixed the Browse All filter dropdown selection-count badge going out of sync after a locale switch. In `blocks/browse-filters/browse-filters.js` (`handleUriHash`), the count was computed from the raw URL-hash values instead of the checkboxes actually matched/checked in the DOM — after a locale switch, a hash-referenced facet value could fail to match a current option, leaving the badge stuck (e.g. "(1)") with no visible selection below it. The count is now derived from actually-checked checkboxes, matching the existing pattern already used in `updateCountAndCheckedState` in the same file.

## ⚠️ Open Questions / Gaps
- Live browser validation of the exact repro steps (select filter → switch locale → observe badge) was not performed in this headless session, since no browser automation tool was available. The fix was verified via source-level root-cause tracing and mirrors an existing correct counting pattern in the same file. Recommend a manual QA pass before merge.

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5515--exlm--adobe-experience-league.aem.live
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://exlm-5515--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->