### PR TITLE
Fix brand concierge close event dataLayer edge case

### DIFF
--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -74,7 +74,11 @@ let impressionObserver = null;
 let bcConversationId = null;
 /** Count of chat replies since the start of the conversation, used as bcChatMessageNumber. */
 let bcMessageNumber = 0;
-/** Whether any message has been submitted in this conversation (for close with/without wording). */
+/**
+ * Whether any message has been submitted since the widget was mounted (for close with/without
+ * wording). Deliberately survives a transcript clear (see BC_EVENT_HISTORY_CLEARED handling) so
+ * send -> clear -> close is still tracked as "close with message".
+ */
 let bcHasMessage = false;
 
 /**
@@ -418,7 +422,9 @@ function handleBrandConciergeClientEvent(event) {
   if (event.eventType === BC_EVENT_HISTORY_CLEARED) {
     bcConversationId = null;
     bcMessageNumber = 0;
-    bcHasMessage = false;
+    // bcHasMessage is intentionally left as-is: clearing the transcript starts a new
+    // conversation, but if a message was sent before the clear, a subsequent widget
+    // close should still be tracked as "close with message".
   }
 
   if (event.eventType === BC_EVENT_QUERY_SUBMITTED) {
@@ -666,7 +672,8 @@ async function clearBrandConciergeConversation() {
 
   bcConversationId = null;
   bcMessageNumber = 0;
-  bcHasMessage = false;
+  // bcHasMessage is intentionally left as-is; see handleBrandConciergeClientEvent's
+  // BC_EVENT_HISTORY_CLEARED branch for why.
 
   const bcMount = getBrandConciergeMount();
   scrollToBottomWatcher?.cleanup();

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -82,6 +82,16 @@ let bcMessageNumber = 0;
 let bcHasMessage = false;
 
 /**
+ * Resets per-conversation tracking state on a transcript clear. Deliberately does not touch
+ * bcHasMessage: it tracks the widget-open session, not the conversation, so send -> clear -> close
+ * is still tracked as "close with message".
+ */
+function resetBcConversationTracking() {
+  bcConversationId = null;
+  bcMessageNumber = 0;
+}
+
+/**
  * Removes persisted BC chat sessions from localStorage (transcript + metadata).
  * @param {{ broad?: boolean }} [options] - If broad, also remove any key containing `bc_chat`.
  */
@@ -420,11 +430,7 @@ function handleBrandConciergeClientEvent(event) {
   if (!event?.eventType) return;
 
   if (event.eventType === BC_EVENT_HISTORY_CLEARED) {
-    bcConversationId = null;
-    bcMessageNumber = 0;
-    // bcHasMessage is intentionally left as-is: clearing the transcript starts a new
-    // conversation, but if a message was sent before the clear, a subsequent widget
-    // close should still be tracked as "close with message".
+    resetBcConversationTracking();
   }
 
   if (event.eventType === BC_EVENT_QUERY_SUBMITTED) {
@@ -670,10 +676,7 @@ async function clearBrandConciergeConversation() {
     await concierge.bootstrap(getBootstrapOptions());
   }
 
-  bcConversationId = null;
-  bcMessageNumber = 0;
-  // bcHasMessage is intentionally left as-is; see handleBrandConciergeClientEvent's
-  // BC_EVENT_HISTORY_CLEARED branch for why.
+  resetBcConversationTracking();
 
   const bcMount = getBrandConciergeMount();
   scrollToBottomWatcher?.cleanup();


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://bc-datalayer--exlm--adobe-experience-league.aem.live?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->