### PR TITLE
fix(EXLM-5409): Enhancements to code updates to support Course versioning

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,6 +12,7 @@
     <script type="module">
       import { sampleRUM } from '/scripts/lib-franklin.js';
       import { getPathDetails } from '/scripts/scripts.js';
+      import { getCourseFragmentUrl } from '/scripts/courses/course-utils.js';
       const { lang = 'en' } = getPathDetails() || {};
       const errorPagePath = `/${lang}/404`;
       const defaultErrorHTML = `
@@ -48,9 +49,32 @@
         }
       };
 
-      window.addEventListener('load', () => {
+      // Bookmarked/linked course step, module, or certificate pages can 404 after an author
+      // deletes the module. Route those visitors to the course landing page instead of
+      // showing the generic 404, but only once we've confirmed the course itself still exists
+      // (otherwise fall through to the generic 404 below to avoid a redirect loop).
+      const redirectToCourseIfDeleted = async () => {
+        const { pathname, search } = window.location;
+        const courseUrl = getCourseFragmentUrl(pathname);
+        if (!courseUrl || courseUrl === pathname) return false;
+        try {
+          const response = await fetch(courseUrl);
+          if (response.ok) {
+            window.location.replace(`${courseUrl}${search}`);
+            return true;
+          }
+        } catch (error) {
+          // Network error verifying the course page - fall through to the generic 404.
+        }
+        return false;
+      };
+
+      window.addEventListener('load', async () => {
         sampleRUM('404', { source: document.referrer });
-        fetchAndParseHTML('main');
+        const redirected = await redirectToCourseIfDeleted();
+        if (!redirected) {
+          fetchAndParseHTML('main');
+        }
       });
     </script>
     <link rel="stylesheet" href="/styles/styles.css" />


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID: EXLM-5409

🤖 Auto-generated draft from Jira. Review before marking ready.

## What was implemented
Added course-aware 404 handling in `404.html`: when a bookmarked/linked course step, module, or certificate page returns a 404 because an author deleted the underlying content, the visitor is now redirected to the course landing page instead of seeing the generic "Page not found" screen. The fix reuses the existing pure `getCourseFragmentUrl()` helper from `scripts/courses/course-utils.js` to compute the course landing URL from the dead path, and verifies that URL still resolves before redirecting (falling back to the existing generic 404 otherwise) so it can't redirect into a second 404 or loop.

## ⚠️ Open Questions / Gaps
- Redirect applies uniformly to all visitors, signed in or not — a real edge 404 means the existing signed-in-only redirect in `blocks/module-info/module-info.js` never runs anyway for this scenario, so this is additive rather than overlapping.
- The query string from the dead URL is preserved onto the course-landing redirect; the path itself is not.
- A second, related repro mentioned in the JIRA comments was never reproduced by the team and was explicitly tabled ("pick it back up if the need arises") — out of scope for this fix.
- A manual `redirects.json` stopgap entry for the specific already-broken AJO example URL from the ticket is a content-authoring action, not a code change — flagging for the content team rather than implementing here.
- No automated test infrastructure exists in this repo (no `test/` directory, no test script) — this was verified manually: exercised the redirect decision logic (the same `getCourseFragmentUrl` + fetch check used in the fix) directly against the local dev server for a deleted-module/step path, a fully bogus course slug, an unrelated non-course 404, and the course landing page itself, confirming the expected redirect/no-redirect outcome in each case.

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://exlm-5409--exlm--adobe-experience-league.aem.live
- After: https://exlm-5409--exlm--adobe-experience-league.aem.live/en/courses/ajo-design-and-manage-journeys-and-action-campaigns?martech=off
- After: https://exlm-5409--exlm--adobe-experience-league.aem.live/en/courses/ajo-design-and-manage-journeys-and-action-campaigns/deleted-module-example/step-1?martech=off
- After: https://exlm-5409--exlm--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://exlm-5409--exlm--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://exlm-5409--exlm--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->
- The catch block in `redirectToCourseIfDeleted` intentionally swallows fetch/network errors silently, matching the existing silent-catch pattern already used in this same file's `fetchAndParseHTML`.