### PR TITLE
Header safari fix - 

### DIFF
--- a/blocks/header/exl-header-v2.css
+++ b/blocks/header/exl-header-v2.css
@@ -458,15 +458,11 @@ button:focus {
   position: absolute;
   z-index: var(--z-dropdown);
 
-  /* for full bleed panel on desktops > 1440px.
-     Uses --viewport-width (set from document.documentElement.clientWidth in header-v2.js) rather
-     than the 100vw unit: 100vw doesn't subtract the scrollbar's reserved width on non-macOS
-     platforms, so it overshoots the true visible width by the scrollbar's width, pushing this
-     panel's edge past the page and adding a spurious horizontal scrollbar. --viewport-width
-     excludes the scrollbar, so the panel never overflows and no clipping workaround is needed. */
-  left: min(0px, calc((var(--nav-max-width) - var(--viewport-width, 100vw)) / 2));
+  /* for full bleed panel on desktops > 1440px. Any overshoot from 100vw not subtracting the
+     scrollbar's width (Windows/Linux) is caught by .header-clip's overflow-x: hidden. */
+  left: min(0px, calc((var(--nav-max-width) - 100vw) / 2));
   top: 101%;
-  width: var(--viewport-width, 100vw);
+  width: 100vw;
   background: var(--nav-dropdown-bg);
   box-shadow: var(--nav-dropdown-shadow);
   border-top: 1px solid var(--border-color-regular);

--- a/blocks/header/exl-header-v2.css
+++ b/blocks/header/exl-header-v2.css
@@ -190,6 +190,8 @@ button:focus {
 .header {
   z-index: var(--z-header);
   width: 100%;
+  max-width: var(--nav-max-width);
+  margin: 0 auto;
   height: var(--nav-height);
   position: relative;
   background-color: var(--nav-bg-color);
@@ -200,19 +202,18 @@ button:focus {
 /* Purely structural: decouples the horizontal-overflow safety net from `.header`'s visible
    52px height. Generously tall (so Safari's forced overflow-y:auto — see the overflow-x/y
    mismatch note below — never has anything to visually clip) and absolutely positioned (so
-   that height doesn't push down page content). `overflow-x: hidden` here properly excludes
-   the level-0 dropdown's intentional (and, pre-JS-measurement, occasionally residual) horizontal
-   overflow from the page's scrollable area, fixing the Windows scrollbar-width issue for good —
-   unlike `clip-path`, which only affects painting, not what counts toward page scroll width.
-   Replicates `.header-wrapper`'s old flex-centering by hand, since absolutely positioned
-   elements don't participate in flex layout. */
+   that height doesn't push down page content). Spans the *entire* width of `.header-wrapper`
+   (no max-width) — it must be at least as wide as the full-bleed dropdown itself, or its
+   `overflow-x: hidden` would clip the intentional full-bleed along with any accidental overflow.
+   `.header`'s own max-width/centering (above) is unaffected, since it's independent of this
+   layer's width. `overflow-x: hidden` here properly excludes overflow from the page's scrollable
+   area, fixing the Windows scrollbar-width issue for good — unlike `clip-path`, which only
+   affects painting, not what counts toward page scroll width. */
 .header-clip {
   position: absolute;
   top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 100%;
-  max-width: var(--nav-max-width);
+  left: 0;
+  right: 0;
   height: 100vh;
   overflow-x: hidden;
 

--- a/blocks/header/exl-header-v2.css
+++ b/blocks/header/exl-header-v2.css
@@ -189,23 +189,41 @@ button:focus {
 
 .header {
   z-index: var(--z-header);
-  height: 100%;
+  width: 100%;
+  height: var(--nav-height);
   position: relative;
-  max-width: var(--nav-max-width);
   background-color: var(--nav-bg-color);
   container-name: headersection;
   container-type: inline-size;
 }
 
-@media (min-width: 1200px) {
-  .header-wrapper {
-    display: flex;
-    justify-content: center;
-  }
+/* Purely structural: decouples the horizontal-overflow safety net from `.header`'s visible
+   52px height. Generously tall (so Safari's forced overflow-y:auto — see the overflow-x/y
+   mismatch note below — never has anything to visually clip) and absolutely positioned (so
+   that height doesn't push down page content). `overflow-x: hidden` here properly excludes
+   the level-0 dropdown's intentional (and, pre-JS-measurement, occasionally residual) horizontal
+   overflow from the page's scrollable area, fixing the Windows scrollbar-width issue for good —
+   unlike `clip-path`, which only affects painting, not what counts toward page scroll width.
+   Replicates `.header-wrapper`'s old flex-centering by hand, since absolutely positioned
+   elements don't participate in flex layout. */
+.header-clip {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: var(--nav-max-width);
+  height: 100vh;
+  overflow-x: hidden;
 
-  .header {
-    width: 100%;
-  }
+  /* don't block clicks on page content below the header for the invisible portion of this
+     100vh box; restored to `auto` on `.header` below, which is the only part that's ever
+     visible or needs to be interactive */
+  pointer-events: none;
+}
+
+.header-clip > .header {
+  pointer-events: auto;
 }
 
 /* Mobile: 5-column grid; desktop: 9-column grid */

--- a/blocks/header/exl-header-v2.css
+++ b/blocks/header/exl-header-v2.css
@@ -185,9 +185,6 @@ button:focus {
   height: var(--nav-height);
   border-bottom: 1px solid var(--border-color-regular);
   box-shadow: var(--nav-shadow);
-
-  /* clip the 100vw full-bleed dropdown's scrollbar-width overflow (Windows) without clipping its vertical extent */
-  overflow: clip visible;
 }
 
 .header {
@@ -442,10 +439,15 @@ button:focus {
   position: absolute;
   z-index: var(--z-dropdown);
 
-  /* for full bleed panel on desktops > 1440px */
-  left: min(0px, calc((var(--nav-max-width) - 100vw) / 2));
+  /* for full bleed panel on desktops > 1440px.
+     Uses --viewport-width (set from document.documentElement.clientWidth in header-v2.js) rather
+     than the 100vw unit: 100vw doesn't subtract the scrollbar's reserved width on non-macOS
+     platforms, so it overshoots the true visible width by the scrollbar's width, pushing this
+     panel's edge past the page and adding a spurious horizontal scrollbar. --viewport-width
+     excludes the scrollbar, so the panel never overflows and no clipping workaround is needed. */
+  left: min(0px, calc((var(--nav-max-width) - var(--viewport-width, 100vw)) / 2));
   top: 101%;
-  width: 100vw;
+  width: var(--viewport-width, 100vw);
   background: var(--nav-dropdown-bg);
   box-shadow: var(--nav-dropdown-shadow);
   border-top: 1px solid var(--border-color-regular);

--- a/blocks/header/header-v2.js
+++ b/blocks/header/header-v2.js
@@ -627,19 +627,6 @@ const navDecorator = async (navBlock, decoratorOptions) => {
   simplifySingleCellBlock(navBlock);
   const navOverlay = document.querySelector('.nav-overlay');
 
-  // Keep --viewport-width (used by the full-bleed level-0 dropdown panel instead of the `100vw`
-  // unit) in sync with the true visible viewport width. `100vw` doesn't subtract the browser's
-  // reserved scrollbar width on platforms where scrollbars aren't overlays (Windows, Linux), so
-  // the panel would overflow the true viewport by the scrollbar's width and force a spurious
-  // horizontal scrollbar on the page; clientWidth excludes it. Custom properties cross the shadow
-  // boundary, so setting this on the host makes it available to the shadow-scoped CSS.
-  const shadowHost = navBlock.getRootNode()?.host;
-  if (shadowHost) {
-    registerHeaderResizeHandler(() => {
-      shadowHost.style.setProperty('--viewport-width', `${document.documentElement.clientWidth}px`);
-    });
-  }
-
   // Clone the source ul for mobile BEFORE moving it to the desktop nav-wrapper
   const sourceUl = navBlock.querySelector(':scope > ul');
   const mobileUl = sourceUl ? sourceUl.cloneNode(true) : document.createElement('ul');

--- a/blocks/header/header-v2.js
+++ b/blocks/header/header-v2.js
@@ -627,6 +627,19 @@ const navDecorator = async (navBlock, decoratorOptions) => {
   simplifySingleCellBlock(navBlock);
   const navOverlay = document.querySelector('.nav-overlay');
 
+  // Keep --viewport-width (used by the full-bleed level-0 dropdown panel instead of the `100vw`
+  // unit) in sync with the true visible viewport width. `100vw` doesn't subtract the browser's
+  // reserved scrollbar width on platforms where scrollbars aren't overlays (Windows, Linux), so
+  // the panel would overflow the true viewport by the scrollbar's width and force a spurious
+  // horizontal scrollbar on the page; clientWidth excludes it. Custom properties cross the shadow
+  // boundary, so setting this on the host makes it available to the shadow-scoped CSS.
+  const shadowHost = navBlock.getRootNode()?.host;
+  if (shadowHost) {
+    registerHeaderResizeHandler(() => {
+      shadowHost.style.setProperty('--viewport-width', `${document.documentElement.clientWidth}px`);
+    });
+  }
+
   // Clone the source ul for mobile BEFORE moving it to the desktop nav-wrapper
   const sourceUl = navBlock.querySelector(':scope > ul');
   const mobileUl = sourceUl ? sourceUl.cloneNode(true) : document.createElement('ul');

--- a/blocks/header/header-v2.js
+++ b/blocks/header/header-v2.js
@@ -1020,8 +1020,10 @@ class ExlHeader extends HTMLElement {
     if (headerFragment) {
       loadSearchElement();
 
+      // .header-clip is a purely structural layer: see its CSS rule for why it exists
+      // (decouples the horizontal-overflow safety net from `.header`'s visible 52px height).
       const headerWrapper = htmlToElement(
-        '<div class="header-wrapper" id="header-wrapper"><div class="header block"></div></div>',
+        '<div class="header-wrapper" id="header-wrapper"><div class="header-clip"><div class="header block"></div></div></div>',
       );
       this.shadowRoot.appendChild(headerWrapper);
       const header = this.shadowRoot.querySelector('.header');

--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -2,7 +2,7 @@
   position: fixed;
   bottom: 24px;
   right: 24px;
-  z-index: 25000;
+  z-index: 999;
   display: flex;
   align-items: center;
   gap: 10px;


### PR DESCRIPTION

Jira ID: https://jira.corp.adobe.com/browse/EXLM-5595

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://header-safari-fix--exlm--adobe-experience-league.aem.live
- After: https://header-safari-fix--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://header-safari-fix--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://header-safari-fix--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://header-safari-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://header-safari-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->