### PR TITLE
feat(EXLM-5507): show all filter options in events-search, remove scroll bar

### DIFF
--- a/blocks/events-search/events-search.css
+++ b/blocks/events-search/events-search.css
@@ -161,24 +161,8 @@ main .events-search .events-search-filter-options {
 main .events-search .events-search-filter-options-list {
   display: grid;
   min-height: calc(3 * (16px + 2 * var(--spectrum-spacing-75)));
-  overflow-y: auto;
   box-sizing: border-box;
-  padding-inline-end: calc(6px + var(--spectrum-spacing-75));
-  scrollbar-width: thin;
-  scrollbar-color: var(--non-spectrum-scrollbar-thumb) transparent;
-}
-
-main .events-search .events-search-filter-options-list::-webkit-scrollbar {
-  width: 6px;
-}
-
-main .events-search .events-search-filter-options-list::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-main .events-search .events-search-filter-options-list::-webkit-scrollbar-thumb {
-  background-color: var(--non-spectrum-scrollbar-thumb);
-  border-radius: 3px;
+  padding-inline-end: var(--spectrum-spacing-75);
 }
 
 main .events-search .events-search-filter-group:not(.is-expanded) .events-search-filter-options {

--- a/blocks/events-search/events-search.js
+++ b/blocks/events-search/events-search.js
@@ -31,35 +31,8 @@ const PLACEHOLDER_COUNT_TOKEN = '${count}';
 const PLACEHOLDER_PG_COUNT_TOKEN = '${pgCount}';
 /* eslint-enable no-template-curly-in-string */
 const RESULTS_SCROLL_ADJUSTMENT_OFFSET = -12;
-const MAX_VISIBLE_FILTER_OPTIONS = 11;
 
 // Filter UI helpers
-
-/**
- * Caps the options list height to MAX_VISIBLE_FILTER_OPTIONS rows using the actual rendered row
- * height (measured from the DOM rather than assumed via CSS) so the scrollbar kicks in at the
- * right point regardless of font metrics. Only measurable while the group is expanded/visible.
- */
-function applyFilterOptionsScrollCap(groupEl) {
-  const optionsList = groupEl?.querySelector('.events-search-filter-options-list');
-  if (!optionsList) return;
-  const options = optionsList.querySelectorAll('.events-search-filter-option');
-  if (options.length <= MAX_VISIBLE_FILTER_OPTIONS) {
-    optionsList.style.maxHeight = '';
-    return;
-  }
-  if (optionsList.offsetParent === null) return;
-  const listTop = optionsList.getBoundingClientRect().top;
-  const lastVisibleBottom = options[MAX_VISIBLE_FILTER_OPTIONS - 1].getBoundingClientRect().bottom;
-  const capHeight = lastVisibleBottom - listTop;
-  if (capHeight > 0) optionsList.style.maxHeight = `${Math.ceil(capHeight)}px`;
-}
-
-function recalcExpandedFilterScrollCaps(block) {
-  block.querySelectorAll('.events-search-filter-group.is-expanded').forEach((groupEl) => {
-    applyFilterOptionsScrollCap(groupEl);
-  });
-}
 
 function removeFilterGroupOptionsShimmer(optionsContainer) {
   optionsContainer?.querySelector('.events-search-filter-options-shimmer')?.remove();
@@ -220,7 +193,6 @@ function syncDynamicFacetGroup(block, group) {
   if (wasExpanded) {
     groupEl.classList.add('is-expanded');
     groupEl.querySelector('.events-search-filter-group-header')?.setAttribute('aria-expanded', 'true');
-    applyFilterOptionsScrollCap(groupEl);
   }
 }
 
@@ -1175,10 +1147,6 @@ function bindFilterInteractions(block, groups) {
   const panel = block.querySelector('.events-search-filters-panel');
   if (!panel) return;
 
-  // Recompute the scroll cap on resize so it stays accurate across breakpoints.
-  const resizeObserver = new ResizeObserver(() => recalcExpandedFilterScrollCaps(block));
-  resizeObserver.observe(panel);
-
   panel.addEventListener('click', (event) => {
     const groupHeader = event.target.closest('.events-search-filter-group-header');
     if (!groupHeader) return;
@@ -1187,7 +1155,6 @@ function bindFilterInteractions(block, groups) {
     const isExpanded = groupEl.classList.contains('is-expanded');
     groupEl.classList.toggle('is-expanded', !isExpanded);
     groupHeader.setAttribute('aria-expanded', isExpanded ? 'false' : 'true');
-    if (!isExpanded) applyFilterOptionsScrollCap(groupEl);
   });
 
   panel.addEventListener('change', (event) => {


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

Jira ID: EXLM-5507

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5507--exlm--adobe-experience-league.aem.live
- After: https://exlm-5507--exlm--adobe-experience-league.aem.live/en/events?martech=off

## Description

Removes the artificial 11-item visual cap and scrollbar on the Product/Series filter dropdowns in the events-search block (Events Hub V2, /en/events). All facet options were already rendered in the DOM — the cap only set an inline max-height via JS. Expanding a filter group now shows the full list of options with no scrollbar.

## AI Review Notes

- Removed the ResizeObserver in bindFilterInteractions entirely — it existed solely to recompute the now-removed scroll cap on resize, so no replacement observer is needed.