### PR TITLE
EXLM 5155 - Update filters properly when switching languages 

### DIFF
--- a/blocks/browse-filters/browse-filters.js
+++ b/blocks/browse-filters/browse-filters.js
@@ -404,8 +404,15 @@ function handleUriHash(isInitialLoad) {
         const ddObject = getObjectById(dropdownOptions, keyName);
         const { name } = ddObject;
         facetValues.forEach((facetValueString) => {
+          // Some facet values are opaque strings that contain a literal '|' (e.g. the
+          // isEventsV2 content types 'Event|On Demand Event', 'Event|Upcoming Event') and
+          // must match a checkbox by their full value. Others (e.g. Community sub-facets)
+          // encode multiple hash entries that all map back to one checkbox keyed by the
+          // segment before the '|'. Try the exact value first, then fall back to the key.
           const [facetValue] = facetValueString.split('|');
-          const inputEl = filterOptionEl.querySelector(`input[value="${facetValue}"]`);
+          const inputEl =
+            filterOptionEl.querySelector(`input[value="${facetValueString}"]`) ||
+            filterOptionEl.querySelector(`input[value="${facetValue}"]`);
           if (inputEl && !inputEl.checked) {
             const label = inputEl.dataset.label || '';
             inputEl.checked = true;
@@ -415,7 +422,7 @@ function handleUriHash(isInitialLoad) {
                 id: keyName,
                 name,
                 label,
-                value: facetValue,
+                value: inputEl.value,
               },
               'handleUriHash',
             );

--- a/blocks/language/language.js
+++ b/blocks/language/language.js
@@ -34,10 +34,11 @@ const switchLanguage = (language) => {
   const { lang } = pathDetails;
   if (lang !== language) {
     const newPathname = getLanguagePath(language);
-    // Drop the whole hash on locale switch: filters/facets are carried as raw values
-    // (e.g. Coveo facet values that differ per locale/feature-flag) which don't reliably
-    // resolve on the destination locale, leaving stale selection counts or lost pagination.
-    window.location.href = newPathname + window.location.search;
+    // Strip firstResult so pagination resets to page 1 after locale switch.
+    // Keeping it causes a "no results" state when the new locale has fewer results.
+    const cleanHash = window.location.hash.replace(/&firstResult=[^&]*/g, '').replace(/#firstResult=[^&]*&?/, '#');
+    window.location.href =
+      newPathname + window.location.search + (cleanHash === '#' || cleanHash === '' ? '' : cleanHash);
   }
 };
 

--- a/blocks/language/language.js
+++ b/blocks/language/language.js
@@ -34,11 +34,10 @@ const switchLanguage = (language) => {
   const { lang } = pathDetails;
   if (lang !== language) {
     const newPathname = getLanguagePath(language);
-    // Strip firstResult so pagination resets to page 1 after locale switch.
-    // Keeping it causes a "no results" state when the new locale has fewer results.
-    const cleanHash = window.location.hash.replace(/&firstResult=[^&]*/g, '').replace(/#firstResult=[^&]*&?/, '#');
-    window.location.href =
-      newPathname + window.location.search + (cleanHash === '#' || cleanHash === '' ? '' : cleanHash);
+    // Drop the whole hash on locale switch: filters/facets are carried as raw values
+    // (e.g. Coveo facet values that differ per locale/feature-flag) which don't reliably
+    // resolve on the destination locale, leaving stale selection counts or lost pagination.
+    window.location.href = newPathname + window.location.search;
   }
 };
 


### PR DESCRIPTION
Jira ID: https://jira.corp.adobe.com/browse/EXLM-5515

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://exlm-5155-fix--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->