### PR TITLE
EXLM 5438 - Fix user details missing in event search data layer

### DIFF
--- a/scripts/analytics/lib-analytics.js
+++ b/scripts/analytics/lib-analytics.js
@@ -1182,7 +1182,7 @@ export function pushBrowseFilterSearchClearEvent(searchType, filterType, filterV
  * @param {string} [params.sortBy='relevancy']
  * @param {string} [params.term] - Keyword entered in the search box
  */
-export function pushEventsFilterSearchEvent({
+export async function pushEventsFilterSearchEvent({
   linkTitle,
   linkType,
   destinationDomain,
@@ -1193,6 +1193,7 @@ export function pushEventsFilterSearchEvent({
   term = '',
 } = {}) {
   window.adobeDataLayer = window.adobeDataLayer || [];
+  const { user, userData } = await getDataLayerUserDetails();
 
   window.adobeDataLayer.push({
     event: 'eventsFilterSearch',
@@ -1214,6 +1215,7 @@ export function pushEventsFilterSearchEvent({
       sortBy,
       term,
     },
+    ...(userData && { user }),
   });
 }
 
@@ -1222,8 +1224,9 @@ export function pushEventsFilterSearchEvent({
  *
  * @param {string} [destinationDomain] - Defaults to the current page URL
  */
-export function pushEventsClearFiltersEvent(destinationDomain) {
+export async function pushEventsClearFiltersEvent(destinationDomain) {
   window.adobeDataLayer = window.adobeDataLayer || [];
+  const { user, userData } = await getDataLayerUserDetails();
 
   window.adobeDataLayer.push({
     event: 'linkClicked',
@@ -1234,6 +1237,7 @@ export function pushEventsClearFiltersEvent(destinationDomain) {
       linkType: 'link',
       destinationDomain: destinationDomain || window.location.href,
     },
+    ...(userData && { user }),
   });
 }
 


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: https://jira.corp.adobe.com/browse/EXLM-5438

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://exlm-5438-bug--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->