### PR TITLE
EXLM-5499 fix: double line in header

### DIFF
--- a/blocks/header/exl-header-v2.css
+++ b/blocks/header/exl-header-v2.css
@@ -690,6 +690,7 @@ button:focus {
     display: inline-flex;
     align-items: center;
     gap: 6px;
+    max-width: none;
   }
 
   .header .nav-items-secondary a::before {


### PR DESCRIPTION

Jira ID: https://jira.corp.adobe.com/browse/EXLM-5499

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/events?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://exlm-5499-fix--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->